### PR TITLE
fix(agent): repair non-functional agent_app.py; industry-standard SOAR response model

### DIFF
--- a/scripts/setup/ai_agent/agent_app.py
+++ b/scripts/setup/ai_agent/agent_app.py
@@ -1,5 +1,8 @@
 import os
 import re
+import json
+import time
+import uuid
 import hmac
 import hashlib
 import ipaddress
@@ -274,6 +277,71 @@ def _append_pending_action(action: dict) -> None:
 
 
 def _read_queue():
+    """Read every action from the append-only approval queue (oldest first).
+
+    A missing queue file simply means nothing has been drafted yet.
+    """
+    actions = []
+    try:
+        with open(APPROVAL_QUEUE, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    actions.append(json.loads(line))
+                except json.JSONDecodeError:
+                    app.logger.warning("Skipping malformed approval-queue line.")
+    except FileNotFoundError:
+        pass
+    return actions
+
+
+# =============================================================================
+# 3c. ISOLATION EXECUTION — only ever reached after a guard (flag or approval)
+# =============================================================================
+def _execute_isolation(mac: str, ip: str = ""):
+    """Run isolate.sh for a format-validated MAC. Returns (ok: bool, detail: str).
+
+    isolate.sh is MAC-only, so without a valid MAC we never invoke the
+    subprocess. The exclusion list is re-checked here (defence in depth, CDP
+    §12.4) so neither the autonomous path nor a human approval can ever quarantine
+    protected infrastructure.
+    """
+    if not is_valid_mac(mac):
+        return False, f"no valid MAC to isolate (got {mac!r}); manual action required"
+    excluded = is_excluded(mac=mac, ip=ip)
+    if excluded:
+        return False, f"{excluded} is on the permanent exclusion list — refused"
+    try:
+        result = subprocess.run(["sudo", ISOLATE_SCRIPT, mac], check=False)
+    except Exception as exc:  # noqa: BLE001 - never let response handling crash
+        app.logger.error("isolate.sh invocation failed: %s", exc)
+        return False, f"isolate.sh error: {exc}"
+    ok = result.returncode == 0
+    return ok, ("isolated" if ok else f"isolate.sh exited {result.returncode}")
+
+
+# =============================================================================
+# 3.5 SOAR FEEDBACK LOOP — index response actions back to Elasticsearch
+# =============================================================================
+def log_soar_action(action_type, target_ip, target_mac, ai_summary, severity):
+    """Index a SOAR response action to Elasticsearch for the Executive dashboard.
+
+    Writes to a daily soar-actions-YYYY.MM.dd index. Failures are logged but never
+    raised — dashboard telemetry must not break alert handling. `response.automated`
+    is True only for actually-executed actions, not drafted/review items.
+    """
+    doc = {
+        "@timestamp":         datetime.now(timezone.utc).isoformat(),
+        "action.type":        action_type,
+        "source.ip":          target_ip,
+        "source.mac":         target_mac or "N/A",
+        "ai.summary":         ai_summary,
+        "event.severity":     severity,
+        "response.automated": action_type not in ("analyst_review", "drafted"),
+    }
+    index = "soar-actions-" + datetime.now(timezone.utc).strftime("%Y.%m.%d")
     try:
         requests.post(
             f"{ES_HOST}/{index}/_doc",
@@ -314,100 +382,85 @@ def handle_kibana_webhook():
     # Step 1: AI triage
     ai_summary = analyze_alert_with_ai(raw_details)
 
-    # Step 2: Automated response
-    if severity == "critical" and valid_mac:
-        # Quarantine by MAC address (persists across IP/DHCP changes). Only a
-        # format-validated MAC ever reaches the subprocess. Wrapped so a failed
-        # isolate.sh invocation (e.g. missing ssh/sudo, unreachable router) is
-        # logged rather than crashing the handler into a 500.
-        try:
-            subprocess.run(["sudo", ISOLATE_SCRIPT, valid_mac], check=False)
-        except Exception as exc:  # noqa: BLE001 - never let response handling crash
-            app.logger.error("isolate.sh invocation failed: %s", exc)
-        target_ip = safe_ip
-
-        # ntfy mobile push
-        alert_body = (
-            f"NODE ISOLATED\nIP: {target_ip} | MAC: {valid_mac}\n\n"
-            f"AI Analysis:\n{ai_summary}"
-        )
-        return jsonify({"status": "Alert Processed", "ai_analysis": ai_summary}), 200
-
-    # --- Critical path ---
-    # §12.4: if the target is protected infrastructure, never even draft a block.
+    # Step 2 — §12.4: never act on protected infrastructure, not even to draft.
+    # Checked first so neither the autonomous path nor a draft can target it.
     excluded = is_excluded(ip=target_ip, mac=target_mac)
     if excluded:
-        app.logger.warning("Critical alert targets excluded asset %s — no action drafted.", excluded)
+        app.logger.warning("Alert targets excluded asset %s — no action taken.", excluded)
         send_soc_alert(
-            title="CRITICAL: Alert on PROTECTED asset — no action",
+            title=f"{severity.upper()}: Alert on PROTECTED asset — no action",
             message=(
-                f"Alert targets {excluded}, which is on the permanent exclusion list.\n"
-                f"NO isolation drafted. Investigate manually.\n\nAI Analysis:\n{ai_summary}"
+                f"Alert targets {excluded}, on the permanent exclusion list.\n"
+                f"No isolation taken or drafted. Investigate manually.\n\n"
+                f"AI Analysis:\n{ai_summary}"
             ),
             priority=5,
             tags="shield,warning,robot",
         )
+        log_soar_action("analyst_review", safe_ip, valid_mac, ai_summary, severity)
+        return jsonify({
+            "status": "no_action_protected_asset",
+            "asset": excluded,
+            "ai_analysis": ai_summary,
+        }), 200
 
-        # Discord SOC channel notification
-        send_discord_alert(
-            device_ip=target_ip,
-            device_mac=valid_mac,
-            ai_summary=ai_summary,
+    # Step 3 — §12.3: autonomous containment is OFF by default (it is destructive
+    # and irreversible without a human). We auto-execute ONLY when an operator has
+    # explicitly opted in (AUTONOMOUS_ISOLATION=true) AND the alert is critical
+    # with a format-validated MAC. Every other case is drafted for human approval.
+    if AUTONOMOUS_ISOLATION and severity == "critical" and valid_mac:
+        ok, detail = _execute_isolation(valid_mac, safe_ip)
+        send_soc_alert(
+            title="CRITICAL: Autonomous Isolation" if ok else "CRITICAL: Auto-isolation FAILED",
+            message=(
+                f"{'NODE ISOLATED' if ok else 'ISOLATION FAILED'}\n"
+                f"IP: {safe_ip} | MAC: {valid_mac}\nDetail: {detail}\n\n"
+                f"AI Analysis:\n{ai_summary}"
+            ),
+            priority=5,
+            tags="skull,lock,robot" if ok else "warning,lock,robot",
         )
-        return jsonify({"status": "Auto-isolated", "detail": detail, "ai_analysis": ai_summary}), 200
+        send_discord_alert(device_ip=safe_ip, device_mac=valid_mac, ai_summary=ai_summary)
+        log_soar_action(
+            "quarantine_mac" if ok else "analyst_review",
+            safe_ip, valid_mac, ai_summary, severity,
+        )
+        return jsonify({
+            "status": "auto_isolated" if ok else "isolation_failed",
+            "detail": detail,
+            "ai_analysis": ai_summary,
+        }), (200 if ok else 200)
 
-    # Default: DRAFT the action and queue it for human approval.
+    # Step 4 — default: DRAFT the action and queue it for a human-of-record, who
+    # executes it via POST /approve. Medium alerts and critical alerts without a
+    # valid MAC also land here (review-only).
     action = {
-        "id":        uuid.uuid4().hex[:12],
-        "ts":        time.time(),
-        "status":    "pending",
-        "severity":  severity,
-        "target_ip": target_ip,
-        "target_mac": target_mac,
+        "id":         uuid.uuid4().hex[:12],
+        "ts":         time.time(),
+        "status":     "pending",
+        "severity":   severity,
+        "target_ip":  safe_ip,
+        "target_mac": valid_mac,
         "ai_summary": ai_summary,
-        "recommended_action": "isolate (MAC)" if target_mac else "isolate (IP)",
+        "recommended_action": "isolate (MAC)" if valid_mac else "review (no valid MAC)",
     }
     _append_pending_action(action)
-
-        # SOAR feedback loop — record the automated quarantine for the dashboard
-        log_soar_action(
-            action_type="quarantine_mac",
-            target_ip=target_ip,
-            target_mac=valid_mac,
-            ai_summary=ai_summary,
-            severity=severity,
-        )
-    else:
-        # Either a medium alert, or a critical one we cannot auto-contain because
-        # no valid MAC was supplied (isolate.sh is MAC-only — we never feed it an
-        # IP). Both escalate to a human instead of taking an OS action.
-        if severity == "critical":
-            title = "CRITICAL: Manual Isolation Required (no valid MAC)"
-            priority = 5
-            note = "Auto-isolation skipped — supply a valid source_mac to quarantine."
-        else:
-            title = "MEDIUM: Analyst Review Requested"
-            priority = 3
-            note = "Review required for isolation."
-        alert_body = (
-            f"Suspicious Activity from {safe_ip}\n\n"
-            f"AI Analysis:\n{ai_summary}\n\n{note}"
-        )
-        send_soc_alert(
-            title=title,
-            message=alert_body,
-            priority=priority,
-            tags="warning,mag,robot",
-        )
-
-        # SOAR feedback loop — record the manual-review path (not automated)
-        log_soar_action(
-            action_type="analyst_review",
-            target_ip=safe_ip,
-            target_mac=valid_mac,
-            ai_summary=ai_summary,
-            severity=severity,
-        )
+    send_soc_alert(
+        title=f"{severity.upper()}: Response DRAFTED — approval required",
+        message=(
+            f"Drafted: {action['recommended_action']} for {safe_ip or valid_mac or 'unknown'}.\n"
+            f"Approve via POST /approve (id={action['id']}).\n\n"
+            f"AI Analysis:\n{ai_summary}"
+        ),
+        priority=5 if severity == "critical" else 3,
+        tags="memo,hourglass,robot",
+    )
+    log_soar_action("analyst_review", safe_ip, valid_mac, ai_summary, severity)
+    return jsonify({
+        "status": "drafted",
+        "action_id": action["id"],
+        "ai_analysis": ai_summary,
+    }), 200
 
 
 # =============================================================================

--- a/tests/ai_agent/test_alert_auth.py
+++ b/tests/ai_agent/test_alert_auth.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python3
 """
-WS0.2 — webhook authentication & input-validation tests for the SOC AI agent.
+SOC AI agent — webhook auth, input validation, and SOAR response-model tests.
 
-Asserts that the /alert endpoint:
-  * rejects requests with a missing or invalid HMAC signature (401) and never
-    invokes isolate.sh;
-  * quarantines only when a valid signature AND a format-valid MAC are present;
-  * never passes an invalid/malicious MAC to the isolate.sh subprocess.
+Covers WS0.2 (HMAC auth + MAC validation) and the CDP §12.3/§12.4 response model:
+
+  * /alert rejects missing/invalid HMAC signatures (401) and never executes;
+  * autonomous containment is OFF by default — a critical alert with a valid MAC
+    is DRAFTED for human approval, NOT auto-executed (the industry-standard
+    human-in-the-loop posture for a destructive, irreversible action);
+  * autonomous execution happens ONLY when an operator opts in
+    (AUTONOMOUS_ISOLATION=true);
+  * a malicious/invalid MAC never reaches the isolate.sh subprocess;
+  * §12.4 protected assets are never isolated and never even drafted;
+  * a drafted action can be listed (/pending) and executed by a human (/approve).
 
 Run:  python tests/ai_agent/test_alert_auth.py     (or: pytest tests/ai_agent)
 """
@@ -17,6 +23,7 @@ import json
 import types
 import hmac
 import hashlib
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -36,23 +43,38 @@ sys.path.insert(0, str(AGENT_DIR))
 
 import agent_app  # noqa: E402
 
+# An IP guaranteed to be on the permanent exclusion list (governance/exclusion_list.txt).
+EXCLUDED_IP = "192.168.1.1"
+GOOD_MAC = "AA:BB:CC:DD:EE:FF"
+
 
 def _sign(body: bytes) -> str:
     return "sha256=" + hmac.new(SECRET.encode(), body, hashlib.sha256).hexdigest()
 
 
-class AlertAuthTests(unittest.TestCase):
+class AlertResponseTests(unittest.TestCase):
     def setUp(self):
         agent_app.app.testing = True
         self.client = agent_app.app.test_client()
-        # Neutralize every outbound side-effect so the test is hermetic.
+
+        # Isolate the approval queue to a throwaway file per test.
+        self._qfile = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False, encoding="utf-8")
+        self._qfile.close()
+        self._qpatch = mock.patch.object(agent_app, "APPROVAL_QUEUE", self._qfile.name)
+        self._qpatch.start()
+
+        # Neutralize outbound side-effects. subprocess.run returns success (rc=0)
+        # so the autonomous/approve paths see isolate.sh "succeed".
         self.mock_run = mock.patch.object(agent_app.subprocess, "run").start()
+        self.mock_run.return_value.returncode = 0
         for fn in ("analyze_alert_with_ai", "send_soc_alert",
                    "send_discord_alert", "log_soar_action"):
             mock.patch.object(agent_app, fn, return_value="stub").start()
         self.addCleanup(mock.patch.stopall)
+        self.addCleanup(lambda: os.unlink(self._qfile.name))
 
-    def _post(self, payload, sign=True, tamper=False):
+    def _post(self, payload, sign=True, tamper=False, path="/alert"):
         body = json.dumps(payload).encode()
         headers = {"Content-Type": "application/json"}
         if sign:
@@ -60,31 +82,77 @@ class AlertAuthTests(unittest.TestCase):
             if tamper:
                 sig = sig[:-1] + ("0" if sig[-1] != "0" else "1")
             headers["x-elastic-signature"] = sig
-        return self.client.post("/alert", data=body, headers=headers)
+        return self.client.post(path, data=body, headers=headers)
 
+    # --- WS0.2 authentication ------------------------------------------------
     def test_missing_signature_rejected(self):
-        r = self._post({"severity": "critical", "source_mac": "AA:BB:CC:DD:EE:FF"}, sign=False)
+        r = self._post({"severity": "critical", "source_mac": GOOD_MAC}, sign=False)
         self.assertEqual(r.status_code, 401)
         self.mock_run.assert_not_called()
 
     def test_invalid_signature_rejected(self):
-        r = self._post({"severity": "critical", "source_mac": "AA:BB:CC:DD:EE:FF"}, tamper=True)
+        r = self._post({"severity": "critical", "source_mac": GOOD_MAC}, tamper=True)
         self.assertEqual(r.status_code, 401)
         self.mock_run.assert_not_called()
 
-    def test_valid_signature_valid_mac_quarantines(self):
+    # --- §12.3 draft-by-default (autonomous OFF) -----------------------------
+    def test_critical_valid_mac_drafts_not_executes_by_default(self):
         r = self._post({"severity": "critical", "source_ip": "1.2.3.4",
-                        "source_mac": "AA:BB:CC:DD:EE:FF"})
+                        "source_mac": GOOD_MAC})
         self.assertEqual(r.status_code, 200)
-        self.mock_run.assert_called_once()
-        passed_args = self.mock_run.call_args[0][0]
-        self.assertIn("AA:BB:CC:DD:EE:FF", passed_args)
+        self.assertEqual(r.get_json()["status"], "drafted")
+        self.mock_run.assert_not_called()          # NEVER auto-executes by default
+        # The drafted action is queued for approval.
+        pending = self.client.get("/pending").get_json()["pending"]
+        self.assertTrue(any(a["target_mac"] == GOOD_MAC for a in pending))
 
-    def test_valid_signature_malicious_mac_never_reaches_subprocess(self):
+    def test_malicious_mac_never_reaches_subprocess(self):
         r = self._post({"severity": "critical", "source_ip": "1.2.3.4",
                         "source_mac": "x; rm -rf / #"})
-        self.assertEqual(r.status_code, 200)         # handled (escalated to review)
-        self.mock_run.assert_not_called()            # but NEVER quarantined
+        self.assertEqual(r.status_code, 200)
+        self.mock_run.assert_not_called()
+
+    # --- §12.3 autonomous path (opt-in) --------------------------------------
+    def test_autonomous_flag_executes_isolation(self):
+        with mock.patch.object(agent_app, "AUTONOMOUS_ISOLATION", True):
+            r = self._post({"severity": "critical", "source_ip": "1.2.3.4",
+                            "source_mac": GOOD_MAC})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.get_json()["status"], "auto_isolated")
+        self.mock_run.assert_called_once()
+        self.assertIn(GOOD_MAC, self.mock_run.call_args[0][0])
+
+    def test_autonomous_flag_still_blocks_invalid_mac(self):
+        with mock.patch.object(agent_app, "AUTONOMOUS_ISOLATION", True):
+            r = self._post({"severity": "critical", "source_ip": "1.2.3.4",
+                            "source_mac": "not-a-mac"})
+        self.assertEqual(r.status_code, 200)
+        self.mock_run.assert_not_called()          # no valid MAC -> never executes
+
+    # --- §12.4 exclusion list ------------------------------------------------
+    def test_excluded_asset_never_acted_on(self):
+        with mock.patch.object(agent_app, "AUTONOMOUS_ISOLATION", True):
+            r = self._post({"severity": "critical", "source_ip": EXCLUDED_IP,
+                            "source_mac": GOOD_MAC})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.get_json()["status"], "no_action_protected_asset")
+        self.mock_run.assert_not_called()          # protected asset, even with flag on
+        # And nothing was drafted for it either.
+        pending = self.client.get("/pending").get_json()["pending"]
+        self.assertFalse(any(a["target_ip"] == EXCLUDED_IP for a in pending))
+
+    # --- approval flow: human executes a drafted action ----------------------
+    def test_pending_then_approve_executes(self):
+        draft = self._post({"severity": "critical", "source_ip": "1.2.3.4",
+                            "source_mac": GOOD_MAC}).get_json()
+        action_id = draft["action_id"]
+        self.mock_run.assert_not_called()          # still not executed at draft time
+
+        r = self._post({"id": action_id, "approver": "analyst1"}, path="/approve")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.get_json()["status"], "executed")
+        self.mock_run.assert_called_once()         # the human approval executes it
+        self.assertIn(GOOD_MAC, self.mock_run.call_args[0][0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why
`scripts/setup/ai_agent/agent_app.py` on `main` **does not parse and never ran** — the CDP §12.3 approval-queue merge committed broken code. The module is missing `import json/uuid/time`, is missing `log_soar_action` and `_execute_isolation` (both still called), `_read_queue()`'s body is actually `log_soar_action`'s ES-indexing code, and the `/alert` handler has an `IndentationError` plus an undefined `detail`. The agent — the SOC's response engine — is currently down on `main`, and its test suite can't even import the module.

## What this fixes
**Repairs the broken merge:**
- adds the missing `json` / `uuid` / `time` imports;
- restores `log_soar_action` (indexes SOAR actions to `soar-actions-*`);
- restores `_read_queue` to actually read the append-only approval queue;
- restores `_execute_isolation` (runs `isolate.sh` for a format-validated MAC, re-checks the §12.4 exclusion list) — used by `/approve`;
- fixes the `/alert` handler structure (IndentationError, undefined `detail`).

**Resolves the auto-isolate-vs-draft conflict per industry best practice** (human-in-the-loop for a destructive, irreversible action):
- **§12.4 exclusion check first** — protected infrastructure is never isolated *or* drafted;
- **autonomous containment OFF by default** — a critical alert with a valid MAC is **drafted for human approval**, not auto-executed;
- **autonomous execution only when `AUTONOMOUS_ISOLATION=true`** (explicit operator opt-in);
- a human-of-record executes a drafted action via `POST /approve`.

This supersedes the old WS0.2 test expectation (auto-quarantine by default), which encoded the pre-§12.3 behavior.

## Tests (all green)
Rewrote `tests/ai_agent/test_alert_auth.py` (8 cases): HMAC auth (401), draft-by-default (no execution), opt-in autonomous execution, malicious/invalid MAC never reaching the subprocess, §12.4 exclusion always winning (even with the flag on), and the `/pending` → `/approve` execution flow. **8/8 green; broker suite still 6/6; both modules compile.**

## Notes
- Scope: this is the agent-handler repair only. It pairs with the framework-enrichment work in #112 (separate concern) and unblocks the WS0.3/§12.3 reconciliation.
- The `AUTONOMOUS_ISOLATION` flag was already declared on `main` but unused; this wires it in as the single switch for autonomous behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)