### PR TITLE
docs(readme): remove merge-conflict cruft + duplicate milestones table

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@
   - [2. Manual Testing](#2-manual-testing)
 - [License](#license)
 - [Additional Notes](#additional-notes)
- chore/repo-cleanup-may20
-
   - [Project-Specific Considerations](#project-specific-considerations)
   - [Future Enhancements](#future-enhancements)
   - [Known Issues & Limitations](#known-issues--limitations)
@@ -42,7 +40,6 @@
 This project directly covers the following course modules from CIS 3353 — Computer Systems Security:
 
 | Module | Topic | Connection to Pipeline |
-main
 |---|---|---|
 | **Module 2** | Network Fundamentals & Traffic Analysis | The core pipeline captures and analyzes raw boundary network traffic from our OpenWrt mesh router, applying the principles of packet inspection, protocol dissection, and traffic scoping covered in this module. |
 | **Module 8** | Intrusion Detection Systems (IDS) | Zeek functions as our IDS engine, parsing PCAP captures into structured JSON logs and generating `notice.log` alerts for port scans, brute-force attempts, and anomalous file transfers — directly applying the detection methodology from this module. |
@@ -216,15 +213,3 @@ This project is licensed under the MIT License. (Make sure you include a `LICENS
 
 ### Known Issues & Limitations:
 * Performance for streaming very large packet volumes from the router hasn't been heavily benchmarked and may require interface optimization.
-
-feat/offline-integration-patch
-
-## Project Status Milestones
-
-| Milestone | Target Date | Description | Status |
-| :--- | :--- | :--- | :--- |
-| **Iteration 1** | TBD | Initial architecture and core framework setup | In Progress |
-| **Iteration 2** | TBD | Behavioral detection algorithms integration | Planned |
-| **Iteration 3** | TBD | Distributed node deployment and testing | Planned |
-| **Iteration 4** | TBD | Real-time alerting framework and visualizations | Planned |
-


### PR DESCRIPTION
## Summary

Three orphan branch-name labels and one duplicate section were left in `README.md` after prior merge-conflict resolutions stripped the conflict markers but kept the branch labels. This PR removes the cruft and the duplicate milestones table.

## Changes (all in `README.md`)

| Location | Was | Now |
|---|---|---|
| Line 26 | stray `chore/repo-cleanup-may20` between TOC entries | removed |
| Line 45 | stray `main` between table header and separator (broke GitHub table rendering) | removed |
| Lines 220-230 | stray `feat/offline-integration-patch` + placeholder \"Project Status Milestones\" table (Iteration 1-4 TBDs) | removed — duplicate of the real \"Project Status\" table on lines 53-60 with populated M1-M6 status |

Net: `-15 lines, 0 added`.

## Why delete (not populate) the milestones table

The README already has a populated \"Project Status\" table at the top with the actual milestones (M1-M6) and current statuses:

```
| M1 | Topology                                          | ✅ Complete |
| M2 | Data Acquisition (The Mesh capture)               | ✅ Complete |
| M3 | The Processing Pipeline (Zeek & Agent)            | ✅ Complete |
| M4 | Data Visualization (ELK Integration)              | ✅ Complete |
| M5 | Advanced Features/Automation (SOAR Quarantine)    | 🔄 In Progress |
| M6 | Presentation                                      | 🔄 In Progress |
```

The lower \"Project Status Milestones\" table was placeholder boilerplate (`Iteration 1` / `TBD` / `In Progress`) that didn't map to any of our actual milestones. Keeping both would create two sources of truth.

## Test plan

- [x] View the rendered README on GitHub and confirm the Course Modules table on line 44 now renders as a real markdown table (was broken by the stray `main` line)
- [x] Confirm Table of Contents has no orphan entries
- [x] Confirm the file ends cleanly after \"Known Issues & Limitations\" with no trailing duplicate section

🤖 Generated with [Claude Code](https://claude.com/claude-code)