### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/scripts/setup/ai_agent/agent_app.py
+++ b/scripts/setup/ai_agent/agent_app.py
@@ -1,9 +1,11 @@
 import os
 import requests
 import subprocess
+import logging
 from flask import Flask, request, jsonify
 
 app = Flask(__name__)
+logger = logging.getLogger(__name__)
 
 # --- Configuration ---
 NTFY_TOPIC = "uiw_lab_soc_alerts_tjlam_99"
@@ -43,8 +45,9 @@ def analyze_alert_with_ai(raw_log_data):
             return response.json()['choices'][0]['message']['content']
         else:
             return "AI Analysis failed. Manual review required."
-    except Exception as e:
-        return f"AI Integration Error: {e}"
+    except Exception:
+        logger.exception("AI integration failed during alert analysis.")
+        return "AI Analysis failed. Manual review required."
 
 # --- 2. The Notification Engine ---
 def send_soc_alert(title, message, priority=3, tags="rotating_light"):


### PR DESCRIPTION
Potential fix for [https://github.com/sterlinggarnett/Suburban_SOC/security/code-scanning/1](https://github.com/sterlinggarnett/Suburban_SOC/security/code-scanning/1)

To fix this without changing core behavior, keep returning an AI summary string but ensure exceptions produce a **generic, non-sensitive message**. Log the detailed exception only on the server.

Best single fix in this file:
1. Add Python `logging` setup near the top.
2. In `analyze_alert_with_ai`, replace:
   - `except Exception as e: return f"AI Integration Error: {e}"`
   with:
   - server-side logging of the exception (`logger.exception(...)`)
   - safe generic return string (for example, same fallback style as non-200 path: `"AI Analysis failed. Manual review required."`)

This preserves endpoint response shape and downstream logic while removing sensitive exception disclosure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
