### PR TITLE
feat(soar): implement automated MAC-based quarantine pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,11 @@ main
 | Milestone | Title | Status |
 |---|---|---|
 | M1 | Topology | ✅ Complete |
-| M2 | Data Acquisition (Mesh Capture) | ✅ Complete |
-| M3 | The Processing Pipeline (Zeek & Filebeat) | ✅ Complete |
+| M2 | Data Acquisition (The Mesh capture) | ✅ Complete |
+| M3 | The Processing Pipeline (Zeek & Agent) | ✅ Complete |
 | M4 | Data Visualization (ELK Integration) | ✅ Complete |
-| M5 | Threat Intelligence Integration | 🔄 In Progress |
-| M6 | Proactive Kibana Alerting | 🔄 In Progress |
-| M7 | Custom Home Network Dashboards | 🔄 In Progress |
-| M8 | Live Anomaly Simulation & SOC Response Testing | 🔄 In Progress |
+| M5 | Advanced Features/Automation (SOAR Quarantine) | 🔄 In Progress |
+| M6 | Presentation | 🔄 In Progress |
 
 ## Architecture
 
@@ -115,6 +113,7 @@ This project encompasses the design, development, and testing of an advanced **n
 * **Logstash & Filebeat Forwarders:** Aggregates, filters, and forwards logs robustly.
 * **Elasticsearch Database:** Stores and indexes log data efficiently.
 * **Kibana UI:** A user-friendly interface to visualize metrics, initiate queries, and view security dashboards.
+* **AI Agent & SOAR Quarantine:** Automated threat triage via LLM and instant OpenWrt MAC-based device isolation upon receiving high-confidence alerts.
 
 ### Security Domain & Vulnerabilities Covered:
 * The primary focus is on **network security monitoring and threat detection** across the defined network segments monitored by the OpenWrt router.
@@ -213,7 +212,7 @@ This project is licensed under the MIT License. (Make sure you include a `LICENS
 
 ### Future Enhancements:
 * Integrate threat intelligence feeds directly into Zeek.
-* Set up real-time alerting using ElastAlert or native Kibana alerts for anomalous activity.
+* Implement dynamic rollback of automated quarantine rules after 24 hours.
 
 ### Known Issues & Limitations:
 * Performance for streaming very large packet volumes from the router hasn't been heavily benchmarked and may require interface optimization.

--- a/configs/logstash.conf
+++ b/configs/logstash.conf
@@ -35,6 +35,10 @@ filter {
         "[network_parsed][rcode_name]"  => "dns.response.code"
         "[network_parsed][method]"      => "http.request.method"
         "[network_parsed][status_code]" => "http.response.status_code"
+        # Phase A: SOAR MAC enrichment — maps Zeek conn MAC fields to ECS
+        # Requires @load policy/protocols/conn/mac-logging in local.zeek
+        "[network_parsed][orig_l2_addr]" => "source.mac"
+        "[network_parsed][resp_l2_addr]" => "destination.mac"
       }
     }
 

--- a/configs/zeek/local.zeek
+++ b/configs/zeek/local.zeek
@@ -1,0 +1,9 @@
+# Zeek local.zeek configuration
+# Suburban-SOC — Phase A: MAC Address Enrichment (SOAR Integration)
+#
+# Load MAC address logging so that orig_l2_addr and resp_l2_addr
+# are appended to zeek.conn logs, enabling device-level quarantine
+# by MAC address rather than IP (which can be spoofed or rotated via DHCP).
+
+@load base/protocols/conn
+@load policy/protocols/conn/mac-logging

--- a/rules/elastic_watcher/soar_quarantine_alert.json
+++ b/rules/elastic_watcher/soar_quarantine_alert.json
@@ -1,0 +1,49 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "1m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "indices": ["logstash-security-*"],
+        "body": {
+          "query": {
+            "bool": {
+              "must": [
+                { "match": { "event.dataset": "zeek.conn" } },
+                { "exists": { "field": "threat.indicator.domain" } }
+              ],
+              "filter": {
+                "range": {
+                  "@timestamp": { "gte": "now-1m" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "condition": {
+    "compare": {
+      "ctx.payload.hits.total": { "gt": 0 }
+    }
+  },
+  "actions": {
+    "webhook_to_soar_agent": {
+      "webhook": {
+        "scheme": "http",
+        "host": "127.0.0.1",
+        "port": 5000,
+        "method": "post",
+        "path": "/alert",
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": "{\"severity\": \"critical\", \"source_ip\": \"{{ctx.payload.hits.hits.0._source.source.ip}}\", \"source_mac\": \"{{ctx.payload.hits.hits.0._source.source.mac}}\", \"raw_log\": {{ctx.payload.hits.hits.0._source}}}"
+      }
+    }
+  }
+}

--- a/scripts/agile/create_soar_issues.ps1
+++ b/scripts/agile/create_soar_issues.ps1
@@ -1,0 +1,86 @@
+## GitHub Issues Script — SOAR Quarantine Epic
+## Milestone 5: Advanced Features/Automation (#9)
+## Milestone 6: Presentation (#10)
+## Repo: voltron-1/Suburban-SOC
+
+$repo = "voltron-1/Suburban-SOC"
+$m5   = "Milestone 5: Advanced Features/Automation"
+$m6   = "Milestone 6: Presentation"
+
+Write-Host "=== Creating SOAR Quarantine Epic Issues ==="
+
+# ─── MILESTONE 5 ────────────────────────────────────────────────────────────
+Write-Host "`n[M5] Creating User Story: MAC Address Enrichment..."
+$us_m5 = gh issue create --repo $repo `
+  --title "[User Story] Enable MAC address enrichment in Zeek + Logstash pipeline" `
+  --body "**Epic:** Automated Quarantine — SOAR Integration`n**Milestone:** M5 — Threat Intelligence Integration`n**Owner:** @voltron-1`n**Priority:** HIGH`n`n## User Story`nAs a SOC Analyst, I want Zeek to log Layer 2 MAC addresses alongside IPs in conn logs, so that infected devices can be identified and quarantined by hardware address (which persists across DHCP/IP changes).`n`n## Acceptance Criteria`n- [ ] ``@load policy/protocols/conn/mac-logging`` added to ``configs/zeek/local.zeek```n- [ ] ``logstash.conf`` maps ``orig_l2_addr`` → ``source.mac`` and ``resp_l2_addr`` → ``destination.mac```n- [ ] ``source.mac`` field visible in Kibana ``zeek.conn`` index`n`n## Files Changed`n- ``configs/zeek/local.zeek`` [NEW]`n- ``configs/logstash.conf`` [MODIFIED]" `
+  --milestone $m5 `
+  --assignee "voltron-1" `
+  --label "enhancement,user-story"
+Write-Host "Created: $us_m5"
+
+Write-Host "`n[M5] Creating Task: Zeek MAC logging config..."
+$t_a1 = gh issue create --repo $repo `
+  --title "[Task] Add mac-logging policy to Zeek local.zeek" `
+  --body "**Owner:** @voltron-1 | **Priority:** HIGH | **Time:** 30 min`n`n## Description`nCreate ``configs/zeek/local.zeek`` and load the ``policy/protocols/conn/mac-logging`` policy to emit ``orig_l2_addr`` and ``resp_l2_addr`` fields in conn logs.`n`n## Acceptance Criteria`n- [ ] ``configs/zeek/local.zeek`` created with correct load directives`n- [ ] Zeek conn logs contain ``orig_l2_addr`` field on test capture" `
+  --milestone $m5 `
+  --assignee "voltron-1" `
+  --label "user-story"
+Write-Host "Created: $t_a1"
+
+Write-Host "`n[M5] Creating Task: Logstash MAC field mapping..."
+$t_a2 = gh issue create --repo $repo `
+  --title "[Task] Map orig_l2_addr/resp_l2_addr to source.mac in logstash.conf" `
+  --body "**Owner:** @voltron-1 | **Priority:** HIGH | **Time:** 20 min`n`n## Description`nUpdate the mutate/rename block in ``configs/logstash.conf`` to map Zeek MAC fields to ECS ``source.mac`` and ``destination.mac`` fields for Elasticsearch indexing.`n`n## Acceptance Criteria`n- [ ] ``source.mac`` field present in logstash-security-* index`n- [ ] Kibana can filter/visualize by ``source.mac``" `
+  --milestone $m5 `
+  --assignee "voltron-1" `
+  --label "user-story"
+Write-Host "Created: $t_a2"
+
+# ─── MILESTONE 6 ────────────────────────────────────────────────────────────
+Write-Host "`n[M6] Creating User Story: Automated MAC Quarantine via OpenWrt..."
+$us_m6a = gh issue create --repo $repo `
+  --title "[User Story] Automated MAC-based device quarantine via OpenWrt uci" `
+  --body "**Epic:** Automated Quarantine — SOAR Integration`n**Milestone:** M6 — Proactive Kibana Alerting`n**Owner:** @voltron-1`n**Priority:** CRITICAL`n`n## User Story`nAs a SOC Analyst, I want the system to automatically quarantine infected devices by MAC address the moment a high-confidence IOC is detected, so that ransomware or C2-communicating devices are isolated at machine-speed without manual intervention.`n`n## Acceptance Criteria`n- [ ] ``scripts/setup/isolate.sh`` executes uci MAC DROP rules on OpenWrt via SSH`n- [ ] ``agent_app.py`` extracts ``source_mac`` from Kibana payload and calls ``isolate.sh`` with MAC`n- [ ] Fallback to IP quarantine when MAC is unavailable`n- [ ] Quarantine rule persists across router reboots (uci commit)`n`n## Files Changed`n- ``scripts/setup/isolate.sh`` [NEW]`n- ``scripts/setup/ai_agent/agent_app.py`` [MODIFIED]" `
+  --milestone $m6 `
+  --assignee "voltron-1" `
+  --label "enhancement,user-story"
+Write-Host "Created: $us_m6a"
+
+Write-Host "`n[M6] Creating User Story: Discord SOC quarantine notification..."
+$us_m6b = gh issue create --repo $repo `
+  --title "[User Story] Discord SOC channel notification on device quarantine" `
+  --body "**Epic:** Automated Quarantine — SOAR Integration`n**Milestone:** M6 — Proactive Kibana Alerting`n**Owner:** @voltron-1`n**Priority:** MEDIUM`n`n## User Story`nAs a SOC Analyst, I want to receive a Discord embed notification when a device is automatically quarantined, including device IP, MAC, threat reason, and AI analysis, so I have immediate situational awareness without checking the dashboard.`n`n## Acceptance Criteria`n- [ ] ``send_discord_alert()`` function added to ``agent_app.py```n- [ ] Discord embed fires on critical quarantine events`n- [ ] ``DISCORD_WEBHOOK_URL`` env var controls the destination`n- [ ] Graceful no-op if env var is not set`n`n## Files Changed`n- ``scripts/setup/ai_agent/agent_app.py`` [MODIFIED]" `
+  --milestone $m6 `
+  --assignee "voltron-1" `
+  --label "enhancement,user-story"
+Write-Host "Created: $us_m6b"
+
+Write-Host "`n[M6] Creating Task: Write isolate.sh quarantine script..."
+$t_c1 = gh issue create --repo $repo `
+  --title "[Task] Write isolate.sh — OpenWrt uci MAC firewall rule injection" `
+  --body "**Owner:** @voltron-1 | **Priority:** CRITICAL | **Time:** 45 min`n`n## Description`nWrite a bash script at ``scripts/setup/isolate.sh`` that accepts a MAC address argument, SSHes into the OpenWrt router using the ``id_ed25519_hivemind`` key, and injects a persistent DROP rule targeting that MAC via uci.`n`n## Acceptance Criteria`n- [ ] Script validates MAC address format before executing`n- [ ] uci rule named ``SOAR_QUARANTINE_<MAC>`` for traceability`n- [ ] uci commit + firewall restart applied`n- [ ] Script exits non-zero on SSH failure" `
+  --milestone $m6 `
+  --assignee "voltron-1" `
+  --label "user-story"
+Write-Host "Created: $t_c1"
+
+Write-Host "`n[M6] Creating Task: Update agent_app.py for MAC quarantine + Discord..."
+$t_cd = gh issue create --repo $repo `
+  --title "[Task] Update agent_app.py — MAC quarantine + Discord notification" `
+  --body "**Owner:** @voltron-1 | **Priority:** CRITICAL | **Time:** 60 min`n`n## Description`nUpdate ``scripts/setup/ai_agent/agent_app.py`` to: (1) extract ``source_mac`` from Kibana webhook payload, (2) pass MAC to isolate.sh instead of IP, (3) add ``send_discord_alert()`` function, (4) fire Discord embed on critical quarantine events.`n`n## Acceptance Criteria`n- [ ] ``source_mac`` extracted from payload with graceful fallback`n- [ ] ``isolate.sh`` called with MAC as primary argument`n- [ ] ``send_discord_alert()`` posts rich embed to SOC Discord channel`n- [ ] ``DISCORD_WEBHOOK_URL`` env var controls destination (no-op if unset)" `
+  --milestone $m6 `
+  --assignee "voltron-1" `
+  --label "user-story"
+Write-Host "Created: $t_cd"
+
+Write-Host "`n[M6] Creating Task: Kibana MAC-aware alert rule..."
+$t_b1 = gh issue create --repo $repo `
+  --title "[Task] Update Kibana Watcher rule to include source.mac in webhook payload" `
+  --body "**Owner:** @voltron-1 | **Priority:** HIGH | **Time:** 30 min`n`n## Description`nCreate/update the Kibana Watcher rule in ``rules/elastic_watcher/soar_quarantine_alert.json`` to monitor ``zeek.conn`` for high-confidence IOC hits and include ``source.mac`` in the webhook payload sent to the AI agent.`n`n## Acceptance Criteria`n- [ ] Watcher rule targets ``logstash-security-*`` index`n- [ ] Webhook payload includes both ``source_ip`` and ``source_mac```n- [ ] Alert fires within 1 minute of IOC match" `
+  --milestone $m6 `
+  --assignee "voltron-1" `
+  --label "user-story"
+Write-Host "Created: $t_b1"
+
+Write-Host "`n=== All SOAR Quarantine issues created! ==="

--- a/scripts/agile/create_soar_issues.sh
+++ b/scripts/agile/create_soar_issues.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# create_soar_issues.sh — creates all GitHub issues for the SOAR Quarantine Epic
+# Repo: sterlinggarnett/Suburban_SOC
+# Run from repo root: bash scripts/agile/create_soar_issues.sh
+
+set -euo pipefail
+
+REPO="sterlinggarnett/Suburban_SOC"
+M5="Milestone 5: Advanced Features/Automation"
+M6="Milestone 5: Advanced Features/Automation"
+ASSIGNEE="voltron-1"
+TMP=$(mktemp -d)
+
+echo "=== Creating SOAR Quarantine Epic Issues ==="
+
+# ─── M5: Phase A — MAC Enrichment User Story ────────────────────────────────
+cat > "$TMP/us_m5.md" << 'EOF'
+**Epic:** Automated Quarantine — SOAR Integration
+**Milestone:** M5 — Threat Intelligence Integration
+**Owner:** @voltron-1
+**Priority:** HIGH
+
+## User Story
+As a SOC Analyst, I want Zeek to log Layer 2 MAC addresses alongside IPs in conn logs, so that infected devices can be identified and quarantined by hardware address (which persists across DHCP/IP changes).
+
+## Acceptance Criteria
+- [ ] `@load policy/protocols/conn/mac-logging` added to `configs/zeek/local.zeek`
+- [ ] `logstash.conf` maps `orig_l2_addr` → `source.mac` and `resp_l2_addr` → `destination.mac`
+- [ ] `source.mac` field visible in Kibana `zeek.conn` index
+
+## Files Changed
+- `configs/zeek/local.zeek` [NEW]
+- `configs/logstash.conf` [MODIFIED]
+EOF
+echo "[M5] Creating User Story: MAC Address Enrichment..."
+US_M5=$(gh issue create --repo "$REPO" \
+  --title "[User Story] Enable MAC address enrichment in Zeek + Logstash pipeline" \
+  --body-file "$TMP/us_m5.md" \
+  --milestone "$M5" \
+  --assignee "$ASSIGNEE" \
+  --label "enhancement,user-story")
+echo "Created: $US_M5"
+
+# ─── M5: Task A.1 ────────────────────────────────────────────────────────────
+cat > "$TMP/t_a1.md" << 'EOF'
+**Owner:** @voltron-1 | **Priority:** HIGH | **Time:** 30 min
+
+## Description
+Create `configs/zeek/local.zeek` and load the `policy/protocols/conn/mac-logging` policy to emit `orig_l2_addr` and `resp_l2_addr` fields in conn logs.
+
+## Acceptance Criteria
+- [ ] `configs/zeek/local.zeek` created with correct load directives
+- [ ] Zeek conn logs contain `orig_l2_addr` field on test capture
+EOF
+echo "[M5] Creating Task A.1: Zeek MAC logging config..."
+T_A1=$(gh issue create --repo "$REPO" \
+  --title "[Task] Add mac-logging policy to Zeek local.zeek" \
+  --body-file "$TMP/t_a1.md" \
+  --milestone "$M5" \
+  --assignee "$ASSIGNEE" \
+  --label "user-story")
+echo "Created: $T_A1"
+
+# ─── M5: Task A.2 ────────────────────────────────────────────────────────────
+cat > "$TMP/t_a2.md" << 'EOF'
+**Owner:** @voltron-1 | **Priority:** HIGH | **Time:** 20 min
+
+## Description
+Update the mutate/rename block in `configs/logstash.conf` to map Zeek MAC fields to ECS `source.mac` and `destination.mac` fields for Elasticsearch indexing.
+
+## Acceptance Criteria
+- [ ] `source.mac` field present in logstash-security-* index
+- [ ] Kibana can filter/visualize by `source.mac`
+EOF
+echo "[M5] Creating Task A.2: Logstash MAC field mapping..."
+T_A2=$(gh issue create --repo "$REPO" \
+  --title "[Task] Map orig_l2_addr/resp_l2_addr to source.mac in logstash.conf" \
+  --body-file "$TMP/t_a2.md" \
+  --milestone "$M5" \
+  --assignee "$ASSIGNEE" \
+  --label "user-story")
+echo "Created: $T_A2"
+
+# ─── M6: Phase B — Kibana Alert User Story ───────────────────────────────────
+cat > "$TMP/t_b1.md" << 'EOF'
+**Owner:** @voltron-1 | **Priority:** HIGH | **Time:** 30 min
+
+## Description
+Create/update the Kibana Watcher rule in `rules/elastic_watcher/soar_quarantine_alert.json` to monitor `zeek.conn` for high-confidence IOC hits and include `source.mac` in the webhook payload sent to the AI agent.
+
+## Acceptance Criteria
+- [ ] Watcher rule targets `logstash-security-*` index
+- [ ] Webhook payload includes both `source_ip` and `source_mac`
+- [ ] Alert fires within 1 minute of IOC match
+EOF
+echo "[M6] Creating Task B.1: Kibana MAC-aware alert rule..."
+T_B1=$(gh issue create --repo "$REPO" \
+  --title "[Task] Update Kibana Watcher rule to include source.mac in webhook payload" \
+  --body-file "$TMP/t_b1.md" \
+  --milestone "$M6" \
+  --assignee "$ASSIGNEE" \
+  --label "user-story")
+echo "Created: $T_B1"
+
+# ─── M6: Phase C — Quarantine User Story ─────────────────────────────────────
+cat > "$TMP/us_m6a.md" << 'EOF'
+**Epic:** Automated Quarantine — SOAR Integration
+**Milestone:** M6 — Proactive Kibana Alerting
+**Owner:** @voltron-1
+**Priority:** CRITICAL
+
+## User Story
+As a SOC Analyst, I want the system to automatically quarantine infected devices by MAC address the moment a high-confidence IOC is detected, so that ransomware or C2-communicating devices are isolated at machine-speed without manual intervention.
+
+## Acceptance Criteria
+- [ ] `scripts/setup/isolate.sh` executes uci MAC DROP rules on OpenWrt via SSH
+- [ ] `agent_app.py` extracts `source_mac` from Kibana payload and calls `isolate.sh` with MAC
+- [ ] Fallback to IP quarantine when MAC is unavailable
+- [ ] Quarantine rule persists across router reboots (uci commit)
+
+## Files Changed
+- `scripts/setup/isolate.sh` [NEW]
+- `scripts/setup/ai_agent/agent_app.py` [MODIFIED]
+EOF
+echo "[M6] Creating User Story: Automated MAC Quarantine..."
+US_M6A=$(gh issue create --repo "$REPO" \
+  --title "[User Story] Automated MAC-based device quarantine via OpenWrt uci" \
+  --body-file "$TMP/us_m6a.md" \
+  --milestone "$M6" \
+  --assignee "$ASSIGNEE" \
+  --label "enhancement,user-story")
+echo "Created: $US_M6A"
+
+# ─── M6: Task C.1 ─────────────────────────────────────────────────────────────
+cat > "$TMP/t_c1.md" << 'EOF'
+**Owner:** @voltron-1 | **Priority:** CRITICAL | **Time:** 45 min
+
+## Description
+Write a bash script at `scripts/setup/isolate.sh` that accepts a MAC address argument, SSHes into the OpenWrt router using the `id_ed25519_hivemind` key, and injects a persistent DROP rule targeting that MAC via uci.
+
+## Acceptance Criteria
+- [ ] Script validates MAC address format before executing
+- [ ] uci rule named `SOAR_QUARANTINE_<MAC>` for traceability
+- [ ] uci commit + firewall restart applied
+- [ ] Script exits non-zero on SSH failure
+EOF
+echo "[M6] Creating Task C.1: isolate.sh quarantine script..."
+T_C1=$(gh issue create --repo "$REPO" \
+  --title "[Task] Write isolate.sh — OpenWrt uci MAC firewall rule injection" \
+  --body-file "$TMP/t_c1.md" \
+  --milestone "$M6" \
+  --assignee "$ASSIGNEE" \
+  --label "user-story")
+echo "Created: $T_C1"
+
+# ─── M6: Task C.2 + D combined ────────────────────────────────────────────────
+cat > "$TMP/t_cd.md" << 'EOF'
+**Owner:** @voltron-1 | **Priority:** CRITICAL | **Time:** 60 min
+
+## Description
+Update `scripts/setup/ai_agent/agent_app.py` to:
+1. Extract `source_mac` from Kibana webhook payload
+2. Pass MAC to `isolate.sh` instead of IP (with IP fallback)
+3. Add `send_discord_alert()` function for rich SOC embed notifications
+4. Fire Discord embed on critical quarantine events
+
+## Acceptance Criteria
+- [ ] `source_mac` extracted from payload with graceful IP fallback
+- [ ] `isolate.sh` called with MAC as primary argument
+- [ ] `send_discord_alert()` posts rich embed to SOC Discord channel
+- [ ] `DISCORD_WEBHOOK_URL` env var controls destination (no-op if unset)
+EOF
+echo "[M6] Creating Task C.2+D: Update agent_app.py..."
+T_CD=$(gh issue create --repo "$REPO" \
+  --title "[Task] Update agent_app.py — MAC quarantine + Discord SOC notification" \
+  --body-file "$TMP/t_cd.md" \
+  --milestone "$M6" \
+  --assignee "$ASSIGNEE" \
+  --label "user-story")
+echo "Created: $T_CD"
+
+# ─── M6: Phase D — Discord User Story ────────────────────────────────────────
+cat > "$TMP/us_m6b.md" << 'EOF'
+**Epic:** Automated Quarantine — SOAR Integration
+**Milestone:** M6 — Proactive Kibana Alerting
+**Owner:** @voltron-1
+**Priority:** MEDIUM
+
+## User Story
+As a SOC Analyst, I want to receive a Discord embed notification when a device is automatically quarantined, including device IP, MAC, threat reason, and AI analysis, so I have immediate situational awareness without checking the dashboard.
+
+## Acceptance Criteria
+- [ ] `send_discord_alert()` function added to `agent_app.py`
+- [ ] Discord embed fires on critical quarantine events
+- [ ] `DISCORD_WEBHOOK_URL` env var controls the destination
+- [ ] Graceful no-op if env var is not set
+
+## Files Changed
+- `scripts/setup/ai_agent/agent_app.py` [MODIFIED]
+EOF
+echo "[M6] Creating User Story: Discord SOC notification..."
+US_M6B=$(gh issue create --repo "$REPO" \
+  --title "[User Story] Discord SOC channel notification on device quarantine" \
+  --body-file "$TMP/us_m6b.md" \
+  --milestone "$M6" \
+  --assignee "$ASSIGNEE" \
+  --label "enhancement,user-story")
+echo "Created: $US_M6B"
+
+rm -rf "$TMP"
+echo ""
+echo "=== All SOAR Quarantine issues created successfully! ==="

--- a/scripts/setup/ai_agent/agent_app.py
+++ b/scripts/setup/ai_agent/agent_app.py
@@ -12,10 +12,11 @@ app = Flask(__name__)
 logger = logging.getLogger(__name__)
 
 # --- Configuration ---
-NTFY_TOPIC  = os.environ.get("NTFY_TOPIC",    "uiw_lab_soc_alerts_tjlam_99")
-LLM_API_KEY = os.environ.get("LLM_API_KEY",   "your_api_key_here")
-LLM_API_URL = os.environ.get("LLM_API_URL",   "https://api.openai.com/v1/chat/completions")
-LLM_MODEL   = os.environ.get("LLM_MODEL",     "gpt-4")
+NTFY_TOPIC         = os.environ.get("NTFY_TOPIC",         "uiw_lab_soc_alerts_tjlam_99")
+LLM_API_KEY        = os.environ.get("LLM_API_KEY",        "your_api_key_here")
+LLM_API_URL        = os.environ.get("LLM_API_URL",        "https://api.openai.com/v1/chat/completions")
+LLM_MODEL          = os.environ.get("LLM_MODEL",          "gpt-4")
+DISCORD_WEBHOOK_URL = os.environ.get("DISCORD_WEBHOOK_URL", "")
 
 
 # =============================================================================
@@ -70,28 +71,80 @@ def send_soc_alert(title, message, priority=3, tags="rotating_light"):
 
 
 # =============================================================================
-# 3. WEBHOOK LISTENER — real-time alert triage
+# 3. DISCORD NOTIFICATION — SOC channel alert
+# =============================================================================
+def send_discord_alert(device_ip: str, device_mac: str, ai_summary: str):
+    """
+    Posts a rich quarantine notification to the SOC Discord channel.
+    Requires DISCORD_WEBHOOK_URL environment variable to be set.
+    """
+    if not DISCORD_WEBHOOK_URL:
+        app.logger.warning("DISCORD_WEBHOOK_URL not set — skipping Discord notification.")
+        return
+
+    payload = {
+        "embeds": [{
+            "title": "\ud83d\udd12 Device Automatically Quarantined",
+            "color": 15158332,  # Red
+            "fields": [
+                {"name": "Device IP",    "value": device_ip,  "inline": True},
+                {"name": "MAC Address",  "value": device_mac, "inline": True},
+                {"name": "Reason",       "value": "High-Confidence IOC — Ransomware/C2 domain communication detected", "inline": False},
+                {"name": "AI Analysis",  "value": ai_summary[:1024], "inline": False},
+            ],
+            "footer": {"text": "Suburban-SOC | Automated SOAR Response"}
+        }]
+    }
+    try:
+        requests.post(DISCORD_WEBHOOK_URL, json=payload, timeout=10)
+    except Exception as e:
+        app.logger.error("Discord notification failed: %s", e)
+
+
+# =============================================================================
+# 4. WEBHOOK LISTENER — real-time alert triage
 # =============================================================================
 @app.route("/alert", methods=["POST"])
 def handle_kibana_webhook():
     """Receives Kibana alert payload and orchestrates AI triage + response."""
-    data       = request.json or {}
-    severity   = data.get("severity",   "medium")
-    target_ip  = data.get("source_ip",  "unknown")
-    raw_details = data.get("raw_log",   "No log data provided")
+    data        = request.json or {}
+    severity    = data.get("severity",   "medium")
+    target_ip   = data.get("source_ip",  "unknown")
+    target_mac  = data.get("source_mac", "")
+    raw_details = data.get("raw_log",    "No log data provided")
 
     # Step 1: AI triage
     ai_summary = analyze_alert_with_ai(raw_details)
 
     # Step 2: Automated response
     if severity == "critical":
-        subprocess.run(["sudo", "./isolate.sh", target_ip], check=False)
-        alert_body = f"NODE ISOLATED: {target_ip}\n\nAI Analysis:\n{ai_summary}"
+        if target_mac:
+            # Quarantine by MAC address (persists across IP/DHCP changes)
+            subprocess.run(["sudo", "./isolate.sh", target_mac], check=False)
+            quarantine_target = target_mac
+        else:
+            # Fallback: quarantine by IP if MAC is unavailable
+            app.logger.warning("source_mac missing from payload — falling back to IP quarantine.")
+            subprocess.run(["sudo", "./isolate.sh", target_ip], check=False)
+            quarantine_target = target_ip
+
+        # ntfy mobile push
+        alert_body = (
+            f"NODE ISOLATED\nIP: {target_ip} | MAC: {target_mac or 'N/A'}\n\n"
+            f"AI Analysis:\n{ai_summary}"
+        )
         send_soc_alert(
             title="CRITICAL: Autonomous Isolation",
             message=alert_body,
             priority=5,
             tags="skull,lock,robot",
+        )
+
+        # Discord SOC channel notification
+        send_discord_alert(
+            device_ip=target_ip,
+            device_mac=target_mac or "N/A",
+            ai_summary=ai_summary,
         )
     else:
         alert_body = (
@@ -110,7 +163,7 @@ def handle_kibana_webhook():
 
 
 # =============================================================================
-# 4. WEEKLY CISO REPORT ENDPOINT  (Issue #51 — wired from weekly_ciso_report.py)
+# 5. WEEKLY CISO REPORT ENDPOINT  (Issue #51 — wired from weekly_ciso_report.py)
 # =============================================================================
 @app.route("/weekly-report", methods=["POST"])
 def trigger_weekly_report():

--- a/scripts/setup/isolate.sh
+++ b/scripts/setup/isolate.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# =============================================================================
+# isolate.sh — Suburban-SOC SOAR Quarantine Script
+# Phase C: OpenWrt uci MAC-based device isolation
+#
+# Usage:
+#   ./isolate.sh <MAC_ADDRESS>
+#   Example: ./isolate.sh AA:BB:CC:DD:EE:FF
+#
+# This script connects to the OpenWrt router via SSH and injects a
+# permanent firewall DROP rule targeting the specified MAC address.
+# The rule persists across reboots via uci commit.
+#
+# Prerequisites:
+#   - SSH key ~/.ssh/id_ed25519_hivemind must be authorized on the router
+#   - OPENWRT_HOST env var set to router IP (default: 192.168.1.1)
+#   - OPENWRT_USER env var set (default: root)
+# =============================================================================
+
+set -euo pipefail
+
+TARGET_MAC="${1:-}"
+OPENWRT_HOST="${OPENWRT_HOST:-192.168.1.1}"
+OPENWRT_USER="${OPENWRT_USER:-root}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519_hivemind}"
+
+# --- Validate input ---
+if [[ -z "$TARGET_MAC" ]]; then
+  echo "[ERROR] No MAC address provided." >&2
+  echo "Usage: $0 <MAC_ADDRESS>" >&2
+  exit 1
+fi
+
+# Basic MAC format validation (accepts both XX:XX:XX:XX:XX:XX and XX-XX-XX-XX-XX-XX)
+if ! echo "$TARGET_MAC" | grep -qE '^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$'; then
+  echo "[ERROR] Invalid MAC address format: $TARGET_MAC" >&2
+  exit 1
+fi
+
+echo "[*] Initiating quarantine for device: $TARGET_MAC"
+echo "[*] Connecting to OpenWrt router at $OPENWRT_HOST..."
+
+# --- Execute uci firewall rule injection via SSH ---
+ssh -i "$SSH_KEY" \
+    -o StrictHostKeyChecking=no \
+    -o ConnectTimeout=10 \
+    "${OPENWRT_USER}@${OPENWRT_HOST}" \
+    "uci add firewall rule && \
+     uci set firewall.@rule[-1].name='SOAR_QUARANTINE_${TARGET_MAC//:/}' && \
+     uci set firewall.@rule[-1].src='lan' && \
+     uci set firewall.@rule[-1].src_mac='${TARGET_MAC}' && \
+     uci set firewall.@rule[-1].target='DROP' && \
+     uci set firewall.@rule[-1].enabled='1' && \
+     uci commit firewall && \
+     /etc/init.d/firewall restart"
+
+EXIT_CODE=$?
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+  echo "[+] SUCCESS: Device $TARGET_MAC has been quarantined on $OPENWRT_HOST"
+else
+  echo "[-] FAILURE: Could not quarantine $TARGET_MAC on $OPENWRT_HOST (exit code: $EXIT_CODE)" >&2
+  exit $EXIT_CODE
+fi


### PR DESCRIPTION
Phase A (M5): Enable Zeek MAC logging via local.zeek and pipe source.mac through Logstash into Elasticsearch for device-level identification.

Phase B (M5): Add Kibana Watcher rule that fires MAC-aware webhook payload to the AI agent on high-confidence IOC detection.

Phase C (M5): Write isolate.sh to SSH into OpenWrt and inject persistent uci MAC-based DROP firewall rules. Fix agent_app.py to quarantine by MAC address with IP fallback.

Phase D (M5): Add send_discord_alert() to agent_app.py for SOC channel notifications upon automated device quarantine.

Closes #21 (Real-Time Alerting Framework)
Related to Milestone 5: Advanced Features/Automation
