### PR TITLE
feat(frameworks): MITRE ATT&CK + NIST CSF enrichment + operationalize 10 Sigma rules

### DIFF
--- a/configs/logstash.conf
+++ b/configs/logstash.conf
@@ -131,15 +131,53 @@ filter {
           "[winlog][event_data][Hashes]"          => "file.hash.sha256"
         }
       }
-      # Component 3: tag Sigma-matched detections for the Endpoint dashboard
-      if [process][executable] =~ "(?i)\\rundll32\.exe" and [process][args] =~ "(?i)comsvcs" {
+      # ----------------------------------------------------------------------
+      # Sigma detections (rules/sigma/*.yml) operationalized as Logstash
+      # conditionals. Each match adds a sigma_<rule> tag; the Endpoint dashboard
+      # "Sigma Rule Hits" panel filters on tags:sigma_*. The MITRE ATT&CK / NIST
+      # CSF classification for each tag is applied in the Framework Enrichment
+      # block (Category 5) so detection logic and framework mapping stay cleanly
+      # separated. Each conditional mirrors that rule's `detection:` selection.
+      # ----------------------------------------------------------------------
+      # T1003.001 — LSASS memory dump via comsvcs.dll MiniDump
+      if [process][executable] =~ "(?i)\\rundll32\.exe" and [process][args] =~ "(?i)comsvcs\.dll" and [process][args] =~ "(?i)minidump" {
         mutate { add_tag => ["sigma_lsass_dump", "CRITICAL_THREAT"] }
       }
-      if [process][executable] =~ "(?i)\\wevtutil\.exe" and [process][args] =~ "(?i)(cl|clear-log)" {
+      # T1070.001 — Clearing Windows event logs via wevtutil
+      if [process][executable] =~ "(?i)\\wevtutil\.exe" and [process][args] =~ "(?i)(\bcl\b|clear-log)" {
         mutate { add_tag => ["sigma_event_log_clear"] }
       }
-      if [process][executable] =~ "(?i)powershell" and [process][args] =~ "(?i)-enc" {
+      # T1059.001 — Encoded PowerShell command
+      if [process][executable] =~ "(?i)\\(powershell|pwsh)\.exe" and [process][args] =~ "(?i)(-enc|-encodedcommand|-ec\s)" {
         mutate { add_tag => ["sigma_powershell_encoded"] }
+      }
+      # T1105 — Malicious file download via bitsadmin
+      if [process][executable] =~ "(?i)\\bitsadmin\.exe" and [process][args] =~ "(?i)/transfer" {
+        mutate { add_tag => ["sigma_bitsadmin_download"] }
+      }
+      # T1136.001 — Local account creation via net.exe / net1.exe
+      if [process][executable] =~ "(?i)\\net1?\.exe" and [process][args] =~ "(?i)user" and [process][args] =~ "(?i)/add" {
+        mutate { add_tag => ["sigma_local_account_create"] }
+      }
+      # T1574 — RDP session hijack via tscon
+      if [process][executable] =~ "(?i)\\tscon\.exe" and [process][args] =~ "(?i)/dest:" {
+        mutate { add_tag => ["sigma_rdp_hijack"] }
+      }
+      # T1218.010 — Regsvr32 remote scriptlet (squiblydoo)
+      if [process][executable] =~ "(?i)\\regsvr32\.exe" and [process][args] =~ "(?i)/i:http" and [process][args] =~ "(?i)scrobj\.dll" {
+        mutate { add_tag => ["sigma_regsvr32_remote_sct"] }
+      }
+      # T1053.005 — Scheduled task creation via schtasks
+      if [process][executable] =~ "(?i)\\schtasks\.exe" and [process][args] =~ "(?i)/create" and [process][args] =~ "(?i)/tn" {
+        mutate { add_tag => ["sigma_scheduled_task_create"] }
+      }
+      # T1033 — System owner/user discovery via whoami /all
+      if [process][executable] =~ "(?i)\\whoami\.exe" and [process][args] =~ "(?i)/all" {
+        mutate { add_tag => ["sigma_user_discovery"] }
+      }
+      # T1047 — WMI process call create via wmic
+      if [process][executable] =~ "(?i)\\wmic\.exe" and [process][args] =~ "(?i)process" and [process][args] =~ "(?i)call" and [process][args] =~ "(?i)create" {
+        mutate { add_tag => ["sigma_wmi_process_create"] }
       }
     }
 
@@ -190,45 +228,140 @@ filter {
     }
   }
 
-  # --- Category 5: Framework Enrichment (Executive Dashboard) ---
-  # Tag events with MITRE ATT&CK technique/tactic + NIST CSF function so the
-  # Executive dashboard's MITRE heatmap and NIST donut can aggregate them.
+  # --- Category 5: Framework Enrichment (MITRE ATT&CK + NIST CSF) ------------
+  # Classify each fired detection with its ECS threat.* fields and NIST CSF
+  # function so the Executive dashboard's MITRE heatmap (threat.technique.id) and
+  # NIST donut (nist.function) aggregate correctly. Endpoint detections key off
+  # the sigma_* tags set in Category 2; network detections key off Zeek fields.
+  # Every technique ID traces back to a source rule (rules/sigma/*.yml or the
+  # Zeek scan/brute policies); tests/pipeline/test_framework_enrichment.py
+  # asserts each Sigma rule's technique is mapped here.
 
-  # Network: Zeek port-scan notice -> Discovery
+  # -- Network detections (Zeek) --
+  # T1046 — Zeek port-scan notice -> Discovery
   if [note] == "Scan::Port_Scan" {
-    mutate {
-      add_field => {
-        "[threat][technique][id]"   => "T1046"
-        "[threat][technique][name]" => "Network Service Discovery"
-        "[threat][tactic][name]"    => "Discovery"
-        "[nist][function]"          => "Detect"
-      }
-    }
+    mutate { add_field => {
+      "[threat][technique][id]"   => "T1046"
+      "[threat][technique][name]" => "Network Service Discovery"
+      "[threat][tactic][id]"      => "TA0007"
+      "[threat][tactic][name]"    => "Discovery"
+      "[threat][framework]"       => "MITRE ATT&CK"
+      "[nist][function]"          => "Detect"
+    } }
   }
-
-  # Network: Zeek SSH failed-auth (brute force) -> Credential Access
+  # T1110 — Zeek SSH failed-auth (brute force) -> Credential Access.
   # auth_success arrives as a boolean from Zeek JSON; =~ coerces to string.
   if [auth_success] =~ /(?i)false/ {
-    mutate {
-      add_field => {
-        "[threat][technique][id]"   => "T1110"
-        "[threat][technique][name]" => "Brute Force"
-        "[threat][tactic][name]"    => "Credential Access"
-        "[nist][function]"          => "Detect"
-      }
-    }
+    mutate { add_field => {
+      "[threat][technique][id]"   => "T1110"
+      "[threat][technique][name]" => "Brute Force"
+      "[threat][tactic][id]"      => "TA0006"
+      "[threat][tactic][name]"    => "Credential Access"
+      "[threat][framework]"       => "MITRE ATT&CK"
+      "[nist][function]"          => "Detect"
+    } }
   }
 
-  # Endpoint: encoded PowerShell (Sysmon) -> Execution
-  if [process][executable] =~ "(?i)powershell" and [process][args] =~ "(?i)-enc" {
-    mutate {
-      add_field => {
-        "[threat][technique][id]"   => "T1059.001"
-        "[threat][technique][name]" => "PowerShell"
-        "[threat][tactic][name]"    => "Execution"
-        "[nist][function]"          => "Detect"
-      }
-    }
+  # -- Endpoint detections (Sigma tag -> ATT&CK technique) --
+  if "sigma_lsass_dump" in [tags] {
+    mutate { add_field => {
+      "[threat][technique][id]"   => "T1003.001"
+      "[threat][technique][name]" => "OS Credential Dumping: LSASS Memory"
+      "[threat][tactic][id]"      => "TA0006"
+      "[threat][tactic][name]"    => "Credential Access"
+      "[threat][framework]"       => "MITRE ATT&CK"
+      "[nist][function]"          => "Detect"
+    } }
+  }
+  if "sigma_event_log_clear" in [tags] {
+    mutate { add_field => {
+      "[threat][technique][id]"   => "T1070.001"
+      "[threat][technique][name]" => "Indicator Removal: Clear Windows Event Logs"
+      "[threat][tactic][id]"      => "TA0005"
+      "[threat][tactic][name]"    => "Defense Evasion"
+      "[threat][framework]"       => "MITRE ATT&CK"
+      "[nist][function]"          => "Detect"
+    } }
+  }
+  if "sigma_powershell_encoded" in [tags] {
+    mutate { add_field => {
+      "[threat][technique][id]"   => "T1059.001"
+      "[threat][technique][name]" => "Command and Scripting Interpreter: PowerShell"
+      "[threat][tactic][id]"      => "TA0002"
+      "[threat][tactic][name]"    => "Execution"
+      "[threat][framework]"       => "MITRE ATT&CK"
+      "[nist][function]"          => "Detect"
+    } }
+  }
+  if "sigma_bitsadmin_download" in [tags] {
+    mutate { add_field => {
+      "[threat][technique][id]"   => "T1105"
+      "[threat][technique][name]" => "Ingress Tool Transfer"
+      "[threat][tactic][id]"      => "TA0011"
+      "[threat][tactic][name]"    => "Command and Control"
+      "[threat][framework]"       => "MITRE ATT&CK"
+      "[nist][function]"          => "Detect"
+    } }
+  }
+  if "sigma_local_account_create" in [tags] {
+    mutate { add_field => {
+      "[threat][technique][id]"   => "T1136.001"
+      "[threat][technique][name]" => "Create Account: Local Account"
+      "[threat][tactic][id]"      => "TA0003"
+      "[threat][tactic][name]"    => "Persistence"
+      "[threat][framework]"       => "MITRE ATT&CK"
+      "[nist][function]"          => "Detect"
+    } }
+  }
+  if "sigma_rdp_hijack" in [tags] {
+    mutate { add_field => {
+      "[threat][technique][id]"   => "T1574"
+      "[threat][technique][name]" => "Hijack Execution Flow"
+      "[threat][tactic][id]"      => "TA0003"
+      "[threat][tactic][name]"    => "Persistence"
+      "[threat][framework]"       => "MITRE ATT&CK"
+      "[nist][function]"          => "Detect"
+    } }
+  }
+  if "sigma_regsvr32_remote_sct" in [tags] {
+    mutate { add_field => {
+      "[threat][technique][id]"   => "T1218.010"
+      "[threat][technique][name]" => "System Binary Proxy Execution: Regsvr32"
+      "[threat][tactic][id]"      => "TA0005"
+      "[threat][tactic][name]"    => "Defense Evasion"
+      "[threat][framework]"       => "MITRE ATT&CK"
+      "[nist][function]"          => "Detect"
+    } }
+  }
+  if "sigma_scheduled_task_create" in [tags] {
+    mutate { add_field => {
+      "[threat][technique][id]"   => "T1053.005"
+      "[threat][technique][name]" => "Scheduled Task/Job: Scheduled Task"
+      "[threat][tactic][id]"      => "TA0002"
+      "[threat][tactic][name]"    => "Execution"
+      "[threat][framework]"       => "MITRE ATT&CK"
+      "[nist][function]"          => "Detect"
+    } }
+  }
+  if "sigma_user_discovery" in [tags] {
+    mutate { add_field => {
+      "[threat][technique][id]"   => "T1033"
+      "[threat][technique][name]" => "System Owner/User Discovery"
+      "[threat][tactic][id]"      => "TA0007"
+      "[threat][tactic][name]"    => "Discovery"
+      "[threat][framework]"       => "MITRE ATT&CK"
+      "[nist][function]"          => "Detect"
+    } }
+  }
+  if "sigma_wmi_process_create" in [tags] {
+    mutate { add_field => {
+      "[threat][technique][id]"   => "T1047"
+      "[threat][technique][name]" => "Windows Management Instrumentation"
+      "[threat][tactic][id]"      => "TA0002"
+      "[threat][tactic][name]"    => "Execution"
+      "[threat][framework]"       => "MITRE ATT&CK"
+      "[nist][function]"          => "Detect"
+    } }
   }
 
   # --- Category 6: SOAR webhook signing (WS0.2) ---

--- a/tests/pipeline/test_framework_enrichment.py
+++ b/tests/pipeline/test_framework_enrichment.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Framework-enrichment consistency tests (MITRE ATT&CK + NIST CSF).
+
+These guard the detection-framework mapping in configs/logstash.conf:
+
+  * every Sigma rule in rules/sigma/*.yml is operationalized in the pipeline —
+    its ATT&CK technique is classified into ECS threat.technique.id, and a
+    sigma_* tag exists for the Endpoint dashboard's "Sigma Rule Hits" panel;
+  * every threat.technique.id mapping carries a tactic and a NIST CSF function
+    (so the MITRE heatmap and NIST donut never aggregate half-tagged events);
+  * the network detections (port scan T1046, SSH brute force T1110) are mapped.
+
+Pure stdlib (no pyyaml / no running stack) so it runs in any CI.
+
+Run:  python tests/pipeline/test_framework_enrichment.py     (or: pytest tests/pipeline)
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CONF = (ROOT / "configs" / "logstash.conf").read_text(encoding="utf-8")
+SIGMA_DIR = ROOT / "rules" / "sigma"
+
+# Network detections that must be classified in the pipeline (non-Sigma source).
+NETWORK_TECHNIQUES = {"T1046", "T1110"}
+
+_TECH_RE = re.compile(r"attack\.(t\d{4}(?:\.\d{3})?)", re.IGNORECASE)
+_ID_ASSIGN_RE = re.compile(r"\[threat\]\[technique\]\[id\]\"\s*=>\s*\"([^\"]+)\"")
+_TACTIC_ASSIGN_RE = re.compile(r"\[threat\]\[tactic\]\[name\]\"\s*=>")
+_NIST_ASSIGN_RE = re.compile(r"\[nist\]\[function\]\"\s*=>")
+_SIGMA_TAG_RE = re.compile(r"\bsigma_[a-z0-9_]+\b")
+
+
+def rule_technique(text: str):
+    """Return the ATT&CK technique id (e.g. T1003.001) declared in a Sigma rule."""
+    m = _TECH_RE.search(text)
+    return m.group(1).upper() if m else None
+
+
+class FrameworkEnrichmentTests(unittest.TestCase):
+    def setUp(self):
+        self.rules = sorted(SIGMA_DIR.glob("*.yml"))
+        self.mapped_ids = set(_ID_ASSIGN_RE.findall(CONF))
+
+    def test_sigma_rules_present(self):
+        # Sanity: the rule corpus exists (guards against a moved/empty dir).
+        self.assertGreaterEqual(len(self.rules), 10,
+                                f"expected >=10 Sigma rules, found {len(self.rules)}")
+
+    def test_every_sigma_technique_is_mapped(self):
+        # Completeness: each Sigma rule's ATT&CK technique is classified in the
+        # pipeline. This is what keeps rules/ and logstash.conf from drifting.
+        missing = []
+        for rule in self.rules:
+            tech = rule_technique(rule.read_text(encoding="utf-8"))
+            self.assertIsNotNone(tech, f"{rule.name}: no attack.tXXXX tag found")
+            if tech not in self.mapped_ids:
+                missing.append(f"{rule.name} ({tech})")
+        self.assertEqual([], missing,
+                         f"Sigma techniques not mapped in logstash.conf: {missing}")
+
+    def test_network_detections_mapped(self):
+        for tech in NETWORK_TECHNIQUES:
+            self.assertIn(tech, self.mapped_ids,
+                          f"network technique {tech} not mapped in logstash.conf")
+
+    def test_every_technique_has_tactic_and_nist(self):
+        # Each threat.technique.id assignment must be accompanied by a tactic name
+        # and a NIST CSF function so dashboards never see half-classified events.
+        n_ids = len(_ID_ASSIGN_RE.findall(CONF))
+        n_tactic = len(_TACTIC_ASSIGN_RE.findall(CONF))
+        n_nist = len(_NIST_ASSIGN_RE.findall(CONF))
+        self.assertEqual(n_ids, n_tactic,
+                         f"{n_ids} technique ids but {n_tactic} tactic names")
+        self.assertEqual(n_ids, n_nist,
+                         f"{n_ids} technique ids but {n_nist} nist functions")
+
+    def test_at_least_twelve_mappings(self):
+        # 10 Sigma + 2 network detections.
+        self.assertGreaterEqual(len(self.mapped_ids), 12,
+                                f"only {len(self.mapped_ids)} distinct techniques mapped")
+
+    def test_sigma_tags_defined_for_each_rule(self):
+        # Each rule must contribute at least one sigma_* tag in the detection layer.
+        tags = set(_SIGMA_TAG_RE.findall(CONF))
+        self.assertGreaterEqual(len(tags), len(self.rules),
+                                f"{len(tags)} sigma_* tags for {len(self.rules)} rules: {sorted(tags)}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
Completes the detection-framework enrichment in `configs/logstash.conf` so the Executive/Endpoint dashboards' framework panels populate. The pipeline previously mapped only 3 of 10 Sigma rules and 3 techniques; this wires up **all 10 Sigma rules + 2 network detections** with consistent ECS `threat.*` + NIST CSF classification.

## Changes
- **Detection layer** (`logstash.conf` Category 2): each `rules/sigma/*.yml` now adds a `sigma_<rule>` tag via a conditional mirroring that rule's `detection:` selection (3 → 10 rules).
- **Classification layer** (Category 5): each `sigma_*` tag and Zeek network detection maps to `threat.technique.id`/`name`, `threat.tactic.id`/`name`, `threat.framework`, and `nist.function`. 12 techniques: 10 endpoint (T1003.001, T1070.001, T1059.001, T1105, T1136.001, T1574, T1218.010, T1053.005, T1033, T1047) + 2 network (T1046 port scan, T1110 SSH brute force).
- **`tests/pipeline/test_framework_enrichment.py`** (stdlib-only, no running stack): asserts every Sigma rule's ATT&CK technique is mapped, each mapping carries a tactic + NIST function (no half-classified events), and `rules/` stays in sync with the pipeline.

## Verification
- `tests/pipeline/test_framework_enrichment.py` — **6/6 green**.
- `docker exec logstash bin/logstash --config.test_and_exit` — **Configuration OK**.
- Broker suite (`scripts/hive-mind-broker/test_app.py`) — **6/6 green** (unchanged).
- Design follows the layered detection-as-code pattern: detection → tag, tag → framework classification, keeping `rules/` and `logstash.conf` in sync (enforced by the test).

> **Note (live pipeline):** Logstash hot-reload is not enabled; restart the `logstash` service to load this config into the running stack.

## ⚠️ Out of scope — pre-existing blocker on `main`
While running the full suite I found that `scripts/setup/ai_agent/agent_app.py` on `main` **does not parse / never ran** — the CDP §12.3 approval-queue merge left it missing `import json/uuid/time`, missing the `log_soar_action` and `_execute_isolation` functions, and with `_read_queue()`'s body replaced by `log_soar_action`'s code. The agent test suite cannot import the module. **This PR deliberately does not touch `agent_app.py`** (the fix is a security-critical reconstruction of the SOAR execution path that belongs with the WS0.3/§12.3 reconciliation, not this framework PR). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)