### PR TITLE
feat(multitenancy): WS0.3 — tenant.id edge-stamp, per-tenant storage, tenant-scoped response

### DIFF
--- a/configs/endpoint/filebeat_endpoint.yml
+++ b/configs/endpoint/filebeat_endpoint.yml
@@ -27,6 +27,14 @@ filebeat.inputs:
 # Tag so Logstash routes these through the endpoint_logs branch.
 tags: ["endpoint_logs", "filebeat"]
 
+# Tenant attribution stamped at the edge (WS0.3). Set TENANT_ID per deployment
+# (lowercase slug); every event carries [tenant][id] for per-tenant routing,
+# access isolation, and response scoping. Defaults to "unassigned".
+fields_under_root: true
+fields:
+  tenant:
+    id: "${TENANT_ID:unassigned}"
+
 # Ship to the SOC Logstash beats input. Override host via env if needed.
 output.logstash:
   hosts: ["${LOGSTASH_HOST:localhost:5044}"]

--- a/configs/endpoint/winlogbeat.yml
+++ b/configs/endpoint/winlogbeat.yml
@@ -27,6 +27,14 @@ winlogbeat.event_logs:
 # Tag so Logstash routes these through the endpoint_logs branch.
 tags: ["endpoint_logs", "winlogbeat"]
 
+# Tenant attribution stamped at the edge (WS0.3). Set TENANT_ID per deployment
+# (lowercase slug); every event carries [tenant][id] for per-tenant routing,
+# access isolation, and response scoping. Defaults to "unassigned".
+fields_under_root: true
+fields:
+  tenant:
+    id: "${TENANT_ID:unassigned}"
+
 # Ship to the SOC Logstash beats input. Override host via env if needed.
 output.logstash:
   hosts: ["${LOGSTASH_HOST:localhost:5044}"]

--- a/configs/logstash.conf
+++ b/configs/logstash.conf
@@ -13,6 +13,16 @@ input {
 }
 
 filter {
+  # --- WS0.3: tenant attribution ---
+  # Every event must carry a tenant id. The beats shippers edge-stamp [tenant][id];
+  # the :5514 http input and any unstamped source default to "unassigned" so data is
+  # never dropped, just clearly unattributed. The id becomes part of the index name,
+  # so force lowercase for Elasticsearch index-name validity.
+  if ![tenant][id] {
+    mutate { add_field => { "[tenant][id]" => "unassigned" } }
+  }
+  mutate { lowercase => ["[tenant][id]"] }
+
   # --- Category 0: Zeek logs shipped by Filebeat from /storage/PCAP/zeek_logs ---
   # Filebeat's ndjson parser already expanded each line into top-level fields, so
   # Zeek's native keys (id, source, ts, note, auth_success, mime_type) arrive as-is.
@@ -376,6 +386,7 @@ filter {
         secret = ENV["SOC_AGENT_HMAC_SECRET"].to_s
         body = {
           "severity"   => "critical",
+          "tenant_id"  => event.get("[tenant][id]").to_s,
           "source_ip"  => event.get("[source][ip]").to_s,
           "source_mac" => event.get("[source][mac]").to_s
         }.to_json
@@ -397,7 +408,10 @@ output {
     # `logstash_internal` user (role: logstash_writer), injected as env vars by
     # docker-compose.yml — never the `elastic` superuser, never hardcoded.
     hosts    => ["${ELASTIC_HOSTS:https://elasticsearch:9200}"]
-    index    => "logstash-security-%{+YYYY.MM.dd}"
+    # Per-tenant index (WS0.3): isolation is enforced by ES roles scoped to
+    # logstash-security-<tenant>-*. Still matches the logstash-* data view, so
+    # dashboards keep working. provision_tenant.sh creates the per-tenant role.
+    index    => "logstash-security-%{[tenant][id]}-%{+YYYY.MM.dd}"
     data_stream => false
     user     => "${LOGSTASH_ES_USER}"
     password => "${LOGSTASH_ES_PASS}"

--- a/configs/network/filebeat.yml
+++ b/configs/network/filebeat.yml
@@ -14,6 +14,16 @@ filebeat.inputs:
           overwrite_keys: true
           add_error_key: true
 
+# ============================== Tenant attribution ===========================
+# Edge-stamping (WS0.3): each deployment sets TENANT_ID so every shipped event
+# carries [tenant][id]. Storage routing, ES role isolation, and tenant-scoped
+# response all key on this. Use a lowercase slug (e.g. "home-smith"); defaults
+# to "unassigned" so events are never dropped, just clearly unattributed.
+fields_under_root: true
+fields:
+  tenant:
+    id: "${TENANT_ID:unassigned}"
+
 # ============================== Logstash Output ===============================
 output.logstash:
   # LOGSTASH_HOST env var allows team members to change target without editing this file.

--- a/scripts/hive-mind-broker/app.py
+++ b/scripts/hive-mind-broker/app.py
@@ -6,6 +6,7 @@ import json
 import time
 import uuid
 import os
+import re
 import threading
 
 from inventory import Inventory
@@ -27,6 +28,15 @@ AUTONOMOUS_BLOCK_ENABLED = os.getenv("AUTONOMOUS_BLOCK_ENABLED", "false").lower(
 
 APPROVAL_QUEUE = os.getenv("APPROVAL_QUEUE", "approval_queue.jsonl")
 _queue_lock = threading.Lock()
+
+# Tenant slug (WS0.3) — same grammar as agent_app/logstash/provision_tenant.sh.
+_TENANT_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,38}$")
+
+
+def safe_tenant(value):
+    """Return a validated lowercase tenant slug, or 'unassigned' if invalid."""
+    v = str(value or "").strip().lower()
+    return v if _TENANT_RE.match(v) else "unassigned"
 
 
 def _append_action(action: dict) -> None:
@@ -85,20 +95,30 @@ async def receive_alert(request: Request, background_tasks: BackgroundTasks):
         return {"status": "success",
                 "message": f"IP {attacker_ip} is on the exclusion list — no block drafted."}
 
-    routers = inv.get_routers()
+    # WS0.3: scope the block to the alert's tenant — only that tenant's routers
+    # are ever touched; the broker never broadcasts across tenants. An unknown
+    # tenant (or one with no routers) is a no-op, not a fall-back-to-all.
+    tenant = safe_tenant(payload.get("tenant_id"))
+    routers = inv.get_routers_for_tenant(tenant)
+    if not routers:
+        print(f"[!] No routers for tenant '{tenant}' — refusing to act on {attacker_ip}.")
+        return {"status": "success",
+                "message": f"No routers configured for tenant '{tenant}' — nothing to block."}
 
     if AUTONOMOUS_BLOCK_ENABLED:
         # Legacy, out-of-scope behaviour, retained only behind an explicit flag.
         background_tasks.add_task(dispatch_block_to_all, routers, attacker_ip)
-        print(f"[*] Auto-block dispatched for {attacker_ip} (flag enabled).")
+        print(f"[*] Auto-block dispatched for {attacker_ip} on tenant '{tenant}' (flag enabled).")
         return {"status": "success",
-                "message": f"IP {attacker_ip} dispatched for block across {len(routers)} routers."}
+                "message": f"IP {attacker_ip} dispatched for block across {len(routers)} "
+                           f"router(s) for tenant '{tenant}'."}
 
     # Default: §12.3 — draft the block and queue it for human approval.
     action = {
         "id": uuid.uuid4().hex[:12],
         "ts": time.time(),
         "status": "pending",
+        "tenant": tenant,
         "attacker_ip": attacker_ip,
         "router_count": len(routers),
     }
@@ -139,12 +159,21 @@ async def approve(request: Request):
                         "approver": approver, "result": "exclusion list"})
         raise HTTPException(status_code=422, detail=f"{attacker_ip} is excluded")
 
-    routers = inv.get_routers()
+    # WS0.3: dispatch only to the drafted action's tenant routers — never all.
+    tenant = safe_tenant(action.get("tenant"))
+    routers = inv.get_routers_for_tenant(tenant)
+    if not routers:
+        _append_action({"id": action_id, "ts": time.time(), "status": "denied",
+                        "approver": approver, "result": f"no routers for tenant {tenant}"})
+        raise HTTPException(status_code=422, detail=f"no routers for tenant '{tenant}'")
+
     count = await dispatch_block_to_all(routers, attacker_ip)
     _append_action({"id": action_id, "ts": time.time(), "status": "approved",
-                    "approver": approver, "result": f"{count}/{len(routers)} routers"})
+                    "approver": approver, "tenant": tenant,
+                    "result": f"{count}/{len(routers)} routers"})
     return {"status": "executed", "approver": approver,
-            "message": f"IP {attacker_ip} blocked on {count}/{len(routers)} routers."}
+            "message": f"IP {attacker_ip} blocked on {count}/{len(routers)} "
+                       f"router(s) for tenant '{tenant}'."}
 
 
 if __name__ == "__main__":

--- a/scripts/hive-mind-broker/inventory.example.yaml
+++ b/scripts/hive-mind-broker/inventory.example.yaml
@@ -4,14 +4,20 @@
 # IMPORTANT: do NOT store plain-text secrets here. Reference strictly-scoped
 # Ed25519 SSH keys by path; keep the private keys out of the repo. For production,
 # back this with HashiCorp Vault or SOPS.
+#
+# WS0.3 — every router MUST declare a `tenant` (lowercase slug). A block is only
+# ever dispatched to routers whose tenant matches the alert; the broker never
+# broadcasts across tenants. Routers with no matching tenant are skipped.
 
 routers:
   - id: "primary-node-home"
+    tenant: "home-smith"
     ip_address: "192.168.1.1"
     username: "root"
     ssh_key_path: "~/.ssh/id_ed25519_hivemind"
 
   - id: "secondary-node-neighbor"
+    tenant: "neighbor-jones"
     ip_address: "10.0.0.1"
     username: "root"
     ssh_key_path: "~/.ssh/id_ed25519_hivemind"

--- a/scripts/hive-mind-broker/inventory.py
+++ b/scripts/hive-mind-broker/inventory.py
@@ -22,8 +22,19 @@ class Inventory:
     def get_routers(self):
         return self.routers
 
+    def get_routers_for_tenant(self, tenant):
+        """Return only the routers belonging to *tenant* (WS0.3).
+
+        Tenant isolation: a block must never reach another tenant's router. An
+        unknown tenant — or routers with no `tenant` field — yields an empty list,
+        so the caller dispatches to nothing rather than broadcasting.
+        """
+        if not tenant:
+            return []
+        return [r for r in self.routers if r.get("tenant") == tenant]
+
 # Quick test if run directly
 if __name__ == "__main__":
     inv = Inventory()
     for r in inv.get_routers():
-        print(f"Router ID: {r['id']}, IP: {r['ip_address']}")
+        print(f"Router ID: {r['id']}, Tenant: {r.get('tenant')}, IP: {r['ip_address']}")

--- a/scripts/hive-mind-broker/test_app.py
+++ b/scripts/hive-mind-broker/test_app.py
@@ -1,78 +1,108 @@
+import pytest
 from fastapi.testclient import TestClient
+from unittest import mock
+from unittest.mock import AsyncMock
 import hmac
 import hashlib
 import json
 import os
 
-# Set environment variable before importing app
+# Set the HMAC secret before importing app (read at import).
 os.environ["HIVE_MIND_SECRET"] = "test_secret"
 
+import app as broker_app
 from app import app, HMAC_SECRET
 
 client = TestClient(app)
 
-def test_webhook_alert_missing_signature():
-    response = client.post("/webhook/alert", json={"attacker_ip": "1.2.3.4"})
-    assert response.status_code == 401
-    assert response.json()["detail"] == "Missing signature header"
-
-def test_webhook_alert_invalid_signature():
-    response = client.post(
-        "/webhook/alert",
-        json={"attacker_ip": "1.2.3.4"},
-        headers={"x-elastic-signature": "invalid_sig"}
-    )
-    assert response.status_code == 401
-    assert response.json()["detail"] == "Invalid signature"
-
-def _signed(payload):
-    body = json.dumps(payload).encode('utf-8')
-    sig = hmac.new(HMAC_SECRET, body, hashlib.sha256).hexdigest()
-    return body, {"x-elastic-signature": f"sha256={sig}"}
+# A tenant + its router count, per the local inventory.yaml.
+TENANT = "home-smith"
+EXCLUDED_IP = "192.168.1.1"
 
 
-def test_webhook_alert_valid_signature():
-    payload = {"attacker_ip": "10.10.10.10"}
-    body = json.dumps(payload).encode('utf-8')
-    valid_mac = hmac.new(HMAC_SECRET, body, hashlib.sha256).hexdigest()
-
-    response = client.post(
-        "/webhook/alert",
-        data=body,
-        headers={"x-elastic-signature": f"sha256={valid_mac}"}
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "success"
-    assert "10.10.10.10" in response.json()["message"]
+def _sign(body: bytes) -> str:
+    return "sha256=" + hmac.new(HMAC_SECRET, body, hashlib.sha256).hexdigest()
 
 
-def test_valid_alert_drafts_not_autodispatches():
-    """CDP §12.3: default behaviour is to draft for approval, not auto-block."""
-    body, headers = _signed({"attacker_ip": "10.10.10.11"})
-    response = client.post("/webhook/alert", data=body, headers=headers)
-    assert response.status_code == 200
-    assert "approval" in response.json()["message"].lower()
-    # The drafted action should now appear in the pending queue.
+def _post(payload, sign=True, tamper=False):
+    body = json.dumps(payload).encode("utf-8")
+    headers = {}
+    if sign:
+        sig = _sign(body)
+        if tamper:
+            sig = sig[:-1] + ("0" if sig[-1] != "0" else "1")
+        headers["x-elastic-signature"] = sig
+    return client.post("/webhook/alert", data=body, headers=headers)
+
+
+@pytest.fixture(autouse=True)
+def _no_real_ssh():
+    """Keep the dispatcher from making real SSH calls; reset the queue per test."""
+    broker_app._append_action  # touch to ensure import
+    if os.path.exists(broker_app.APPROVAL_QUEUE):
+        os.remove(broker_app.APPROVAL_QUEUE)
+    with mock.patch.object(broker_app, "dispatch_block_to_all",
+                           new=AsyncMock(return_value=1)) as m:
+        yield m
+    if os.path.exists(broker_app.APPROVAL_QUEUE):
+        os.remove(broker_app.APPROVAL_QUEUE)
+
+
+def test_missing_signature():
+    assert client.post("/webhook/alert", json={"attacker_ip": "1.2.3.4"}).status_code == 401
+
+
+def test_invalid_signature():
+    assert _post({"attacker_ip": "1.2.3.4"}, tamper=True).status_code == 401
+
+
+def test_missing_ip():
+    r = _post({"tenant_id": TENANT})
+    assert r.status_code == 400
+
+
+def test_alert_with_tenant_drafts_for_approval(_no_real_ssh):
+    r = _post({"attacker_ip": "9.9.9.9", "tenant_id": TENANT})
+    assert r.status_code == 200
+    assert "approval" in r.json()["message"].lower()
+    _no_real_ssh.assert_not_awaited()              # draft does NOT dispatch
     pending = client.get("/pending").json()["pending"]
-    assert any(a["attacker_ip"] == "10.10.10.11" for a in pending)
+    drafted = [a for a in pending if a["attacker_ip"] == "9.9.9.9"]
+    assert drafted and drafted[0]["tenant"] == TENANT and drafted[0]["router_count"] >= 1
 
 
-def test_excluded_ip_is_refused():
-    """CDP §12.4: an IP on the exclusion list is never blocked, even when signed."""
-    body, headers = _signed({"attacker_ip": "192.168.1.1"})  # gateway in exclusion_list.txt
-    response = client.post("/webhook/alert", data=body, headers=headers)
-    assert response.status_code == 200
-    assert "exclusion list" in response.json()["message"].lower()
+def test_unknown_tenant_is_no_op(_no_real_ssh):
+    r = _post({"attacker_ip": "9.9.9.9", "tenant_id": "ghost-tenant"})
+    assert r.status_code == 200
+    assert "no routers" in r.json()["message"].lower()
+    _no_real_ssh.assert_not_awaited()
+    assert client.get("/pending").json()["count"] == 0   # nothing drafted
 
-def test_webhook_alert_missing_ip():
-    payload = {"some_other_field": "test"}
-    body = json.dumps(payload).encode('utf-8')
-    valid_mac = hmac.new(HMAC_SECRET, body, hashlib.sha256).hexdigest()
-    
-    response = client.post(
-        "/webhook/alert",
-        data=body,
-        headers={"x-elastic-signature": f"sha256={valid_mac}"}
-    )
-    assert response.status_code == 400
-    assert response.json()["detail"] == "Payload missing attacker_ip"
+
+def test_missing_tenant_is_no_op(_no_real_ssh):
+    # No tenant_id => 'unassigned', which owns no routers => no broadcast.
+    r = _post({"attacker_ip": "9.9.9.9"})
+    assert r.status_code == 200
+    assert "no routers" in r.json()["message"].lower()
+    _no_real_ssh.assert_not_awaited()
+
+
+def test_excluded_ip_refused(_no_real_ssh):
+    r = _post({"attacker_ip": EXCLUDED_IP, "tenant_id": TENANT})
+    assert r.status_code == 200
+    assert "exclusion list" in r.json()["message"].lower()
+    assert client.get("/pending").json()["count"] == 0
+
+
+def test_approve_dispatches_only_to_tenant_routers(_no_real_ssh):
+    draft = _post({"attacker_ip": "9.9.9.9", "tenant_id": TENANT}).json()
+    # pull the drafted id
+    action_id = [a for a in client.get("/pending").json()["pending"]
+                 if a["attacker_ip"] == "9.9.9.9"][0]["id"]
+
+    r = client.post("/approve", json={"id": action_id, "approver": "analyst1"})
+    assert r.status_code == 200
+    assert r.json()["status"] == "executed"
+    _no_real_ssh.assert_awaited_once()
+    routers_arg = _no_real_ssh.await_args[0][0]
+    assert routers_arg and all(rt.get("tenant") == TENANT for rt in routers_arg)

--- a/scripts/setup/.env.example
+++ b/scripts/setup/.env.example
@@ -33,13 +33,26 @@ SOC_AGENT_HMAC_SECRET=changeme_soar_webhook_secret
 
 # --- AI agent notifications & LLM triage (optional; blank = feature disabled) ---
 # ntfy topic for mobile push alerts. Pick a long, unguessable value.
+# Also the fallback topic for the 'unassigned' tenant (single-tenant deploys).
 NTFY_TOPIC=
 # OpenAI-compatible API key + endpoint for Level-1 AI triage.
 LLM_API_KEY=
 LLM_API_URL=https://api.openai.com/v1/chat/completions
 LLM_MODEL=gpt-4
-# Discord webhook for SOC channel notifications.
+# Discord webhook for SOC channel notifications (fallback for 'unassigned').
 DISCORD_WEBHOOK_URL=
+
+# --- Per-tenant response & notifications (WS0.3) ---
+# One set per tenant slug, suffixed UPPER_SNAKE (home-smith -> HOME_SMITH).
+# When a tenant's containment executes (autonomous OR human-approved), the agent
+# resolves that tenant's router from ROUTER_HOST_*; if unset, it refuses rather
+# than touching a default or another tenant's router. Notify vars fall back to
+# the global topic/webhook above.
+# ROUTER_HOST_HOME_SMITH=192.168.1.1
+# ROUTER_USER_HOME_SMITH=root
+# ROUTER_KEY_HOME_SMITH=/keys/id_ed25519_home_smith
+# NTFY_TOPIC_HOME_SMITH=subsoc-home-smith
+# DISCORD_WEBHOOK_URL_HOME_SMITH=https://discord.com/api/webhooks/...
 
 # --- Hive-Mind broker (router block dispatcher; runs separately) ---
 # Shared secret for HMAC-signing broker webhook requests. openssl rand -hex 32

--- a/scripts/setup/ai_agent/agent_app.py
+++ b/scripts/setup/ai_agent/agent_app.py
@@ -99,6 +99,64 @@ def is_valid_ip(value: str) -> bool:
         return False
 
 
+# --- WS0.3: per-tenant response & notification resolution --------------------
+_TENANT_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,38}$")
+
+
+def safe_tenant(value) -> str:
+    """Return a validated lowercase tenant slug, or 'unassigned' if invalid."""
+    v = str(value or "").strip().lower()
+    return v if _TENANT_RE.match(v) else "unassigned"
+
+
+def _tenant_env_suffix(tenant: str) -> str:
+    """home-smith -> HOME_SMITH (env-var suffix)."""
+    return tenant.upper().replace("-", "_")
+
+
+def resolve_router(tenant: str):
+    """Resolve a tenant's OpenWrt router SSH target from env (WS0.3).
+
+    A named tenant MUST have ROUTER_HOST_<TENANT>; if absent, returns None so the
+    caller refuses to isolate (never on a default or another tenant's router). The
+    'unassigned' tenant falls back to the global OPENWRT_* env (an empty host lets
+    isolate.sh apply its built-in default). Returns {host,user,key} or None.
+    """
+    if tenant == "unassigned":
+        return {
+            "host": os.environ.get("OPENWRT_HOST", ""),
+            "user": os.environ.get("OPENWRT_USER", ""),
+            "key":  os.environ.get("SSH_KEY", ""),
+        }
+    suffix = _tenant_env_suffix(tenant)
+    host = os.environ.get(f"ROUTER_HOST_{suffix}", "")
+    if not host:
+        return None
+    return {
+        "host": host,
+        "user": os.environ.get(f"ROUTER_USER_{suffix}", "root"),
+        "key":  os.environ.get(f"ROUTER_KEY_{suffix}", ""),
+    }
+
+
+def ntfy_topic_for(tenant: str) -> str:
+    """Per-tenant ntfy topic (NTFY_TOPIC_<TENANT>), else the global NTFY_TOPIC."""
+    if tenant != "unassigned":
+        topic = os.environ.get(f"NTFY_TOPIC_{_tenant_env_suffix(tenant)}")
+        if topic:
+            return topic
+    return NTFY_TOPIC
+
+
+def discord_webhook_for(tenant: str) -> str:
+    """Per-tenant Discord webhook, else the global DISCORD_WEBHOOK_URL."""
+    if tenant != "unassigned":
+        url = os.environ.get(f"DISCORD_WEBHOOK_URL_{_tenant_env_suffix(tenant)}")
+        if url:
+            return url
+    return DISCORD_WEBHOOK_URL
+
+
 # =============================================================================
 # 0a. EXCLUSION LIST — never isolate core infrastructure  (CDP §12.4)
 # =============================================================================
@@ -218,12 +276,13 @@ def analyze_alert_with_ai(raw_log_data):
 # =============================================================================
 # 2. NOTIFICATION ENGINE — ntfy push
 # =============================================================================
-def send_soc_alert(title, message, priority=3, tags="rotating_light"):
-    """Pushes formatted alerts to the analyst's mobile device via ntfy."""
-    if not NTFY_TOPIC:
-        app.logger.warning("NTFY_TOPIC not set — skipping ntfy push.")
+def send_soc_alert(title, message, priority=3, tags="rotating_light", tenant="unassigned"):
+    """Push formatted alerts to the analyst via ntfy, on the tenant's topic (WS0.3)."""
+    topic = ntfy_topic_for(tenant)
+    if not topic:
+        app.logger.warning("No ntfy topic for tenant '%s' — skipping ntfy push.", tenant)
         return
-    url = f"https://ntfy.sh/{NTFY_TOPIC}"
+    url = f"https://ntfy.sh/{topic}"
     headers = {
         "Title":    title,
         "Priority": str(priority),
@@ -238,13 +297,14 @@ def send_soc_alert(title, message, priority=3, tags="rotating_light"):
 # =============================================================================
 # 3. DISCORD NOTIFICATION — SOC channel alert
 # =============================================================================
-def send_discord_alert(device_ip: str, device_mac: str, ai_summary: str):
+def send_discord_alert(device_ip: str, device_mac: str, ai_summary: str, tenant: str = "unassigned"):
     """
-    Posts a rich quarantine notification to the SOC Discord channel.
-    Requires DISCORD_WEBHOOK_URL environment variable to be set.
+    Posts a rich quarantine notification to the SOC Discord channel, on the
+    tenant's webhook (WS0.3), falling back to the global DISCORD_WEBHOOK_URL.
     """
-    if not DISCORD_WEBHOOK_URL:
-        app.logger.warning("DISCORD_WEBHOOK_URL not set — skipping Discord notification.")
+    webhook = discord_webhook_for(tenant)
+    if not webhook:
+        app.logger.warning("No Discord webhook for tenant '%s' — skipping notification.", tenant)
         return
 
     payload = {
@@ -261,7 +321,7 @@ def send_discord_alert(device_ip: str, device_mac: str, ai_summary: str):
         }]
     }
     try:
-        requests.post(DISCORD_WEBHOOK_URL, json=payload, timeout=10)
+        requests.post(webhook, json=payload, timeout=10)
     except Exception as e:
         app.logger.error("Discord notification failed: %s", e)
 
@@ -300,21 +360,32 @@ def _read_queue():
 # =============================================================================
 # 3c. ISOLATION EXECUTION — only ever reached after a guard (flag or approval)
 # =============================================================================
-def _execute_isolation(mac: str, ip: str = ""):
+def _execute_isolation(mac: str, ip: str = "", tenant: str = "unassigned"):
     """Run isolate.sh for a format-validated MAC. Returns (ok: bool, detail: str).
 
-    isolate.sh is MAC-only, so without a valid MAC we never invoke the
-    subprocess. The exclusion list is re-checked here (defence in depth, CDP
-    §12.4) so neither the autonomous path nor a human approval can ever quarantine
-    protected infrastructure.
+    isolate.sh is MAC-only, so without a valid MAC we never invoke the subprocess.
+    The exclusion list is re-checked here (defence in depth, CDP §12.4) so neither
+    the autonomous path nor a human approval can ever quarantine protected infra.
+
+    WS0.3: the tenant's router is resolved and passed to isolate.sh as positional
+    args (they survive `sudo`, which strips env). A NAMED tenant with no configured
+    router is refused — we never isolate on a default or another tenant's router.
     """
     if not is_valid_mac(mac):
         return False, f"no valid MAC to isolate (got {mac!r}); manual action required"
     excluded = is_excluded(mac=mac, ip=ip)
     if excluded:
         return False, f"{excluded} is on the permanent exclusion list — refused"
+    router = resolve_router(tenant)
+    if router is None:
+        return False, (f"no router configured for tenant '{tenant}' "
+                       f"(set ROUTER_HOST_{_tenant_env_suffix(tenant)}); manual isolation required")
     try:
-        result = subprocess.run(["sudo", ISOLATE_SCRIPT, mac], check=False)
+        result = subprocess.run(
+            ["sudo", ISOLATE_SCRIPT, mac,
+             router.get("host", ""), router.get("user", ""), router.get("key", "")],
+            check=False,
+        )
     except Exception as exc:  # noqa: BLE001 - never let response handling crash
         app.logger.error("isolate.sh invocation failed: %s", exc)
         return False, f"isolate.sh error: {exc}"
@@ -325,15 +396,17 @@ def _execute_isolation(mac: str, ip: str = ""):
 # =============================================================================
 # 3.5 SOAR FEEDBACK LOOP — index response actions back to Elasticsearch
 # =============================================================================
-def log_soar_action(action_type, target_ip, target_mac, ai_summary, severity):
+def log_soar_action(action_type, target_ip, target_mac, ai_summary, severity, tenant="unassigned"):
     """Index a SOAR response action to Elasticsearch for the Executive dashboard.
 
-    Writes to a daily soar-actions-YYYY.MM.dd index. Failures are logged but never
-    raised — dashboard telemetry must not break alert handling. `response.automated`
-    is True only for actually-executed actions, not drafted/review items.
+    Writes to a per-tenant daily soar-actions-<tenant>-YYYY.MM.dd index (WS0.3),
+    matching the soar-actions-* data view and the per-tenant role grant. Failures
+    are logged but never raised — dashboard telemetry must not break alert
+    handling. `response.automated` is True only for actually-executed actions.
     """
     doc = {
         "@timestamp":         datetime.now(timezone.utc).isoformat(),
+        "tenant.id":          tenant,
         "action.type":        action_type,
         "source.ip":          target_ip,
         "source.mac":         target_mac or "N/A",
@@ -341,7 +414,7 @@ def log_soar_action(action_type, target_ip, target_mac, ai_summary, severity):
         "event.severity":     severity,
         "response.automated": action_type not in ("analyst_review", "drafted"),
     }
-    index = "soar-actions-" + datetime.now(timezone.utc).strftime("%Y.%m.%d")
+    index = f"soar-actions-{tenant}-" + datetime.now(timezone.utc).strftime("%Y.%m.%d")
     try:
         requests.post(
             f"{ES_HOST}/{index}/_doc",
@@ -378,6 +451,7 @@ def handle_kibana_webhook():
     # blanked (never passed through) so the subprocess only ever sees a clean MAC.
     valid_mac = target_mac if is_valid_mac(target_mac) else ""
     safe_ip   = target_ip if is_valid_ip(target_ip) else "unknown"
+    tenant    = safe_tenant(data.get("tenant_id"))  # WS0.3: scopes response + notify
 
     # Step 1: AI triage
     ai_summary = analyze_alert_with_ai(raw_details)
@@ -396,8 +470,9 @@ def handle_kibana_webhook():
             ),
             priority=5,
             tags="shield,warning,robot",
+            tenant=tenant,
         )
-        log_soar_action("analyst_review", safe_ip, valid_mac, ai_summary, severity)
+        log_soar_action("analyst_review", safe_ip, valid_mac, ai_summary, severity, tenant=tenant)
         return jsonify({
             "status": "no_action_protected_asset",
             "asset": excluded,
@@ -409,7 +484,7 @@ def handle_kibana_webhook():
     # explicitly opted in (AUTONOMOUS_ISOLATION=true) AND the alert is critical
     # with a format-validated MAC. Every other case is drafted for human approval.
     if AUTONOMOUS_ISOLATION and severity == "critical" and valid_mac:
-        ok, detail = _execute_isolation(valid_mac, safe_ip)
+        ok, detail = _execute_isolation(valid_mac, safe_ip, tenant)
         send_soc_alert(
             title="CRITICAL: Autonomous Isolation" if ok else "CRITICAL: Auto-isolation FAILED",
             message=(
@@ -419,11 +494,12 @@ def handle_kibana_webhook():
             ),
             priority=5,
             tags="skull,lock,robot" if ok else "warning,lock,robot",
+            tenant=tenant,
         )
-        send_discord_alert(device_ip=safe_ip, device_mac=valid_mac, ai_summary=ai_summary)
+        send_discord_alert(device_ip=safe_ip, device_mac=valid_mac, ai_summary=ai_summary, tenant=tenant)
         log_soar_action(
             "quarantine_mac" if ok else "analyst_review",
-            safe_ip, valid_mac, ai_summary, severity,
+            safe_ip, valid_mac, ai_summary, severity, tenant=tenant,
         )
         return jsonify({
             "status": "auto_isolated" if ok else "isolation_failed",
@@ -439,6 +515,7 @@ def handle_kibana_webhook():
         "ts":         time.time(),
         "status":     "pending",
         "severity":   severity,
+        "tenant":     tenant,
         "target_ip":  safe_ip,
         "target_mac": valid_mac,
         "ai_summary": ai_summary,
@@ -454,8 +531,9 @@ def handle_kibana_webhook():
         ),
         priority=5 if severity == "critical" else 3,
         tags="memo,hourglass,robot",
+        tenant=tenant,
     )
-    log_soar_action("analyst_review", safe_ip, valid_mac, ai_summary, severity)
+    log_soar_action("analyst_review", safe_ip, valid_mac, ai_summary, severity, tenant=tenant)
     return jsonify({
         "status": "drafted",
         "action_id": action["id"],
@@ -490,7 +568,13 @@ def approve_action():
     if not action:
         return jsonify({"error": f"no pending action {action_id}"}), 404
 
-    ok, detail = _execute_isolation(action.get("target_mac", ""), action.get("target_ip", ""))
+    action_tenant = safe_tenant(action.get("tenant"))
+    ok, detail = _execute_isolation(
+        action.get("target_mac", ""), action.get("target_ip", ""), action_tenant)
+    log_soar_action(
+        "quarantine_mac" if ok else "analyst_review",
+        action.get("target_ip", "unknown"), action.get("target_mac", ""),
+        action.get("ai_summary", ""), action.get("severity", "medium"), tenant=action_tenant)
     _append_pending_action({
         "id": action_id,
         "ts": time.time(),

--- a/scripts/setup/isolate.sh
+++ b/scripts/setup/isolate.sh
@@ -4,8 +4,8 @@
 # Phase C: OpenWrt uci MAC-based device isolation
 #
 # Usage:
-#   ./isolate.sh <MAC_ADDRESS>
-#   Example: ./isolate.sh AA:BB:CC:DD:EE:FF
+#   ./isolate.sh <MAC_ADDRESS> [ROUTER_HOST] [ROUTER_USER] [SSH_KEY]
+#   Example: ./isolate.sh AA:BB:CC:DD:EE:FF 192.168.1.1 root /keys/id_ed25519
 #
 # This script connects to the OpenWrt router via SSH and injects a
 # permanent firewall DROP rule targeting the specified MAC address.
@@ -19,10 +19,14 @@
 
 set -euo pipefail
 
+# WS0.3 tenant-scoped isolation: optional positional args 2-4 (router host/user/
+# key) override the env, which falls back to the built-in defaults. agent_app.py
+# passes the resolved tenant's router this way (positional args survive `sudo`,
+# which strips the environment); an empty arg is treated as unset.
 TARGET_MAC="${1:-}"
-OPENWRT_HOST="${OPENWRT_HOST:-192.168.1.1}"
-OPENWRT_USER="${OPENWRT_USER:-root}"
-SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519_hivemind}"
+OPENWRT_HOST="${2:-${OPENWRT_HOST:-192.168.1.1}}"
+OPENWRT_USER="${3:-${OPENWRT_USER:-root}}"
+SSH_KEY="${4:-${SSH_KEY:-$HOME/.ssh/id_ed25519_hivemind}}"
 
 # --- Validate input ---
 if [[ -z "$TARGET_MAC" ]]; then

--- a/scripts/setup/provision_tenant.sh
+++ b/scripts/setup/provision_tenant.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# =============================================================================
+# provision_tenant.sh — WS0.3 per-tenant isolation provisioner.
+#
+# For a given tenant slug, creates:
+#   * a Kibana Space            (UI isolation)
+#   * a space-scoped data view  (logstash-security-<tenant>-*)
+#   * a least-privilege role    (read ONLY that tenant's indices + that space)
+#   * a tenant viewer user      (mapped to the role; random password printed once)
+#
+# Tenant data is physically separated by index (logstash-security-<tenant>-*,
+# written by configs/logstash.conf). This script grants access to exactly one
+# tenant's slice, so a tenant user can never read another tenant's data.
+#
+# Usage:
+#   cd ~/projects/Suburban-SOC/scripts/setup
+#   ./provision_tenant.sh <tenant-slug>          # e.g. home-smith
+#
+# Env (auto-loaded from ./.env):
+#   ES_URL (default https://localhost:9200), KIBANA_URL (default http://localhost:5601)
+#   ES_USER/ES_PASS (default elastic / $ELASTIC_PASSWORD), ES_CA (optional)
+# =============================================================================
+set -euo pipefail
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+blue()  { printf '\033[34m%s\033[0m\n' "$*"; }
+
+TENANT="${1:-}"
+if [[ -z "$TENANT" ]]; then
+  red "Usage: $0 <tenant-slug>   (lowercase letters, digits, hyphens)"; exit 1
+fi
+if ! [[ "$TENANT" =~ ^[a-z0-9][a-z0-9-]{1,38}$ ]]; then
+  red "ERROR: tenant slug must be lowercase [a-z0-9-], 2-39 chars (got '$TENANT')."; exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[[ -f "$SCRIPT_DIR/.env" ]] && { set -a; . "$SCRIPT_DIR/.env"; set +a; }
+
+ES_URL="${ES_URL:-https://localhost:9200}"
+KIBANA_URL="${KIBANA_URL:-http://localhost:5601}"
+ES_USER="${ES_USER:-elastic}"
+ES_PASS="${ES_PASS:-${ELASTIC_PASSWORD:-}}"
+[[ -z "$ES_PASS" ]] && { red "ERROR: ES_PASS / ELASTIC_PASSWORD required."; exit 1; }
+
+AUTH=(-u "${ES_USER}:${ES_PASS}")
+if [[ -n "${ES_CA:-}" && -f "${ES_CA}" ]]; then TLS=(--cacert "${ES_CA}"); else TLS=(-k); fi
+
+ROLE="tenant_${TENANT//-/_}_viewer"
+USER="tenant_${TENANT//-/_}"
+TENANT_PW="${TENANT_PW:-$(openssl rand -base64 18)}"
+KARGS=(-s -H 'kbn-xsrf: true' -H 'Content-Type: application/json' "${AUTH[@]}")
+
+blue "==> [1/4] Creating Kibana space '${TENANT}'"
+curl "${KARGS[@]}" -o /dev/null -w '    space -> HTTP %{http_code}\n' \
+  -X POST "${KIBANA_URL}/api/spaces/space" \
+  -d "{\"id\":\"${TENANT}\",\"name\":\"${TENANT}\"}" || true
+
+blue "==> [2/4] Creating space-scoped data view (logstash-security-${TENANT}-*)"
+curl "${KARGS[@]}" -o /dev/null -w '    data view -> HTTP %{http_code}\n' \
+  -X POST "${KIBANA_URL}/s/${TENANT}/api/data_views/data_view" \
+  -d "{\"override\":true,\"data_view\":{\"id\":\"logstash-${TENANT}\",\"name\":\"logstash-security-${TENANT}-*\",\"title\":\"logstash-security-${TENANT}-*\",\"timeFieldName\":\"@timestamp\"}}" || true
+
+blue "==> [3/4] Creating least-privilege role '${ROLE}'"
+# Kibana role API sets BOTH the ES index privileges and the space-scoped feature
+# access in one object — the role can read only this tenant's indices + space.
+curl "${KARGS[@]}" -o /dev/null -w '    role -> HTTP %{http_code}\n' \
+  -X PUT "${KIBANA_URL}/api/security/role/${ROLE}" \
+  -d "{
+        \"elasticsearch\": {
+          \"indices\": [
+            {\"names\": [\"logstash-security-${TENANT}-*\", \"soar-actions-${TENANT}-*\"],
+             \"privileges\": [\"read\", \"view_index_metadata\"]}
+          ]
+        },
+        \"kibana\": [ {\"spaces\": [\"${TENANT}\"], \"base\": [\"read\"]} ]
+      }" || true
+
+blue "==> [4/4] Creating tenant user '${USER}'"
+code=$(curl -s -o /dev/null -w '%{http_code}' "${AUTH[@]}" "${TLS[@]}" \
+  -X PUT "${ES_URL}/_security/user/${USER}" \
+  -H 'Content-Type: application/json' \
+  -d "{\"password\":\"${TENANT_PW}\",\"roles\":[\"${ROLE}\"],\"full_name\":\"Tenant viewer: ${TENANT}\"}" || true)
+echo "    user -> HTTP ${code}"
+
+echo
+green "=================== TENANT PROVISIONED ==================="
+printf '  Tenant     : %s\n' "$TENANT"
+printf '  Space      : %s/s/%s\n' "$KIBANA_URL" "$TENANT"
+printf '  Indices    : logstash-security-%s-* , soar-actions-%s-*\n' "$TENANT" "$TENANT"
+printf '  Login      : %s  /  %s\n' "$USER" "$TENANT_PW"
+red    "  ^ Record this password now — it is shown only once."
+green "========================================================="

--- a/tests/ai_agent/test_alert_auth.py
+++ b/tests/ai_agent/test_alert_auth.py
@@ -154,6 +154,54 @@ class AlertResponseTests(unittest.TestCase):
         self.mock_run.assert_called_once()         # the human approval executes it
         self.assertIn(GOOD_MAC, self.mock_run.call_args[0][0])
 
+    # --- WS0.3 tenant-scoped isolation routing -------------------------------
+    def test_named_tenant_router_used_on_autonomous(self):
+        # The tenant's router is resolved and passed to isolate.sh.
+        with mock.patch.object(agent_app, "AUTONOMOUS_ISOLATION", True), \
+             mock.patch.dict(os.environ, {"ROUTER_HOST_HOME_SMITH": "192.168.9.1"}):
+            r = self._post({"severity": "critical", "source_ip": "1.2.3.4",
+                            "source_mac": GOOD_MAC, "tenant_id": "home-smith"})
+        self.assertEqual(r.get_json()["status"], "auto_isolated")
+        self.mock_run.assert_called_once()
+        passed = self.mock_run.call_args[0][0]
+        self.assertIn(GOOD_MAC, passed)
+        self.assertIn("192.168.9.1", passed)       # tenant's router, not a default
+
+    def test_named_tenant_without_router_refuses(self):
+        # A named tenant with no ROUTER_HOST_* must never isolate on a default
+        # or another tenant's router — even with autonomy enabled.
+        with mock.patch.object(agent_app, "AUTONOMOUS_ISOLATION", True), \
+             mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ROUTER_HOST_NEIGHBOR_JONES", None)
+            r = self._post({"severity": "critical", "source_ip": "1.2.3.4",
+                            "source_mac": GOOD_MAC, "tenant_id": "neighbor-jones"})
+        self.assertEqual(r.get_json()["status"], "isolation_failed")
+        self.mock_run.assert_not_called()
+
+
+class TenantResolverTests(unittest.TestCase):
+    """WS0.3 helper unit tests (no Flask client)."""
+
+    def test_safe_tenant(self):
+        self.assertEqual(agent_app.safe_tenant("Home-Smith"), "home-smith")
+        self.assertEqual(agent_app.safe_tenant("bad slug!"), "unassigned")
+        self.assertEqual(agent_app.safe_tenant(None), "unassigned")
+
+    def test_resolve_router_named_requires_host(self):
+        with mock.patch.dict(os.environ, {"ROUTER_HOST_HOME_SMITH": "10.0.0.9"}):
+            self.assertEqual(agent_app.resolve_router("home-smith")["host"], "10.0.0.9")
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ROUTER_HOST_NOBODY", None)
+            self.assertIsNone(agent_app.resolve_router("nobody"))
+
+    def test_resolve_router_unassigned_uses_global(self):
+        with mock.patch.dict(os.environ, {"OPENWRT_HOST": "192.168.1.1"}):
+            self.assertEqual(agent_app.resolve_router("unassigned")["host"], "192.168.1.1")
+
+    def test_notify_resolution_prefers_tenant_then_global(self):
+        with mock.patch.dict(os.environ, {"NTFY_TOPIC_HOME_SMITH": "tenant-topic"}):
+            self.assertEqual(agent_app.ntfy_topic_for("home-smith"), "tenant-topic")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
Completes **WS0.3 (multi-tenancy foundation)** end-to-end, reconciled onto current `main` (the parked work predated #111–#116, so it was re-applied/redesigned, not cherry-picked). Two phases:

### Phase A — ingest & storage (foundation)
- **Beats** (network/endpoint Filebeat, Winlogbeat) edge-stamp `[tenant][id]` from `${TENANT_ID:unassigned}`.
- **Logstash**: guard defaults missing `[tenant][id]` to `unassigned` + lowercases it; storage routes to `logstash-security-<tenant>-%{+YYYY.MM.dd}`; the critical-alert webhook body carries `tenant_id`.
- **`provision_tenant.sh`**: per-tenant Kibana Space + scoped data view + least-privilege role + viewer user.
- **`.env.example`**: per-tenant router/notify knobs.

### Phase B — response plane (redesigned onto CDP §12.3)
Both the agent and broker moved to a draft-for-approval + exclusion model while this was parked; the tenant-scoping is reconciled onto that:
- **Agent**: reads `tenant_id` and threads it through notify (per-tenant ntfy/Discord), `log_soar_action` (per-tenant `soar-actions-<tenant>-*`), and `_execute_isolation`. Isolation resolves the **tenant's** router and passes it to `isolate.sh`; a named tenant with no `ROUTER_HOST_*` is **refused** — never isolate on a default or another tenant's router. Drafted actions carry the tenant; `/approve` uses it.
- **Broker**: dispatches blocks **only** to the alert tenant's routers (draft + approve paths); unknown/absent tenant is a no-op, never a broadcast.

## Tests (all green)
- Agent `tests/ai_agent/` — **14/14** (tenant router used/refused, resolver + notify units, plus the §12.3 cases).
- Broker `hive-mind-broker/test_app.py` — **8/8** (tenant-scoped draft + approve, no-op on unknown/absent tenant, exclusion).
- Framework `tests/pipeline/` — **6/6**; `logstash --config.test_and_exit` → **Configuration OK**.

## Acceptance (roadmap WS0.3)
Two tenants' events are non-cross-readable (per-tenant indices + scoped roles); a quarantine/block for tenant A only ever touches tenant A's router; alerts land on tenant A's topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)