### PR TITLE
feat(soar): harden quarantine pipeline + add anomaly simulation harness (#22)

### DIFF
--- a/docs/SOP-022-anomaly-validation.md
+++ b/docs/SOP-022-anomaly-validation.md
@@ -1,0 +1,222 @@
+# SOP-022: Anomaly Validation via Attack Simulation
+**Document Type:** Standard Operating Procedure
+**Version:** 1.0
+**Owner:** Tommy Lammers (@voltron-1) — Security Analyst / Manager
+**Last Updated:** 2026-05-26
+**Classification:** Internal — CIS 3353 Spring 2026
+**Tracks:** Issue #22 (User Story — Validation via Anomaly Simulation)
+
+---
+
+## Purpose
+
+This SOP defines the end-to-end procedure for validating that the Suburban-SOC pipeline correctly detects three canonical attack scenarios and that the SOAR layer (Kibana Watcher → AI Agent → `isolate.sh` → OpenWrt `uci`) responds at machine-speed by quarantining the offending device's MAC address.
+
+It complements **SOP-001** (pipeline operations); SOP-001 brings the detection plane up, SOP-022 proves it works.
+
+---
+
+## Safety
+
+**This SOP generates real attack traffic patterns.** Port scans, SSH brute-force, and suspicious downloads must only be run against:
+
+- Systems you personally own, OR
+- Lab equipment with explicit written authorization
+
+Defaults in `tests/anomaly_simulation/.env.example` point at `127.0.0.1` and the EICAR test file (a universally-recognized AV/IDS test signature — harmless but reliably triggers detection). Do **not** edit `.env` to target third-party hosts.
+
+---
+
+## Prerequisites
+
+Run `tests/anomaly_simulation/preflight.sh` to validate all items below in one shot. Manual checks:
+
+| Requirement | How to Verify | Fix |
+|---|---|---|
+| `nmap` installed | `command -v nmap` | `sudo apt install nmap` |
+| `sshpass` installed | `command -v sshpass` | `sudo apt install sshpass` |
+| `curl` installed | `command -v curl` | `sudo apt install curl` |
+| Python 3.10+ | `python3 --version` | use system pkg manager |
+| `elasticsearch` python pkg | `python3 -c "import elasticsearch"` | `pip install -r tests/anomaly_simulation/requirements.txt` |
+| Elasticsearch reachable | `curl http://localhost:9200` | `docker compose up -d` |
+| `logstash-security-*` index has data | check Kibana Discover | run a capture script per SOP-001 |
+| AI Agent listening on :5000 | `curl http://localhost:5000/weekly-report/status` | start per step 4 below |
+| Kibana Watcher `soar_quarantine_alert` installed | `curl -u USER:PASS http://localhost:9200/_watcher/watch/soar_quarantine_alert` | step 5 below |
+| OpenWrt SSH reachable | `ssh -i ~/.ssh/id_ed25519_hivemind root@192.168.1.1 'echo ok'` | check key + router |
+| `DISCORD_WEBHOOK_URL` set (optional) | `echo $DISCORD_WEBHOOK_URL` | export from `.env` if you want Discord embeds |
+
+---
+
+## End-to-End Validation Procedure
+
+### Step 1 — Configure the harness
+
+```bash
+cd tests/anomaly_simulation
+cp .env.example .env
+$EDITOR .env   # set TARGET_HOST, OPENWRT_HOST, SSH_KEY at minimum
+```
+
+### Step 2 — Install Python dependencies
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Step 3 — Run preflight
+
+```bash
+./preflight.sh
+```
+
+Expected: every line green; exit 0. Resolve any red items before proceeding — `preflight.sh` is a hard gate.
+
+### Step 4 — Bring up the AI Agent
+
+```bash
+cd ../../scripts/setup/ai_agent
+export DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."   # optional
+flask --app agent_app run --host 0.0.0.0 --port 5000
+```
+
+Expected: `Running on http://0.0.0.0:5000`. Leave this terminal open.
+
+### Step 5 — Install / refresh the Kibana Watcher
+
+```bash
+curl -X PUT -u elastic:$ES_PASS \
+  -H "Content-Type: application/json" \
+  -d @rules/elastic_watcher/soar_quarantine_alert.json \
+  "http://localhost:9200/_watcher/watch/soar_quarantine_alert"
+```
+
+Expected: `"_id": "soar_quarantine_alert", "_version": N`.
+
+### Step 6 — Run the three attack simulations
+
+```bash
+cd tests/anomaly_simulation
+./run_all.sh
+```
+
+Expected output (truncated):
+
+```
+--- [1/3] Network reconnaissance ---
+[*] Port scan sim: TCP SYN scan of 127.0.0.1, ports 1-1024
+[+] Scan complete. Allow ~30s for Zeek + Logstash to index.
+
+--- [2/3] SSH brute force ---
+[*] Brute-force sim: 5 failed SSH attempts → bogususer@127.0.0.1
+[+] Brute-force sim complete (5 attempts). Allow ~30s for indexing.
+
+--- [3/3] Suspicious download ---
+[*] Download sim: pulling https://secure.eicar.org/eicarcom2.zip
+[+] Download complete: /tmp/anomaly_sim_sample.zip (308 bytes)
+
+[*] Waiting 45s for Zeek + Logstash + Elasticsearch indexing...
+
+--- Verifying detections in Elasticsearch ---
+  [PASS] Port scan       (Scan::Port_Scan in zeek.notice) — hits=1 (need >= 1)
+  [PASS] SSH brute force (5+ auth_success=F in zeek.ssh)  — hits=5 (need >= 5)
+  [PASS] Malware download(application/zip in zeek.files)  — hits=1 (need >= 1)
+
+[+] All expected detections present.
+```
+
+Exit code `0` = all three detection paths working end-to-end.
+
+### Step 7 — Trigger the SOAR quarantine path
+
+The default Watcher only fires on `threat.indicator.domain` hits. To validate the quarantine plumbing without waiting for a real IOC, POST a synthetic alert directly to the agent:
+
+```bash
+curl -X POST http://localhost:5000/alert \
+  -H "Content-Type: application/json" \
+  -d '{
+        "severity": "critical",
+        "source_ip": "192.168.1.42",
+        "source_mac": "AA:BB:CC:DD:EE:FF",
+        "raw_log": {"test": "synthetic"}
+      }'
+```
+
+Expected:
+- AI Agent log: `Quarantine by MAC address (persists across IP/DHCP changes)`
+- ntfy push delivered to `$NTFY_TOPIC`
+- Discord embed delivered to `$DISCORD_WEBHOOK_URL` (if set)
+
+### Step 8 — Confirm the OpenWrt rule installed
+
+```bash
+./verify_quarantine.sh AA:BB:CC:DD:EE:FF
+```
+
+Expected:
+```
+[*] Verifying quarantine rule 'SOAR_QUARANTINE_AABBCCDDEEFF' on 192.168.1.1...
+[+] PASS: Rule SOAR_QUARANTINE_AABBCCDDEEFF is installed and persistent.
+```
+
+Cross-check on the router:
+```bash
+ssh -i ~/.ssh/id_ed25519_hivemind root@192.168.1.1 \
+  "uci show firewall | grep SOAR_QUARANTINE"
+```
+
+### Step 9 — Tear down the test rule
+
+```bash
+ssh -i ~/.ssh/id_ed25519_hivemind root@192.168.1.1 \
+  "uci show firewall | grep -oE '@rule\[[0-9]+\]' | head -1 | \
+   xargs -I{} sh -c 'uci delete firewall.{} && uci commit firewall && /etc/init.d/firewall restart'"
+```
+
+> ⚠️ Manually verify the rule index before deleting in a real environment — the example above deletes the first matching rule and assumes only the test rule is present.
+
+---
+
+## Expected Detection Mappings
+
+| Sim | Zeek log | Elasticsearch field | Value |
+|---|---|---|---|
+| Port scan | `notice.log` | `note` | `Scan::Port_Scan` |
+| Brute force | `ssh.log` | `auth_success` | `false` (5+ rows) |
+| Suspicious download | `files.log` | `mime_type` | `application/zip` |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `[FAIL] Port scan — hits=0` | Zeek's Scan policy needs `Scan::analyzing_up_to_port` ≥ scanned range | check `local.zeek` for scan policy load |
+| `[FAIL] SSH brute force — hits=N<5` | Target SSH service rate-limiting | wait 60s and rerun, or target a lab box without fail2ban |
+| `[FAIL] Malware download` | Egress proxy stripping EICAR mid-transit | use an internal sample URL |
+| `verify_quarantine.sh exit 3` | OpenWrt SSH key missing or wrong | check `SSH_KEY` env, regen with `ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_hivemind` and copy to router |
+| AI Agent doesn't invoke isolate.sh | `sudo` requires password | add NOPASSWD entry in sudoers for the isolate.sh path |
+| Discord embed not delivered | `DISCORD_WEBHOOK_URL` not exported | `export DISCORD_WEBHOOK_URL=...` in the same shell that runs Flask |
+| Watcher never fires | `threat.indicator.domain` not present in `zeek.conn` | enrich via the threat-intel feed or test by POSTing directly to `/alert` per Step 7 |
+
+---
+
+## Evidence Capture
+
+Save the following to `evidence/sprint6/anomaly-validation-YYYY-MM-DD/`:
+
+- `run_all.log` — full output of Step 6
+- `kibana-portscan.png` — Discover screenshot showing the `Scan::Port_Scan` notice
+- `kibana-bruteforce.png` — Discover screenshot showing 5+ `auth_success=false` rows
+- `kibana-malware.png` — Discover screenshot showing the `application/zip` file event
+- `quarantine-rule.txt` — output of `uci show firewall | grep SOAR_QUARANTINE`
+- `discord-embed.png` — screenshot of the SOC channel notification
+
+---
+
+## Related Documents
+
+- [SOP-001 — Pipeline Operations](./SOP-001-pipeline-operations.md)
+- [Architecture (wiki)](https://github.com/sterlinggarnett/Suburban-SOC/wiki/Architecture)
+- [Issue #22 — User Story](https://github.com/sterlinggarnett/Suburban_SOC/issues/22)

--- a/scripts/setup/ai_agent/agent_app.py
+++ b/scripts/setup/ai_agent/agent_app.py
@@ -3,6 +3,7 @@ import threading
 import requests
 import subprocess
 import logging
+from pathlib import Path
 from flask import Flask, request, jsonify
 
 # Import the CISO reporting pipeline (Task 4.1-4.5, Issue #51)
@@ -17,6 +18,10 @@ LLM_API_KEY        = os.environ.get("LLM_API_KEY",        "your_api_key_here")
 LLM_API_URL        = os.environ.get("LLM_API_URL",        "https://api.openai.com/v1/chat/completions")
 LLM_MODEL          = os.environ.get("LLM_MODEL",          "gpt-4")
 DISCORD_WEBHOOK_URL = os.environ.get("DISCORD_WEBHOOK_URL", "")
+
+# Absolute path to isolate.sh — resolved at import time so subprocess.run works
+# regardless of Flask's current working directory.
+ISOLATE_SCRIPT = str((Path(__file__).resolve().parent.parent / "isolate.sh"))
 
 
 # =============================================================================
@@ -120,12 +125,12 @@ def handle_kibana_webhook():
     if severity == "critical":
         if target_mac:
             # Quarantine by MAC address (persists across IP/DHCP changes)
-            subprocess.run(["sudo", "./isolate.sh", target_mac], check=False)
+            subprocess.run(["sudo", ISOLATE_SCRIPT, target_mac], check=False)
             quarantine_target = target_mac
         else:
             # Fallback: quarantine by IP if MAC is unavailable
             app.logger.warning("source_mac missing from payload — falling back to IP quarantine.")
-            subprocess.run(["sudo", "./isolate.sh", target_ip], check=False)
+            subprocess.run(["sudo", ISOLATE_SCRIPT, target_ip], check=False)
             quarantine_target = target_ip
 
         # ntfy mobile push

--- a/scripts/setup/isolate.sh
+++ b/scripts/setup/isolate.sh
@@ -37,16 +37,26 @@ if ! echo "$TARGET_MAC" | grep -qE '^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$'; th
   exit 1
 fi
 
+# Normalize: uppercase + colon delimiter (OpenWrt uci expects XX:XX:XX:XX:XX:XX)
+TARGET_MAC="$(echo "$TARGET_MAC" | tr '[:lower:]' '[:upper:]' | tr '-' ':')"
+RULE_NAME="SOAR_QUARANTINE_${TARGET_MAC//:/}"
+
 echo "[*] Initiating quarantine for device: $TARGET_MAC"
 echo "[*] Connecting to OpenWrt router at $OPENWRT_HOST..."
 
-# --- Execute uci firewall rule injection via SSH ---
+# --- Execute uci firewall rule injection via SSH (idempotent) ---
+# If a SOAR_QUARANTINE rule with the same name already exists, skip the
+# add+restart cycle. Avoids accumulating duplicate uci rules on re-fires.
 ssh -i "$SSH_KEY" \
     -o StrictHostKeyChecking=no \
     -o ConnectTimeout=10 \
     "${OPENWRT_USER}@${OPENWRT_HOST}" \
-    "uci add firewall rule && \
-     uci set firewall.@rule[-1].name='SOAR_QUARANTINE_${TARGET_MAC//:/}' && \
+    "if uci show firewall | grep -q \"name='${RULE_NAME}'\"; then \
+       echo '[=] Rule ${RULE_NAME} already present — no-op.'; \
+       exit 0; \
+     fi && \
+     uci add firewall rule && \
+     uci set firewall.@rule[-1].name='${RULE_NAME}' && \
      uci set firewall.@rule[-1].src='lan' && \
      uci set firewall.@rule[-1].src_mac='${TARGET_MAC}' && \
      uci set firewall.@rule[-1].target='DROP' && \
@@ -54,11 +64,4 @@ ssh -i "$SSH_KEY" \
      uci commit firewall && \
      /etc/init.d/firewall restart"
 
-EXIT_CODE=$?
-
-if [[ $EXIT_CODE -eq 0 ]]; then
-  echo "[+] SUCCESS: Device $TARGET_MAC has been quarantined on $OPENWRT_HOST"
-else
-  echo "[-] FAILURE: Could not quarantine $TARGET_MAC on $OPENWRT_HOST (exit code: $EXIT_CODE)" >&2
-  exit $EXIT_CODE
-fi
+echo "[+] SUCCESS: Device $TARGET_MAC has been quarantined on $OPENWRT_HOST"

--- a/tests/anomaly_simulation/README.md
+++ b/tests/anomaly_simulation/README.md
@@ -41,6 +41,9 @@ pip install -r requirements.txt
 ## Usage
 
 ```bash
+# Gate every prereq before the live run (host bins, ES, agent, watcher, router):
+./preflight.sh
+
 # Run a single scenario:
 ./sim_portscan.sh
 ./sim_brute_ssh.sh
@@ -55,6 +58,9 @@ source .env && python3 verify_detections.py
 # End-to-end: run all sims, wait for indexing, then verify:
 ./run_all.sh
 ```
+
+The full live-lab procedure (with troubleshooting and evidence capture) is in
+[`docs/SOP-022-anomaly-validation.md`](../../docs/SOP-022-anomaly-validation.md).
 
 ## Exit codes
 

--- a/tests/anomaly_simulation/README.md
+++ b/tests/anomaly_simulation/README.md
@@ -1,0 +1,82 @@
+# Anomaly Simulation Harness
+
+Validation suite for Issue #22 — exercises the Suburban-SOC detection pipeline
+end-to-end and confirms the SOAR response (MAC quarantine on OpenWrt) executes
+correctly against three canonical attack scenarios.
+
+## Safety
+
+**Lab use only.** These scripts generate traffic patterns that resemble real
+attacks (port scans, SSH brute force, suspicious downloads). Run them only on
+systems and networks where you have explicit authorization. The defaults target
+`127.0.0.1` and a configurable lab attacker host — do not point them at
+production or third-party infrastructure.
+
+## Scenarios
+
+| Sim | Script | Expected detection |
+|---|---|---|
+| Network recon | `sim_portscan.sh` | Zeek `notice.log` → `Scan::Port_Scan` |
+| SSH brute force | `sim_brute_ssh.sh` | Zeek `ssh.log` → 5+ rows with `auth_success=F` |
+| Suspicious download | `sim_malware_download.sh` | Zeek `files.log` → `mime_type=application/zip` |
+
+## Setup
+
+```bash
+# 1. Copy and edit config
+cp .env.example .env
+$EDITOR .env
+
+# 2. Install Python deps for the verifier
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+# 3. Install host prereqs:
+#    - nmap        (sudo apt install nmap)
+#    - sshpass     (sudo apt install sshpass)
+#    - curl        (always present)
+```
+
+## Usage
+
+```bash
+# Run a single scenario:
+./sim_portscan.sh
+./sim_brute_ssh.sh
+./sim_malware_download.sh
+
+# Verify detections landed in Elasticsearch (default: localhost:9200):
+source .env && python3 verify_detections.py
+
+# Confirm SOAR quarantine rule installed on OpenWrt:
+./verify_quarantine.sh AA:BB:CC:DD:EE:FF
+
+# End-to-end: run all sims, wait for indexing, then verify:
+./run_all.sh
+```
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | All assertions passed |
+| `1` | One or more detections missing from Elasticsearch |
+| `2` | Prerequisite missing (nmap, sshpass, etc.) |
+| `3` | OpenWrt SSH unreachable — quarantine verify only |
+
+## Configuration
+
+All knobs in `.env`. Defaults are lab-safe (localhost / RFC1918):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `TARGET_HOST` | `127.0.0.1` | Box the sims point at (must be your lab) |
+| `BRUTE_USER` | `bogususer` | Throwaway SSH user for brute attempts |
+| `MALWARE_SAMPLE_URL` | EICAR test ZIP | Benign signature file inside a ZIP |
+| `ES_URL` | `http://localhost:9200` | Elasticsearch read endpoint |
+| `ES_INDEX` | `logstash-security-*` | Index pattern to query |
+| `LOOKBACK_MIN` | `10` | Verifier search window |
+| `OPENWRT_HOST` | `192.168.1.1` | Router for quarantine check |
+| `OPENWRT_USER` | `root` | SSH user on router |
+| `SSH_KEY` | `~/.ssh/id_ed25519_hivemind` | Key for OpenWrt SSH |

--- a/tests/anomaly_simulation/preflight.sh
+++ b/tests/anomaly_simulation/preflight.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# =============================================================================
+# preflight.sh — gate every prereq for the SOP-022 live-lab session
+#
+# Runs through the prereq table from docs/SOP-022-anomaly-validation.md and
+# prints a single-line PASS / FAIL per check. Exits non-zero on the first
+# failure so the operator can fix one thing at a time.
+#
+# Run from anywhere; the script resolves its own dir to load .env.
+# =============================================================================
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+cd "$HERE"
+
+[[ -f .env ]] && set -a && source .env && set +a
+
+# --- Defaults (mirror .env.example) ---
+TARGET_HOST="${TARGET_HOST:-127.0.0.1}"
+ES_URL="${ES_URL:-http://localhost:9200}"
+ES_INDEX="${ES_INDEX:-logstash-security-*}"
+AGENT_URL="${AGENT_URL:-http://localhost:5000}"
+OPENWRT_HOST="${OPENWRT_HOST:-192.168.1.1}"
+OPENWRT_USER="${OPENWRT_USER:-root}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519_hivemind}"
+WATCHER_NAME="${WATCHER_NAME:-soar_quarantine_alert}"
+
+FAILS=0
+WARNS=0
+
+# Only emit ANSI colors when stdout is a TTY (and not a dumb terminal).
+if [[ -t 1 && "${TERM:-}" != "dumb" ]]; then
+  C_GREEN=$'\033[32m'; C_RED=$'\033[31m'; C_YELLOW=$'\033[33m'; C_RESET=$'\033[0m'
+else
+  C_GREEN=''; C_RED=''; C_YELLOW=''; C_RESET=''
+fi
+
+green()  { printf '  [%sPASS%s] %s\n' "$C_GREEN" "$C_RESET" "$1"; }
+red()    { printf '  [%sFAIL%s] %s\n' "$C_RED"   "$C_RESET" "$1" >&2; FAILS=$((FAILS+1)); }
+yellow() { printf '  [%sWARN%s] %s\n' "$C_YELLOW" "$C_RESET" "$1"; WARNS=$((WARNS+1)); }
+
+section() { echo; echo "=== $1 ==="; }
+
+# --- Host binaries ---
+section "Host binaries"
+for bin in nmap sshpass curl ssh python3; do
+  if command -v "$bin" >/dev/null 2>&1; then
+    green "$bin available ($(command -v "$bin"))"
+  else
+    red "$bin missing — sudo apt install $bin"
+  fi
+done
+
+# --- Python deps ---
+section "Python dependencies"
+if python3 -c "import elasticsearch" 2>/dev/null; then
+  ver=$(python3 -c "import elasticsearch; print(elasticsearch.__version__)")
+  green "elasticsearch python client installed (${ver})"
+else
+  red "elasticsearch python client missing — pip install -r requirements.txt"
+fi
+
+# --- Config file ---
+section "Configuration"
+if [[ -f .env ]]; then
+  green ".env present"
+else
+  yellow ".env not found — using defaults from .env.example (recommended: cp .env.example .env first)"
+fi
+
+# --- Elasticsearch ---
+section "Elasticsearch (${ES_URL})"
+if curl -fsS --max-time 5 "${ES_URL}" >/dev/null 2>&1; then
+  green "ES cluster reachable"
+  if curl -fsS --max-time 5 "${ES_URL}/${ES_INDEX//\*/}_search?size=0" 2>/dev/null \
+       | grep -q '"hits"'; then
+    green "index pattern ${ES_INDEX} returns hits"
+  else
+    yellow "index ${ES_INDEX} returns no hits — run a Zeek capture first per SOP-001"
+  fi
+else
+  red "ES not reachable at ${ES_URL} — start with: docker compose up -d"
+fi
+
+# --- AI Agent ---
+section "AI Agent (${AGENT_URL})"
+if curl -fsS --max-time 5 "${AGENT_URL}/weekly-report/status" >/dev/null 2>&1; then
+  green "AI agent responding on ${AGENT_URL}"
+else
+  red "AI agent not responding — start with: (cd scripts/setup/ai_agent && flask --app agent_app run --host 0.0.0.0 --port 5000)"
+fi
+
+# --- Kibana Watcher ---
+section "Kibana Watcher (${WATCHER_NAME})"
+watcher_resp=$(curl -fsS --max-time 5 "${ES_URL}/_watcher/watch/${WATCHER_NAME}" 2>/dev/null || true)
+if echo "$watcher_resp" | grep -q '"found":true'; then
+  green "Watcher ${WATCHER_NAME} installed"
+elif echo "$watcher_resp" | grep -q '"_id"'; then
+  green "Watcher ${WATCHER_NAME} installed"
+elif [[ -z "$watcher_resp" ]]; then
+  red "Watcher API unreachable or auth required — confirm ES_USER/ES_PASS in .env if x-pack security is on"
+else
+  red "Watcher ${WATCHER_NAME} not installed — see Step 5 of SOP-022"
+fi
+
+# --- OpenWrt SSH ---
+section "OpenWrt SSH (${OPENWRT_USER}@${OPENWRT_HOST})"
+if [[ ! -r "$SSH_KEY" ]]; then
+  red "SSH key not readable: ${SSH_KEY}"
+else
+  green "SSH key readable: ${SSH_KEY}"
+  set +e
+  ssh -i "$SSH_KEY" \
+      -o StrictHostKeyChecking=no \
+      -o BatchMode=yes \
+      -o ConnectTimeout=5 \
+      "${OPENWRT_USER}@${OPENWRT_HOST}" \
+      "uci show firewall >/dev/null 2>&1 && echo ok" 2>/dev/null | grep -q ok
+  ssh_rc=$?
+  set -e
+  if [[ $ssh_rc -eq 0 ]]; then
+    green "OpenWrt SSH + uci access working"
+  else
+    red "OpenWrt SSH failed (rc=${ssh_rc}) — verify key is authorized on router"
+  fi
+fi
+
+# --- Optional: Discord webhook ---
+section "Optional integrations"
+if [[ -n "${DISCORD_WEBHOOK_URL:-}" ]]; then
+  green "DISCORD_WEBHOOK_URL set (embeds will be delivered)"
+else
+  yellow "DISCORD_WEBHOOK_URL not set — Discord embeds will be skipped (graceful no-op)"
+fi
+
+# --- Summary ---
+section "Summary"
+if [[ $FAILS -gt 0 ]]; then
+  echo "  $FAILS prereq(s) failed, $WARNS warning(s). Resolve failures before running run_all.sh." >&2
+  exit 1
+fi
+if [[ $WARNS -gt 0 ]]; then
+  echo "  All hard prereqs satisfied. $WARNS warning(s) — review before live run."
+else
+  echo "  All checks passed. Ready for SOP-022 live-lab session."
+fi

--- a/tests/anomaly_simulation/requirements.txt
+++ b/tests/anomaly_simulation/requirements.txt
@@ -1,0 +1,1 @@
+elasticsearch>=8.0.0

--- a/tests/anomaly_simulation/run_all.sh
+++ b/tests/anomaly_simulation/run_all.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# =============================================================================
+# run_all.sh — Issue #22 orchestrator
+#
+# Runs all three simulation scenarios, waits for the Zeek→Logstash→ES
+# pipeline to index the events, then runs the Python verifier.
+# Does NOT run verify_quarantine.sh (needs the MAC argument and a live router).
+# =============================================================================
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+cd "$HERE"
+
+[[ -f .env ]] && set -a && source .env && set +a
+
+INDEX_WAIT="${INDEX_WAIT:-45}"
+
+echo "============================================================"
+echo " Anomaly Simulation Suite — Issue #22"
+echo "============================================================"
+
+echo
+echo "--- [1/3] Network reconnaissance ---"
+./sim_portscan.sh
+
+echo
+echo "--- [2/3] SSH brute force ---"
+./sim_brute_ssh.sh
+
+echo
+echo "--- [3/3] Suspicious download ---"
+./sim_malware_download.sh
+
+echo
+echo "[*] Waiting ${INDEX_WAIT}s for Zeek + Logstash + Elasticsearch indexing..."
+sleep "$INDEX_WAIT"
+
+echo
+echo "--- Verifying detections in Elasticsearch ---"
+python3 verify_detections.py

--- a/tests/anomaly_simulation/sim_brute_ssh.sh
+++ b/tests/anomaly_simulation/sim_brute_ssh.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# =============================================================================
+# sim_brute_ssh.sh — Issue #22 scenario 2: SSH Brute Force
+#
+# Issues 5+ failed SSH auth attempts so Zeek's ssh analyzer records the
+# auth_success=F cascade in ssh.log.
+# =============================================================================
+
+set -euo pipefail
+
+[[ -f "$(dirname "$0")/.env" ]] && set -a && source "$(dirname "$0")/.env" && set +a
+
+TARGET_HOST="${TARGET_HOST:-127.0.0.1}"
+BRUTE_USER="${BRUTE_USER:-bogususer}"
+BRUTE_PASSWORDS="${BRUTE_PASSWORDS:-wrong1 wrong2 wrong3 wrong4 wrong5}"
+
+if ! command -v sshpass >/dev/null 2>&1; then
+  echo "[ERROR] sshpass not installed. sudo apt install sshpass" >&2
+  exit 2
+fi
+
+echo "[*] Brute-force sim: 5 failed SSH attempts → ${BRUTE_USER}@${TARGET_HOST}"
+echo "[*] Expected Zeek detection: ssh.log → 5+ rows with auth_success=F"
+
+attempt=0
+for pw in $BRUTE_PASSWORDS; do
+  attempt=$((attempt + 1))
+  echo "[*] Attempt $attempt with password: $pw"
+  # Allow non-zero exit; we *want* auth to fail.
+  sshpass -p "$pw" ssh \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -o PreferredAuthentications=password \
+    -o PubkeyAuthentication=no \
+    -o ConnectTimeout=5 \
+    -o NumberOfPasswordPrompts=1 \
+    "${BRUTE_USER}@${TARGET_HOST}" \
+    "exit" 2>/dev/null || true
+done
+
+echo "[+] Brute-force sim complete ($attempt attempts). Allow ~30s for indexing."

--- a/tests/anomaly_simulation/sim_malware_download.sh
+++ b/tests/anomaly_simulation/sim_malware_download.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# =============================================================================
+# sim_malware_download.sh — Issue #22 scenario 3: Suspicious Download
+#
+# Pulls a benign signature file (EICAR test ZIP by default) so Zeek's file
+# analyzer records a files.log entry with mime_type=application/zip.
+# EICAR is the universally-recognized AV/IDS test signature — safe to use,
+# but proves the file-typing chain works end-to-end.
+# =============================================================================
+
+set -euo pipefail
+
+[[ -f "$(dirname "$0")/.env" ]] && set -a && source "$(dirname "$0")/.env" && set +a
+
+URL="${MALWARE_SAMPLE_URL:-https://secure.eicar.org/eicarcom2.zip}"
+DEST="${MALWARE_SAMPLE_PATH:-/tmp/anomaly_sim_sample.zip}"
+
+echo "[*] Download sim: pulling $URL"
+echo "[*] Expected Zeek detection: files.log → mime_type=application/zip"
+
+curl -fsSL -o "$DEST" "$URL"
+
+if [[ ! -s "$DEST" ]]; then
+  echo "[ERROR] Downloaded file is empty or missing." >&2
+  exit 1
+fi
+
+file "$DEST" || true
+echo "[+] Download complete: $DEST ($(stat -c %s "$DEST" 2>/dev/null || stat -f %z "$DEST") bytes)"
+echo "[+] Allow ~30s for Zeek to surface the file event."

--- a/tests/anomaly_simulation/sim_portscan.sh
+++ b/tests/anomaly_simulation/sim_portscan.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# =============================================================================
+# sim_portscan.sh — Issue #22 scenario 1: Network Reconnaissance
+#
+# Runs a SYN scan that Zeek's Scan::Port_Scan policy should flag as a notice.
+# Output appears in zeek.notice with note=Scan::Port_Scan.
+# =============================================================================
+
+set -euo pipefail
+
+# Load .env if present
+[[ -f "$(dirname "$0")/.env" ]] && set -a && source "$(dirname "$0")/.env" && set +a
+
+TARGET_HOST="${TARGET_HOST:-127.0.0.1}"
+
+if ! command -v nmap >/dev/null 2>&1; then
+  echo "[ERROR] nmap not installed. sudo apt install nmap" >&2
+  exit 2
+fi
+
+echo "[*] Port scan sim: TCP SYN scan of $TARGET_HOST, ports 1-1024"
+echo "[*] Expected Zeek detection: notice.log → Scan::Port_Scan"
+
+# -sS SYN scan, -T4 aggressive timing, -Pn skip host-discovery (so Zeek sees the
+# full attack pattern even against unresponsive hosts), -n no DNS resolution.
+nmap -sS -T4 -Pn -n -p 1-1024 "$TARGET_HOST" >/dev/null
+
+echo "[+] Scan complete. Allow ~30s for Zeek + Logstash to index."

--- a/tests/anomaly_simulation/verify_detections.py
+++ b/tests/anomaly_simulation/verify_detections.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+verify_detections.py — Issue #22 verifier.
+
+Queries Elasticsearch for the three expected detections from the anomaly
+simulation suite and prints a pass/fail summary. Exits non-zero if any
+expected detection is missing within the lookback window.
+
+Usage:
+    source .env && python3 verify_detections.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+from elasticsearch import Elasticsearch
+
+
+@dataclass
+class Check:
+    name: str
+    query: dict[str, Any]
+    min_hits: int = 1
+
+
+def build_checks(lookback_min: int) -> list[Check]:
+    time_filter = {"range": {"@timestamp": {"gte": f"now-{lookback_min}m"}}}
+    return [
+        Check(
+            name="Port scan  (Scan::Port_Scan in zeek.notice)",
+            query={
+                "bool": {
+                    "must": [
+                        {"match": {"event.dataset": "zeek.notice"}},
+                        {"match_phrase": {"note": "Scan::Port_Scan"}},
+                    ],
+                    "filter": time_filter,
+                }
+            },
+        ),
+        Check(
+            name="SSH brute force  (5+ auth_success=F in zeek.ssh)",
+            min_hits=5,
+            query={
+                "bool": {
+                    "must": [
+                        {"match": {"event.dataset": "zeek.ssh"}},
+                        {"match": {"auth_success": False}},
+                    ],
+                    "filter": time_filter,
+                }
+            },
+        ),
+        Check(
+            name="Malware download (application/zip in zeek.files)",
+            query={
+                "bool": {
+                    "must": [
+                        {"match": {"event.dataset": "zeek.files"}},
+                        {"match_phrase": {"mime_type": "application/zip"}},
+                    ],
+                    "filter": time_filter,
+                }
+            },
+        ),
+    ]
+
+
+def main() -> int:
+    es_url = os.environ.get("ES_URL", "http://localhost:9200")
+    index = os.environ.get("ES_INDEX", "logstash-security-*")
+    lookback = int(os.environ.get("LOOKBACK_MIN", "10"))
+    user = os.environ.get("ES_USER") or None
+    password = os.environ.get("ES_PASS") or None
+
+    kwargs: dict[str, Any] = {"hosts": [es_url]}
+    if user and password:
+        kwargs["basic_auth"] = (user, password)
+
+    es = Elasticsearch(**kwargs)
+
+    print(f"[*] Elasticsearch: {es_url}")
+    print(f"[*] Index pattern: {index}")
+    print(f"[*] Lookback:      now-{lookback}m\n")
+
+    failures = 0
+    for check in build_checks(lookback):
+        resp = es.count(index=index, query=check.query)
+        hits = resp.get("count", 0)
+        ok = hits >= check.min_hits
+        marker = "PASS" if ok else "FAIL"
+        print(f"  [{marker}] {check.name} — hits={hits} (need >= {check.min_hits})")
+        if not ok:
+            failures += 1
+
+    print()
+    if failures:
+        print(f"[-] {failures} detection(s) missing. Re-run sims or widen LOOKBACK_MIN.")
+        return 1
+    print("[+] All expected detections present.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/anomaly_simulation/verify_detections.py
+++ b/tests/anomaly_simulation/verify_detections.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from elasticsearch import Elasticsearch
+from elastic_transport import TransportError
 
 
 @dataclass
@@ -89,7 +90,11 @@ def main() -> int:
 
     failures = 0
     for check in build_checks(lookback):
-        resp = es.count(index=index, query=check.query)
+        try:
+            resp = es.count(index=index, query=check.query)
+        except TransportError as exc:
+            print(f"  [ERR ] {check.name} — Elasticsearch unreachable: {exc}")
+            return 2
         hits = resp.get("count", 0)
         ok = hits >= check.min_hits
         marker = "PASS" if ok else "FAIL"

--- a/tests/anomaly_simulation/verify_quarantine.sh
+++ b/tests/anomaly_simulation/verify_quarantine.sh
@@ -29,20 +29,29 @@ RULE_NAME="SOAR_QUARANTINE_${MAC_NORM}"
 
 echo "[*] Verifying quarantine rule '${RULE_NAME}' on ${OPENWRT_HOST}..."
 
-# -q for quiet, -o BatchMode to fail fast instead of prompting
-if ! ssh -i "$SSH_KEY" \
-        -o StrictHostKeyChecking=no \
-        -o BatchMode=yes \
-        -o ConnectTimeout=10 \
-        "${OPENWRT_USER}@${OPENWRT_HOST}" \
-        "uci show firewall 2>/dev/null | grep -q \"name='${RULE_NAME}'\""; then
-  rc=$?
-  if [[ $rc -eq 255 ]]; then
+# Run ssh directly so $? captures its real exit code (255 = transport failure,
+# 1 = grep didn't match → rule absent, 0 = rule present). The `if !` pattern
+# masks ssh's exit code, so use an explicit set +e / set -e bracket instead.
+set +e
+ssh -i "$SSH_KEY" \
+    -o StrictHostKeyChecking=no \
+    -o BatchMode=yes \
+    -o ConnectTimeout=10 \
+    "${OPENWRT_USER}@${OPENWRT_HOST}" \
+    "uci show firewall 2>/dev/null | grep -q \"name='${RULE_NAME}'\""
+rc=$?
+set -e
+
+case $rc in
+  0)
+    echo "[+] PASS: Rule ${RULE_NAME} is installed and persistent."
+    ;;
+  255)
     echo "[-] SSH to ${OPENWRT_HOST} failed (network or auth)." >&2
     exit 3
-  fi
-  echo "[-] FAIL: Rule ${RULE_NAME} not found on router." >&2
-  exit 1
-fi
-
-echo "[+] PASS: Rule ${RULE_NAME} is installed and persistent."
+    ;;
+  *)
+    echo "[-] FAIL: Rule ${RULE_NAME} not found on router (ssh rc=$rc)." >&2
+    exit 1
+    ;;
+esac

--- a/tests/anomaly_simulation/verify_quarantine.sh
+++ b/tests/anomaly_simulation/verify_quarantine.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# =============================================================================
+# verify_quarantine.sh — Issue #22 task 4: confirm physical SOAR response
+#
+# SSHes into the OpenWrt router and asserts that a SOAR_QUARANTINE_<MAC>
+# uci firewall rule exists for the given MAC. Exits 0 on present, 1 on
+# missing, 3 if the router is unreachable.
+#
+# Usage: ./verify_quarantine.sh AA:BB:CC:DD:EE:FF
+# =============================================================================
+
+set -euo pipefail
+
+[[ -f "$(dirname "$0")/.env" ]] && set -a && source "$(dirname "$0")/.env" && set +a
+
+TARGET_MAC="${1:-}"
+OPENWRT_HOST="${OPENWRT_HOST:-192.168.1.1}"
+OPENWRT_USER="${OPENWRT_USER:-root}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519_hivemind}"
+
+if [[ -z "$TARGET_MAC" ]]; then
+  echo "Usage: $0 <MAC_ADDRESS>" >&2
+  exit 1
+fi
+
+# Normalize to match isolate.sh's rule-naming convention (uppercase, no separators)
+MAC_NORM="$(echo "$TARGET_MAC" | tr '[:lower:]' '[:upper:]' | tr -d ':-')"
+RULE_NAME="SOAR_QUARANTINE_${MAC_NORM}"
+
+echo "[*] Verifying quarantine rule '${RULE_NAME}' on ${OPENWRT_HOST}..."
+
+# -q for quiet, -o BatchMode to fail fast instead of prompting
+if ! ssh -i "$SSH_KEY" \
+        -o StrictHostKeyChecking=no \
+        -o BatchMode=yes \
+        -o ConnectTimeout=10 \
+        "${OPENWRT_USER}@${OPENWRT_HOST}" \
+        "uci show firewall 2>/dev/null | grep -q \"name='${RULE_NAME}'\""; then
+  rc=$?
+  if [[ $rc -eq 255 ]]; then
+    echo "[-] SSH to ${OPENWRT_HOST} failed (network or auth)." >&2
+    exit 3
+  fi
+  echo "[-] FAIL: Rule ${RULE_NAME} not found on router." >&2
+  exit 1
+fi
+
+echo "[+] PASS: Rule ${RULE_NAME} is installed and persistent."


### PR DESCRIPTION
## Summary

- **Phase 2 — SOAR hardening**: Fix three correctness bugs in the freshly-merged MAC quarantine pipeline (PR #74). `isolate.sh` now resolves absolutely, normalizes MAC delimiter before `uci`, and skips re-adds when the `SOAR_QUARANTINE_<MAC>` rule already exists.
- **Phase 3 — Anomaly simulation harness (Issue #22)**: New `tests/anomaly_simulation/` with three attack-pattern scripts (nmap port scan, sshpass brute force, EICAR ZIP download), an Elasticsearch verifier, and an OpenWrt quarantine verifier. Lab-safe defaults (`127.0.0.1`, RFC1918); never executes outside an explicit `.env`.
- **Validation pass caught a real bug**: `verify_quarantine.sh`'s ` if ! ssh` pattern was masking SSH's exit code, making the transport-failure branch (`exit 3`) unreachable. Restructured with an explicit `set +e`/`set -e` bracket.

## Files Changed

| Change | File | Why |
|---|---|---|
| Modified | `scripts/setup/ai_agent/agent_app.py` | Resolve `isolate.sh` to absolute path at import time so subprocess works regardless of Flask cwd |
| Modified | `scripts/setup/isolate.sh` | Idempotency check, MAC normalization (upper + colon delimiter), drop unreachable EXIT_CODE branch |
| New | `tests/anomaly_simulation/{README,*.env.example,requirements}.txt` | Doc + config template for the harness |
| New | `tests/anomaly_simulation/sim_{portscan,brute_ssh,malware_download}.sh` | Three Issue #22 attack-pattern simulators |
| New | `tests/anomaly_simulation/verify_detections.py` | Elasticsearch count queries asserting each detection landed within lookback |
| New | `tests/anomaly_simulation/verify_quarantine.sh` | SSH to OpenWrt and confirm SOAR uci rule installed |
| New | `tests/anomaly_simulation/run_all.sh` | Orchestrator: sims → wait → verify |
| Modified | `wiki-temp` | Gitlink bump to wiki commit documenting SOAR M5/M6 + Sprint 6 harness landing |

## Validation already performed (7/7 deterministic paths)

- `sim_portscan` without nmap → exit 2 (prereq missing)
- `sim_brute_ssh` without sshpass → exit 2
- `sim_malware_download` with unreachable URL → propagated via `set -e`
- `verify_detections.py` with unreachable ES → clean `[ERR]` line + exit 2 (no traceback)
- `verify_quarantine.sh` with no argument → exit 1 (usage)
- `verify_quarantine.sh` with ssh refused → exit 3 (caught masked exit-code bug)
- `run_all.sh` fails fast on first failing sim

## Test plan (live lab)

- [ ] `cd tests/anomaly_simulation && cp .env.example .env && $EDITOR .env`
- [ ] Install host prereqs: `sudo apt install nmap sshpass`
- [ ] Boot ELK + Zeek + Filebeat (per existing SOP)
- [ ] Boot AI Agent: `cd scripts/setup/ai_agent && flask --app agent_app run --host 0.0.0.0 --port 5000`
- [ ] Install Watcher: POST `rules/elastic_watcher/soar_quarantine_alert.json` to `_watcher/watch/soar_quarantine_alert`
- [ ] Run `./run_all.sh` — confirm all three detections present in Elasticsearch
- [ ] Trigger a high-confidence IOC (or manually POST to `/alert`) and run `./verify_quarantine.sh <MAC>` — confirm `SOAR_QUARANTINE_<MAC>` uci rule installed
- [ ] Confirm Discord embed delivered (requires `DISCORD_WEBHOOK_URL`)

Closes nothing automatically; unblocks #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)