### PR TITLE
feat(lifecycle): WS0.5 — data streams + ILM + snapshot-before-delete (#91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ no customer deploy ships before it closes.
 | WS0.2 | Authenticate & harden the SOAR response webhook (HMAC, fail-closed) | ✅ Complete |
 | WS0.3 | Multi-tenancy foundation (`tenant.id`, per-tenant indices/roles/response) | ✅ Complete (PR #117) |
 | WS0.4 | Secrets management (`.env`, no hardcoded defaults) | ✅ Complete |
-| WS0.5 | Data lifecycle & retention (ILM, per-tenant purge) | 📋 Planned |
+| WS0.5 | Data lifecycle & retention (data streams, ILM hot/warm/delete, snapshot-before-delete) | 🚧 In progress (this branch) |
 | WS0.6 | Consolidate the duplicate Logstash config | ✅ Complete |
 
 ### Recent Enhancements

--- a/configs/elasticsearch/apply-lifecycle.sh
+++ b/configs/elasticsearch/apply-lifecycle.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# =============================================================================
+# apply-lifecycle.sh — install the Suburban-SOC data lifecycle (WS0.5).
+#
+# Bounds storage and makes the evidence window explicit by installing, in order:
+#   1. an fs snapshot repository  (suburban-soc-snapshots)         — needs path.repo
+#   2. an SLM policy              (suburban-soc-daily-snapshots)   — daily snapshots
+#   3. two ILM policies           (logstash-security-ilm 30d,
+#                                  soar-actions-ilm 365d)          — hot/warm/delete
+#   4. the data-stream index templates (via apply-templates.sh)    — data_stream:{}
+#
+# The ILM delete phase is snapshot-gated (wait_for_snapshot), so an index is only
+# deleted once the SLM policy has captured it — "snapshot before delete".
+#
+# Idempotent: every PUT is an upsert. Safe to re-run.
+#
+# Usage (from anywhere; env auto-loaded from scripts/setup/.env):
+#   ES_URL=https://localhost:9200 ES_USER=elastic ES_PASS=... ./apply-lifecycle.sh
+#   ./apply-lifecycle.sh --snapshot-now   # also trigger an immediate SLM snapshot
+# Env: ES_URL (default https://localhost:9200), ES_USER (elastic),
+#      ES_PASS / ELASTIC_PASSWORD.
+# =============================================================================
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$HERE/../../scripts/setup/.env"
+[[ -f "$ENV_FILE" ]] && { set -a; . "$ENV_FILE"; set +a; }
+
+ES_URL="${ES_URL:-https://localhost:9200}"
+ES_USER="${ES_USER:-elastic}"
+ES_PASS="${ES_PASS:-${ELASTIC_PASSWORD:-}}"
+[[ -z "$ES_PASS" ]] && { echo "ERROR: set ES_PASS or ELASTIC_PASSWORD"; exit 1; }
+
+SNAPSHOT_NOW=0
+for arg in "$@"; do
+  case "$arg" in
+    --snapshot-now) SNAPSHOT_NOW=1 ;;
+    --*) echo "Unknown flag: $arg"; exit 1 ;;
+  esac
+done
+
+REPO="suburban-soc-snapshots"
+SLM="suburban-soc-daily-snapshots"
+
+curl_es() { curl -sk -u "${ES_USER}:${ES_PASS}" -H 'Content-Type: application/json' "$@"; }
+put() {  # $1=label  $2=path  $3=json-file
+  curl_es -o /dev/null -w "    ${1} -> HTTP %{http_code}\n" -X PUT \
+    "$ES_URL$2" --data-binary "@$3"
+}
+
+echo "==> [1/4] Registering snapshot repository '${REPO}' (fs, path.repo)"
+# Fails with 500 'path.repo not registered' if docker-compose's path.repo +
+# snapshots volume are not in place — that's the actionable signal to redeploy.
+put "repo" "/_snapshot/${REPO}" "$HERE/ilm/snapshot-repository.json"
+
+echo "==> [2/4] Installing SLM policy '${SLM}'"
+put "slm" "/_slm/policy/${SLM}" "$HERE/ilm/slm-policy.json"
+
+echo "==> [3/4] Installing ILM policies"
+put "logstash-security-ilm" "/_ilm/policy/logstash-security-ilm" "$HERE/ilm/logstash-security.ilm.json"
+put "soar-actions-ilm"      "/_ilm/policy/soar-actions-ilm"      "$HERE/ilm/soar-actions.ilm.json"
+
+echo "==> [4/4] Installing data-stream index templates"
+# Templates carry data_stream:{} + index.lifecycle.name, so they must go in after
+# the ILM policies they reference exist.
+"$HERE/apply-templates.sh"
+
+if [[ $SNAPSHOT_NOW -eq 1 ]]; then
+  echo "==> Triggering an immediate snapshot via SLM '${SLM}'"
+  curl_es -o /dev/null -w '    execute -> HTTP %{http_code}\n' -X POST "$ES_URL/_slm/policy/${SLM}/_execute"
+fi
+
+echo "Done. Data lifecycle installed (ILM + snapshots + data-stream templates)."

--- a/configs/elasticsearch/ilm/logstash-security.ilm.json
+++ b/configs/elasticsearch/ilm/logstash-security.ilm.json
@@ -1,0 +1,36 @@
+{
+  "policy": {
+    "_meta": {
+      "description": "Suburban-SOC security telemetry lifecycle (WS0.5). High-volume Zeek/endpoint events. RETENTION = 30 days from rollover. hot -> warm(2d) -> delete(30d, snapshot-gated). Tune the delete min_age to change the evidence window; keep it aligned with the documented stance in docs/SOP-004-data-retention.md.",
+      "retention_days": 30,
+      "managed_by": "configs/elasticsearch/apply-lifecycle.sh"
+    },
+    "phases": {
+      "hot": {
+        "min_age": "0ms",
+        "actions": {
+          "set_priority": { "priority": 100 },
+          "rollover": {
+            "max_primary_shard_size": "10gb",
+            "max_age": "1d"
+          }
+        }
+      },
+      "warm": {
+        "min_age": "2d",
+        "actions": {
+          "set_priority": { "priority": 50 },
+          "forcemerge": { "max_num_segments": 1 },
+          "readonly": {}
+        }
+      },
+      "delete": {
+        "min_age": "30d",
+        "actions": {
+          "wait_for_snapshot": { "policy": "suburban-soc-daily-snapshots" },
+          "delete": {}
+        }
+      }
+    }
+  }
+}

--- a/configs/elasticsearch/ilm/slm-policy.json
+++ b/configs/elasticsearch/ilm/slm-policy.json
@@ -1,0 +1,18 @@
+{
+  "schedule": "0 30 1 * * ?",
+  "name": "<suburban-soc-snap-{now/d}>",
+  "repository": "suburban-soc-snapshots",
+  "config": {
+    "indices": ["logstash-security-*", "soar-actions-*"],
+    "include_global_state": false,
+    "metadata": {
+      "description": "Suburban-SOC daily snapshot (WS0.5) — gates the ILM delete phase's wait_for_snapshot. Single-node fs repo for the MVP; WS9.1 promotes to object storage with restore tests.",
+      "managed_by": "configs/elasticsearch/apply-lifecycle.sh"
+    }
+  },
+  "retention": {
+    "expire_after": "45d",
+    "min_count": 5,
+    "max_count": 60
+  }
+}

--- a/configs/elasticsearch/ilm/snapshot-repository.json
+++ b/configs/elasticsearch/ilm/snapshot-repository.json
@@ -1,0 +1,7 @@
+{
+  "type": "fs",
+  "settings": {
+    "location": "suburban-soc",
+    "compress": true
+  }
+}

--- a/configs/elasticsearch/ilm/soar-actions.ilm.json
+++ b/configs/elasticsearch/ilm/soar-actions.ilm.json
@@ -1,0 +1,28 @@
+{
+  "policy": {
+    "_meta": {
+      "description": "Suburban-SOC SOAR response-action lifecycle (WS0.5). Low-volume but evidentiary: every automated/analyst quarantine decision. RETENTION = 365 days from rollover so the response-evidence window outlives the raw telemetry (30d). hot -> delete(365d, snapshot-gated). See docs/SOP-004-data-retention.md.",
+      "retention_days": 365,
+      "managed_by": "configs/elasticsearch/apply-lifecycle.sh"
+    },
+    "phases": {
+      "hot": {
+        "min_age": "0ms",
+        "actions": {
+          "set_priority": { "priority": 100 },
+          "rollover": {
+            "max_primary_shard_size": "5gb",
+            "max_age": "30d"
+          }
+        }
+      },
+      "delete": {
+        "min_age": "365d",
+        "actions": {
+          "wait_for_snapshot": { "policy": "suburban-soc-daily-snapshots" },
+          "delete": {}
+        }
+      }
+    }
+  }
+}

--- a/configs/elasticsearch/logstash-security-template.json
+++ b/configs/elasticsearch/logstash-security-template.json
@@ -1,8 +1,9 @@
 {
   "index_patterns": ["logstash-security-*"],
   "priority": 200,
+  "data_stream": {},
   "_meta": {
-    "description": "Suburban-SOC unified security index. Pins ECS fields to keyword/ip/date so cross-index aggregations and dashboards are consistent (fixes the dynamic text+keyword drift that silently failed shard aggregations). WS0.3: tenant.id is a first-class keyword.",
+    "description": "Suburban-SOC unified security index. Pins ECS fields to keyword/ip/date so cross-index aggregations and dashboards are consistent (fixes the dynamic text+keyword drift that silently failed shard aggregations). WS0.3: tenant.id is a first-class keyword. WS0.5: backed by a per-tenant data stream (logstash-security-<tenant>) under ILM policy logstash-security-ilm.",
     "managed_by": "configs/elasticsearch/apply-templates.sh"
   },
   "template": {
@@ -10,7 +11,8 @@
       "number_of_shards": 1,
       "number_of_replicas": 0,
       "refresh_interval": "5s",
-      "index.mapping.ignore_malformed": true
+      "index.mapping.ignore_malformed": true,
+      "index.lifecycle.name": "logstash-security-ilm"
     },
     "mappings": {
       "dynamic_templates": [

--- a/configs/elasticsearch/soar-actions-template.json
+++ b/configs/elasticsearch/soar-actions-template.json
@@ -1,15 +1,17 @@
 {
   "index_patterns": ["soar-actions-*"],
   "priority": 200,
+  "data_stream": {},
   "_meta": {
-    "description": "Suburban-SOC SOAR response actions (written by agent_app.log_soar_action). Pins the dashboard fields so the automated-vs-manual / action-type / per-tenant aggregations are reliable. The agent posts dotted JSON keys (action.type, response.automated, ...) which ES expands into these objects.",
+    "description": "Suburban-SOC SOAR response actions (written by agent_app.log_soar_action). Pins the dashboard fields so the automated-vs-manual / action-type / per-tenant aggregations are reliable. The agent posts dotted JSON keys (action.type, response.automated, ...) which ES expands into these objects. WS0.5: backed by a per-tenant data stream (soar-actions-<tenant>) under ILM policy soar-actions-ilm (365d evidence window).",
     "managed_by": "configs/elasticsearch/apply-templates.sh"
   },
   "template": {
     "settings": {
       "number_of_shards": 1,
       "number_of_replicas": 0,
-      "refresh_interval": "5s"
+      "refresh_interval": "5s",
+      "index.lifecycle.name": "soar-actions-ilm"
     },
     "mappings": {
       "properties": {

--- a/configs/logstash.conf
+++ b/configs/logstash.conf
@@ -408,10 +408,17 @@ output {
     # `logstash_internal` user (role: logstash_writer), injected as env vars by
     # docker-compose.yml — never the `elastic` superuser, never hardcoded.
     hosts    => ["${ELASTIC_HOSTS:https://elasticsearch:9200}"]
-    # Per-tenant index (WS0.3): isolation is enforced by ES roles scoped to
-    # logstash-security-<tenant>-*. Still matches the logstash-* data view, so
-    # dashboards keep working. provision_tenant.sh creates the per-tenant role.
-    index    => "logstash-security-%{[tenant][id]}-%{+YYYY.MM.dd}"
+    # Per-tenant data stream (WS0.3 + WS0.5): isolation is enforced by ES roles
+    # scoped to the data stream name logstash-security-<tenant>. Still matches the
+    # logstash-* data view, so dashboards keep working. provision_tenant.sh creates
+    # the per-tenant role.
+    #
+    # WS0.5: the date suffix is gone — time is now managed by ILM rollover on the
+    # data stream, not by daily index names. `action => create` is required because
+    # data streams only accept op_type=create; ES auto-creates the stream from the
+    # priority-200 data_stream template (logstash-security-template) on first write.
+    index    => "logstash-security-%{[tenant][id]}"
+    action   => "create"
     data_stream => false
     user     => "${LOGSTASH_ES_USER}"
     password => "${LOGSTASH_ES_PASS}"

--- a/docs/SOP-004-data-retention.md
+++ b/docs/SOP-004-data-retention.md
@@ -1,0 +1,96 @@
+# SOP-004 — Data Lifecycle & Retention (WS0.5)
+
+**Status:** Active · **Milestone:** M7 (Platform Security & Multi-Tenancy Foundation) ·
+**Workstream:** WS0.5 · **Owner:** System Architect
+
+## Purpose
+
+Bound Elasticsearch storage and make the **evidence window explicit**. Before WS0.5
+the stack wrote unbounded daily indices (`logstash-security-<tenant>-YYYY.MM.dd`,
+`data_stream => false`) with no lifecycle policy — storage grew without limit and the
+retention period was undefined. WS0.5 converts every tenant stream to an
+**Index Lifecycle Management (ILM)**-governed **data stream** and gates deletion on a
+snapshot.
+
+## Retention policy (the documented window)
+
+| Data | Data stream | ILM policy | Rollover (hot) | Retention | Rationale |
+|------|-------------|-----------|----------------|-----------|-----------|
+| Security telemetry (Zeek / endpoint) | `logstash-security-<tenant>` | `logstash-security-ilm` | 10 GB primary shard **or** 1 day | **30 days** | High volume; 30d is the raw-evidence window for triage/hunt. |
+| SOAR response actions | `soar-actions-<tenant>` | `soar-actions-ilm` | 5 GB primary shard **or** 30 days | **365 days** | Low volume but evidentiary — every quarantine/analyst decision is kept a full year, outliving the raw telemetry. |
+
+Phases:
+
+- **Security telemetry:** `hot` (rollover, priority 100) → `warm` @ 2d (forcemerge to 1
+  segment, read-only, priority 50) → `delete` @ 30d.
+- **SOAR actions:** `hot` (rollover, priority 100) → `delete` @ 365d.
+
+`min_age` for the delete phase is measured **from rollover**, so total lifetime ≈
+rollover age + retention. Adjust the `delete.min_age` in
+`configs/elasticsearch/ilm/*.json` to change a window; keep this table in sync.
+
+> Privacy note: these windows are the technical enforcement of the capture/retention
+> stance. WS3.4 (Privacy/Confidentiality) and any resident-facing data-handling
+> commitment are the source of truth — reconcile the numbers there before changing them.
+
+## Snapshot before delete
+
+The `delete` phase uses ILM **`wait_for_snapshot`** against the SLM policy
+`suburban-soc-daily-snapshots`, so an index is **never deleted until it has been
+captured in a snapshot**.
+
+- **Repository:** `suburban-soc-snapshots` (type `fs`, location `suburban-soc`), backed
+  by the `suburban_soc_snapshots` Docker volume mounted at
+  `/usr/share/elasticsearch/snapshots`. Enabled by `path.repo` in
+  `scripts/setup/docker-compose.yml`.
+- **SLM policy:** `suburban-soc-daily-snapshots` runs daily at 01:30, snapshots
+  `logstash-security-*` + `soar-actions-*`, and expires snapshots after 45 days
+  (keep 5–60).
+- Single-node `fs` repo is the MVP posture. **WS9.1 (Reliability)** promotes this to
+  object storage with periodic restore tests.
+
+## Files
+
+- `configs/elasticsearch/ilm/logstash-security.ilm.json` — 30d telemetry policy
+- `configs/elasticsearch/ilm/soar-actions.ilm.json` — 365d evidence policy
+- `configs/elasticsearch/ilm/snapshot-repository.json` — fs repo definition
+- `configs/elasticsearch/ilm/slm-policy.json` — daily snapshot schedule + retention
+- `configs/elasticsearch/logstash-security-template.json`,
+  `configs/elasticsearch/soar-actions-template.json` — `data_stream:{}` + `index.lifecycle.name`
+- `configs/logstash.conf` — output writes `create` ops to `logstash-security-<tenant>`
+- `scripts/setup/ai_agent/agent_app.py` — `log_soar_action` writes to `soar-actions-<tenant>`
+- `configs/elasticsearch/apply-lifecycle.sh` — installer (repo → SLM → ILM → templates)
+- `scripts/setup/deploy_dashboards.sh` — step [6/7] runs the installer
+- `scripts/setup/verify_lifecycle.sh` — acceptance check
+
+## Install & verify
+
+```bash
+cd ~/projects/Suburban-SOC/scripts/setup
+
+# 1. Bring up the stack with the snapshot volume + path.repo (one-time recreate).
+docker compose up -d
+
+# 2. Install the lifecycle (also runs as step [6/7] of deploy_dashboards.sh).
+../../configs/elasticsearch/apply-lifecycle.sh
+
+# 3. Prove it: ILM attached, ROLLOVER OBSERVED, snapshot-before-delete in place.
+./verify_lifecycle.sh
+```
+
+## Acceptance (WS0.5, issue #91)
+
+- [x] Indices converted to **data streams** (`data_stream:{}` templates; Logstash +
+      agent write `op_type=create`).
+- [x] ILM **hot/warm/delete** defined with a **documented retention window** (table above).
+- [x] **Snapshot before delete** (SLM policy + ILM `wait_for_snapshot`).
+- [x] Policies installed via the **deploy script** (`apply-lifecycle.sh`, wired into
+      `deploy_dashboards.sh`).
+- [x] **Rollover observed** + retention enforced — see `verify_lifecycle.sh`.
+
+## Migration note
+
+Pre-WS0.5 daily indices (`logstash-security-<tenant>-YYYY.MM.dd`) remain as ordinary
+indices and are **not** governed by the new ILM policies. They are readable (they still
+match the `logstash-*` data view) and can be aged out manually, or migrated with
+`configs/elasticsearch/reindex-existing.sh`. New writes land in the data streams.

--- a/scripts/setup/ai_agent/agent_app.py
+++ b/scripts/setup/ai_agent/agent_app.py
@@ -399,10 +399,11 @@ def _execute_isolation(mac: str, ip: str = "", tenant: str = "unassigned"):
 def log_soar_action(action_type, target_ip, target_mac, ai_summary, severity, tenant="unassigned"):
     """Index a SOAR response action to Elasticsearch for the Executive dashboard.
 
-    Writes to a per-tenant daily soar-actions-<tenant>-YYYY.MM.dd index (WS0.3),
-    matching the soar-actions-* data view and the per-tenant role grant. Failures
-    are logged but never raised — dashboard telemetry must not break alert
-    handling. `response.automated` is True only for actually-executed actions.
+    Writes to a per-tenant soar-actions-<tenant> data stream (WS0.3 + WS0.5),
+    matching the soar-actions-* data view and the per-tenant role grant. Retention
+    is enforced by the soar-actions-ilm policy (365d evidence window). Failures are
+    logged but never raised — dashboard telemetry must not break alert handling.
+    `response.automated` is True only for actually-executed actions.
     """
     doc = {
         "@timestamp":         datetime.now(timezone.utc).isoformat(),
@@ -414,12 +415,16 @@ def log_soar_action(action_type, target_ip, target_mac, ai_summary, severity, te
         "event.severity":     severity,
         "response.automated": action_type not in ("analyst_review", "drafted"),
     }
-    index = f"soar-actions-{tenant}-" + datetime.now(timezone.utc).strftime("%Y.%m.%d")
+    # WS0.5: target the per-tenant data stream (no date suffix — ILM rollover owns
+    # time). Data streams only accept op_type=create, so use the _bulk create form;
+    # ES auto-creates the stream from the soar-actions-* data_stream template.
+    data_stream = f"soar-actions-{tenant}"
+    ndjson = '{"create":{}}\n' + json.dumps(doc) + "\n"
     try:
         requests.post(
-            f"{ES_HOST}/{index}/_doc",
-            json=doc,
-            headers={"Content-Type": "application/json"},
+            f"{ES_HOST}/{data_stream}/_bulk",
+            data=ndjson,
+            headers={"Content-Type": "application/x-ndjson"},
             auth=(ES_USER, ES_PASS),
             verify=ES_VERIFY,
             timeout=5,

--- a/scripts/setup/deploy_dashboards.sh
+++ b/scripts/setup/deploy_dashboards.sh
@@ -71,14 +71,14 @@ DASHBOARDS=(
 # -----------------------------------------------------------------------------
 # 1. Pre-flight — Elasticsearch + Kibana reachable
 # -----------------------------------------------------------------------------
-blue "==> [1/6] Validating Elasticsearch at ${ES_URL}"
+blue "==> [1/7] Validating Elasticsearch at ${ES_URL}"
 if ! curl -fsS "${ES_CURL[@]}" "${ES_URL}" >/dev/null 2>&1; then
   red "ERROR: Elasticsearch not reachable/authenticated at ${ES_URL}. Is the stack up (docker compose up -d) and ES_PASS correct?"
   exit 1
 fi
 green "    Elasticsearch is up (authenticated)."
 
-blue "==> [2/6] Validating Kibana at ${KIBANA_URL}"
+blue "==> [2/7] Validating Kibana at ${KIBANA_URL}"
 if ! curl -fsS "${AUTH[@]}" "${KIBANA_URL}/api/status" >/dev/null 2>&1; then
   red "ERROR: Kibana not reachable at ${KIBANA_URL}/api/status. Give it a minute to start (and check ES_PASS)."
   exit 1
@@ -88,7 +88,7 @@ green "    Kibana is up."
 # -----------------------------------------------------------------------------
 # 2. Provision the logstash-* data view (id: logstash-pattern)
 # -----------------------------------------------------------------------------
-blue "==> [3/6] Ensuring data views exist (logstash-pattern, soar-actions-pattern)"
+blue "==> [3/7] Ensuring data views exist (logstash-pattern, soar-actions-pattern)"
 # Use the Data Views API (NOT the low-level saved-objects API) so the data view
 # is created complete — with field caps. A field-less index-pattern object makes
 # aggregation-based visualizations throw "cannot read properties of undefined"
@@ -107,7 +107,7 @@ code=$(create_data_view "soar-actions-pattern" "soar-actions-*" "true")
 # -----------------------------------------------------------------------------
 # 3. Import all dashboard bundles
 # -----------------------------------------------------------------------------
-blue "==> [4/6] Importing dashboard bundles"
+blue "==> [4/7] Importing dashboard bundles"
 imported=0
 for f in "${DASHBOARDS[@]}"; do
   path="${SERVER_DIR}/${f}"
@@ -128,7 +128,7 @@ done
 # -----------------------------------------------------------------------------
 # 4. Install / update Elastic Watchers (best-effort; needs Watcher feature)
 # -----------------------------------------------------------------------------
-blue "==> [5/6] Installing Elastic Watchers"
+blue "==> [5/7] Installing Elastic Watchers"
 watchers=0
 if [[ -d "$WATCHER_DIR" ]]; then
   for w in "$WATCHER_DIR"/*.json; do
@@ -149,12 +149,29 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# 5. Restart Logstash to apply the pipeline config
+# 5b. Install the data lifecycle (WS0.5): ILM + snapshots + data-stream templates
+# -----------------------------------------------------------------------------
+# Must run BEFORE the Logstash restart so the data_stream templates exist when the
+# pipeline reloads and starts writing `create` ops to logstash-security-<tenant>.
+blue "==> [6/7] Installing data lifecycle (ILM + snapshots + data-stream templates)"
+LIFECYCLE_SCRIPT="$REPO_ROOT/configs/elasticsearch/apply-lifecycle.sh"
+if [[ -f "$LIFECYCLE_SCRIPT" ]]; then
+  if ES_URL="$ES_URL" ES_USER="$ES_USER" ES_PASS="$ES_PASS" bash "$LIFECYCLE_SCRIPT"; then
+    green "    Data lifecycle installed."
+  else
+    red "    WARN: apply-lifecycle.sh reported an error (is path.repo + the snapshots volume deployed? re-run docker compose up -d)."
+  fi
+else
+  red "    WARN: ${LIFECYCLE_SCRIPT} not found — ILM/snapshots not installed."
+fi
+
+# -----------------------------------------------------------------------------
+# 6. Restart Logstash to apply the pipeline config
 # -----------------------------------------------------------------------------
 # configs/logstash.conf is the single source of truth and is bind-mounted into
 # the container directly by docker-compose.yml (../../configs/logstash.conf), so
 # there is no copy/sync step — we only need to restart Logstash to reload it.
-blue "==> [6/6] Restarting Logstash to apply configs/logstash.conf"
+blue "==> [7/7] Restarting Logstash to apply configs/logstash.conf"
 if [[ -f "$LOGSTASH_SRC" ]]; then
   if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' | grep -q '^logstash$'; then
     docker restart logstash >/dev/null && green "    Restarted Logstash container."

--- a/scripts/setup/docker-compose.yml
+++ b/scripts/setup/docker-compose.yml
@@ -33,6 +33,9 @@ services:
     container_name: soc_setup
     volumes:
       - certs:/usr/share/elasticsearch/config/certs
+      # WS0.5: setup (root) also owns the snapshots volume so it can hand the fs
+      # repo path to the elasticsearch process (uid 1000) — see chown below.
+      - suburban_soc_snapshots:/usr/share/elasticsearch/snapshots
     user: "0"
     networks:
       - soc-mesh-net
@@ -62,6 +65,13 @@ services:
         # node key stay 640 root:root.
         chmod 755 config/certs config/certs/ca;
         chmod 644 config/certs/ca/ca.crt;
+        # WS0.5: the snapshots named volume mounts as root:root, but the ES process
+        # runs as uid 1000 and must create the fs snapshot repo dir under here.
+        # Hand it ownership so PUT _snapshot/<repo> can create its blob store.
+        echo "Preparing snapshot repository path (WS0.5)";
+        mkdir -p /usr/share/elasticsearch/snapshots;
+        chown 1000:0 /usr/share/elasticsearch/snapshots;
+        chmod 770 /usr/share/elasticsearch/snapshots;
         echo "Waiting for Elasticsearch";
         until curl -s --cacert config/certs/ca/ca.crt https://elasticsearch:9200 | grep -q "missing authentication credentials"; do sleep 5; done;
         echo "Setting kibana_system password";
@@ -100,12 +110,17 @@ services:
       - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
       - xpack.security.transport.ssl.verification_mode=certificate
       - xpack.license.self_generated.type=${LICENSE:-basic}
+      # WS0.5: register the filesystem snapshot repository path. The fs repo
+      # `suburban-soc-snapshots` (location "suburban-soc") lives under here, and the
+      # SLM policy snapshots into it so ILM's wait_for_snapshot can gate deletes.
+      - path.repo=/usr/share/elasticsearch/snapshots
       - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
     ports:
       - ${ES_PORT:-9200}:9200
     volumes:
       - certs:/usr/share/elasticsearch/config/certs
       - suburban_soc_data:/usr/share/elasticsearch/data
+      - suburban_soc_snapshots:/usr/share/elasticsearch/snapshots
     networks:
       - soc-mesh-net
     # Healthcheck now expects an authenticated-required response over HTTPS, proving
@@ -216,3 +231,5 @@ networks:
 volumes:
   certs:
   suburban_soc_data:
+  # WS0.5: persistent store for the fs snapshot repository (snapshot-before-delete).
+  suburban_soc_snapshots:

--- a/scripts/setup/provision_tenant.sh
+++ b/scripts/setup/provision_tenant.sh
@@ -4,13 +4,14 @@
 #
 # For a given tenant slug, creates:
 #   * a Kibana Space            (UI isolation)
-#   * a space-scoped data view  (logstash-security-<tenant>-*)
-#   * a least-privilege role    (read ONLY that tenant's indices + that space)
+#   * a space-scoped data view  (logstash-security-<tenant>)
+#   * a least-privilege role    (read ONLY that tenant's data streams + that space)
 #   * a tenant viewer user      (mapped to the role; random password printed once)
 #
-# Tenant data is physically separated by index (logstash-security-<tenant>-*,
-# written by configs/logstash.conf). This script grants access to exactly one
-# tenant's slice, so a tenant user can never read another tenant's data.
+# Tenant data is physically separated by data stream (logstash-security-<tenant>,
+# soar-actions-<tenant>; WS0.5), written by configs/logstash.conf and the AI agent.
+# This script grants access to exactly one tenant's slice, so a tenant user can
+# never read another tenant's data.
 #
 # Usage:
 #   cd ~/projects/Suburban-SOC/scripts/setup
@@ -56,20 +57,26 @@ curl "${KARGS[@]}" -o /dev/null -w '    space -> HTTP %{http_code}\n' \
   -X POST "${KIBANA_URL}/api/spaces/space" \
   -d "{\"id\":\"${TENANT}\",\"name\":\"${TENANT}\"}" || true
 
-blue "==> [2/4] Creating space-scoped data view (logstash-security-${TENANT}-*)"
+blue "==> [2/4] Creating space-scoped data view (logstash-security-${TENANT})"
+# WS0.5: the per-tenant target is now a data stream (logstash-security-<tenant>),
+# not daily indices, so the data view matches the exact stream name.
 curl "${KARGS[@]}" -o /dev/null -w '    data view -> HTTP %{http_code}\n' \
   -X POST "${KIBANA_URL}/s/${TENANT}/api/data_views/data_view" \
-  -d "{\"override\":true,\"data_view\":{\"id\":\"logstash-${TENANT}\",\"name\":\"logstash-security-${TENANT}-*\",\"title\":\"logstash-security-${TENANT}-*\",\"timeFieldName\":\"@timestamp\"}}" || true
+  -d "{\"override\":true,\"data_view\":{\"id\":\"logstash-${TENANT}\",\"name\":\"logstash-security-${TENANT}\",\"title\":\"logstash-security-${TENANT}\",\"timeFieldName\":\"@timestamp\"}}" || true
 
 blue "==> [3/4] Creating least-privilege role '${ROLE}'"
 # Kibana role API sets BOTH the ES index privileges and the space-scoped feature
-# access in one object — the role can read only this tenant's indices + space.
+# access in one object — the role can read only this tenant's data + space.
+# WS0.5: grant the exact per-tenant data stream names (logstash-security-<tenant>,
+# soar-actions-<tenant>). ES applies a data-stream grant to its backing indices
+# automatically, and exact names (no trailing -*) remove the wildcard prefix
+# collision the old "<tenant>-*" patterns had between slugs like `home`/`home-x`.
 curl "${KARGS[@]}" -o /dev/null -w '    role -> HTTP %{http_code}\n' \
   -X PUT "${KIBANA_URL}/api/security/role/${ROLE}" \
   -d "{
         \"elasticsearch\": {
           \"indices\": [
-            {\"names\": [\"logstash-security-${TENANT}-*\", \"soar-actions-${TENANT}-*\"],
+            {\"names\": [\"logstash-security-${TENANT}\", \"soar-actions-${TENANT}\"],
              \"privileges\": [\"read\", \"view_index_metadata\"]}
           ]
         },
@@ -87,7 +94,7 @@ echo
 green "=================== TENANT PROVISIONED ==================="
 printf '  Tenant     : %s\n' "$TENANT"
 printf '  Space      : %s/s/%s\n' "$KIBANA_URL" "$TENANT"
-printf '  Indices    : logstash-security-%s-* , soar-actions-%s-*\n' "$TENANT" "$TENANT"
+printf '  Data streams: logstash-security-%s , soar-actions-%s\n' "$TENANT" "$TENANT"
 printf '  Login      : %s  /  %s\n' "$USER" "$TENANT_PW"
 red    "  ^ Record this password now — it is shown only once."
 green "========================================================="

--- a/scripts/setup/verify_lifecycle.sh
+++ b/scripts/setup/verify_lifecycle.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# =============================================================================
+# verify_lifecycle.sh — prove the WS0.5 data lifecycle is live (acceptance check).
+#
+# Verifies, against a running stack:
+#   1. ILM policies exist                       (logstash-security-ilm, soar-actions-ilm)
+#   2. data-stream templates are data streams   (data_stream:{} present)
+#   3. the snapshot repository is registered + healthy
+#   4. the SLM policy is installed
+#   5. ROLLOVER OBSERVED — seeds a doc, forces a manual rollover on a security
+#      data stream, and shows generation 1 -> 2 with a fresh backing index.
+#   6. SNAPSHOT — triggers an SLM snapshot and confirms it reaches SUCCESS, so the
+#      ILM delete phase's wait_for_snapshot has something to gate on.
+#
+# Non-destructive: it only writes to a throwaway tenant data stream
+# (logstash-security-_verify) and deletes that stream at the end.
+#
+# Usage (env auto-loaded from scripts/setup/.env):
+#   ./verify_lifecycle.sh
+#   ./verify_lifecycle.sh --keep        # keep the _verify data stream for inspection
+# =============================================================================
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[[ -f "$HERE/.env" ]] && { set -a; . "$HERE/.env"; set +a; }
+
+ES_URL="${ES_URL:-https://localhost:9200}"
+ES_USER="${ES_USER:-elastic}"
+ES_PASS="${ES_PASS:-${ELASTIC_PASSWORD:-}}"
+[[ -z "$ES_PASS" ]] && { echo "ERROR: set ES_PASS or ELASTIC_PASSWORD"; exit 1; }
+
+KEEP=0
+[[ "${1:-}" == "--keep" ]] && KEEP=1
+
+REPO="suburban-soc-snapshots"
+SLM="suburban-soc-daily-snapshots"
+VERIFY_DS="logstash-security-_verify"
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+blue()  { printf '\033[34m%s\033[0m\n' "$*"; }
+
+es() { curl -sk -u "${ES_USER}:${ES_PASS}" -H 'Content-Type: application/json' "$@"; }
+# Bulk needs application/x-ndjson; keep it on its own curl so it never collides
+# with the application/json header in es() (ES rejects two Content-Type headers).
+es_bulk() { curl -sk -u "${ES_USER}:${ES_PASS}" -H 'Content-Type: application/x-ndjson' "$@"; }
+jget() { python3 -c "import sys,json;d=json.load(sys.stdin);print(eval('d$1'))" 2>/dev/null | tr -d '\r'; }
+
+FAIL=0
+pass() { green "    PASS: $*"; }
+warn() { red   "    FAIL: $*"; FAIL=1; }
+
+blue "==> [1/6] ILM policies present"
+for p in logstash-security-ilm soar-actions-ilm; do
+  code=$(es -o /dev/null -w '%{http_code}' "$ES_URL/_ilm/policy/$p")
+  [[ "$code" == "200" ]] && pass "$p installed" || warn "$p missing (HTTP $code) — run apply-lifecycle.sh"
+done
+
+blue "==> [2/6] Index templates are data streams"
+for t in logstash-security-template soar-actions-template; do
+  has_ds=$(es "$ES_URL/_index_template/$t" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+print('yes' if d.get('index_templates',[{}])[0].get('index_template',{}).get('data_stream') is not None else 'no')" 2>/dev/null | tr -d '\r')
+  [[ "$has_ds" == "yes" ]] && pass "$t has data_stream:{}" || warn "$t is NOT a data-stream template — run apply-templates.sh"
+done
+
+blue "==> [3/6] Snapshot repository registered + healthy"
+verify=$(es "$ES_URL/_snapshot/$REPO/_verify" -X POST)
+if echo "$verify" | grep -q '"nodes"'; then
+  pass "repository '$REPO' verified"
+else
+  warn "repository '$REPO' not healthy: $(echo "$verify" | head -c 200) (check path.repo + snapshots volume)"
+fi
+
+blue "==> [4/6] SLM policy installed"
+code=$(es -o /dev/null -w '%{http_code}' "$ES_URL/_slm/policy/$SLM")
+[[ "$code" == "200" ]] && pass "SLM '$SLM' installed" || warn "SLM '$SLM' missing (HTTP $code)"
+
+blue "==> [5/6] ROLLOVER OBSERVED (seed -> manual rollover on $VERIFY_DS)"
+es_bulk -o /dev/null -X POST "$ES_URL/$VERIFY_DS/_bulk" \
+  --data-binary $'{"create":{}}\n{"@timestamp":"2026-01-01T00:00:00Z","tenant":{"id":"_verify"},"message":"ws0.5 verify seed"}\n'
+gen_before=$(es "$ES_URL/_data_stream/$VERIFY_DS" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+ds=d.get('data_streams',[])
+print(ds[0].get('generation') if ds else 'none')" 2>/dev/null | tr -d '\r')
+es -o /dev/null -X POST "$ES_URL/$VERIFY_DS/_rollover"
+gen_after=$(es "$ES_URL/_data_stream/$VERIFY_DS" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+ds=d.get('data_streams',[])
+print(ds[0].get('generation') if ds else 'none')" 2>/dev/null | tr -d '\r')
+n_backing=$(es "$ES_URL/_data_stream/$VERIFY_DS" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+ds=d.get('data_streams',[])
+print(len(ds[0].get('indices',[])) if ds else 0)" 2>/dev/null | tr -d '\r')
+if [[ "$gen_before" =~ ^[0-9]+$ && "$gen_after" =~ ^[0-9]+$ && "$gen_after" -gt "$gen_before" ]]; then
+  pass "rollover observed: generation $gen_before -> $gen_after ($n_backing backing indices)"
+else
+  warn "rollover not observed (gen $gen_before -> $gen_after) — is the data_stream template installed?"
+fi
+
+blue "==> [6/6] SNAPSHOT (trigger SLM, confirm SUCCESS)"
+snap=$(es -X POST "$ES_URL/_slm/policy/$SLM/_execute")
+snap_name=$(echo "$snap" | python3 -c "import sys,json;print(json.load(sys.stdin).get('snapshot_name',''))" 2>/dev/null | tr -d '\r')
+if [[ -n "$snap_name" ]]; then
+  state=""
+  for _ in $(seq 1 30); do
+    state=$(es "$ES_URL/_snapshot/$REPO/$snap_name" | python3 -c "
+import sys,json
+try: print(json.load(sys.stdin)['snapshots'][0]['state'])
+except Exception: print('PENDING')" 2>/dev/null | tr -d '\r')
+    [[ "$state" == "SUCCESS" || "$state" == "PARTIAL" || "$state" == "FAILED" ]] && break
+    sleep 2
+  done
+  [[ "$state" == "SUCCESS" ]] && pass "snapshot '$snap_name' -> SUCCESS" || warn "snapshot '$snap_name' state=$state"
+else
+  warn "SLM execute did not return a snapshot name: $(echo "$snap" | head -c 200)"
+fi
+
+# Cleanup the throwaway verify stream unless --keep.
+if [[ $KEEP -eq 0 ]]; then
+  es -o /dev/null -X DELETE "$ES_URL/_data_stream/$VERIFY_DS" || true
+fi
+
+echo
+if [[ $FAIL -eq 0 ]]; then
+  green "===== WS0.5 lifecycle verified: ILM attached, rollover observed, snapshot-before-delete in place ====="
+  exit 0
+else
+  red "===== WS0.5 verification had failures (see FAIL lines above) ====="
+  exit 1
+fi


### PR DESCRIPTION
Closes #91 (WS0.5 — Data lifecycle & retention, Milestone 7).

## What
Bounds Elasticsearch storage and makes the **evidence window explicit**: converts the per-tenant security + SOAR indices to **data streams** governed by **ILM**, with deletion **gated on a snapshot**.

Naming stays `logstash-security-*` / `soar-actions-*` so WS0.3 tenant roles, data views, and all 5 dashboards keep working unchanged (no rename to the roadmap's `logs-suburbansoc.*` ECS scheme — too much blast radius for the MVP).

## Changes
- **Data streams** — `*-template.json` add `data_stream:{}` + `index.lifecycle.name`. `configs/logstash.conf` writes `action => create` into `logstash-security-<tenant>` (date suffix dropped; rollover owns time). `agent_app.log_soar_action` writes `soar-actions-<tenant>` via `_bulk` create.
- **ILM** — `logstash-security-ilm` (hot → warm@2d forcemerge+readonly → **delete@30d**); `soar-actions-ilm` (hot → **delete@365d** evidence window). Delete phase is `wait_for_snapshot`-gated.
- **Snapshot before delete** — fs repo `suburban-soc-snapshots` (`path.repo` + `suburban_soc_snapshots` volume; the `setup` container owns the path) + SLM `suburban-soc-daily-snapshots`.
- **Install via deploy** — new `apply-lifecycle.sh` (repo → SLM → ILM → templates), wired into `deploy_dashboards.sh` step `[6/7]`.
- **Verifier + doc** — `verify_lifecycle.sh`; `docs/SOP-004-data-retention.md` (documented retention table).
- **provision_tenant.sh** — grants exact data-stream names (removes the old `<tenant>-*` wildcard prefix-collision).

## Retention (documented)
| Data | Data stream | Policy | Retention |
|------|-------------|--------|-----------|
| Security telemetry | `logstash-security-<tenant>` | `logstash-security-ilm` | **30 days** |
| SOAR actions (evidence) | `soar-actions-<tenant>` | `soar-actions-ilm` | **365 days** |

## Validated live (ES 9.3.2 stack)
- ILM policies installed; templates are data streams; repo healthy; SLM installed.
- **Rollover observed**: generation 1 → 2 (2 backing indices).
- **Snapshot SUCCESS** (snapshot-before-delete in place).
- Real **Logstash** pipeline → `logstash-security-unassigned` (ILM-managed); real **agent** SOAR write → `soar-actions-unassigned` (ILM-managed).
- `verify_lifecycle.sh` exits 0; test streams cleaned up.

## Acceptance (#91)
- [x] Convert indices to data streams
- [x] Define ILM hot/warm/delete with documented retention window
- [x] Snapshot before delete
- [x] Install policies via deploy script

🤖 Generated with [Claude Code](https://claude.com/claude-code)