### PR TITLE
feat(soar): route agent quarantine through the hive-mind-broker (#109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Before you begin, ensure you have the following:
 ### 3. Usage:
 1.  **Architecture Flow:**
     **Detection:** `OpenWrt (SSH/tcpdump) ➔ Zeek (JSON + MAC enrichment) ➔ Filebeat ➔ Logstash ➔ Elasticsearch ➔ Kibana`  
-    **Response:** `Kibana Watcher ➔ SOC AI Agent (LLM triage + approval queue) ➔ isolate.sh ➔ OpenWrt (MAC DROP rule)`  
+    **Response:** `Kibana Watcher ➔ SOC AI Agent (LLM triage + approval queue) ➔ Hive-Mind Broker (HMAC) ➔ OpenWrt (nftables IP DROP)`  
     **Alerts:** `SOC AI Agent ➔ ntfy (mobile push) + Discord (SOC channel)`
 2.  **Running the Pipeline:**
     Execute the relevant bash scripts in `/scripts/setup/` to begin streaming raw PCAP data over SSH.

--- a/scripts/hive-mind-broker/Dockerfile
+++ b/scripts/hive-mind-broker/Dockerfile
@@ -1,0 +1,17 @@
+# Hive-Mind Broker — authenticated router-block dispatcher (#109).
+# Slim image: only needs Python + the pure-wheel deps (asyncssh/cryptography ship
+# manylinux wheels, so no build toolchain required).
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# Router inventory (inventory.yaml) and the SSH key are mounted at runtime by
+# docker-compose — never baked into the image (they are host-specific secrets).
+EXPOSE 8000
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/scripts/hive-mind-broker/app.py
+++ b/scripts/hive-mind-broker/app.py
@@ -52,35 +52,40 @@ def _read_queue():
     except OSError:
         return []
 
-@app.post("/webhook/alert")
-async def receive_alert(request: Request, background_tasks: BackgroundTasks):
-    """
-    Receives webhook payloads from Kibana when a critical alert fires.
+
+async def _verify_and_parse(request: Request) -> dict:
+    """Fail-closed HMAC gate shared by every block-producing endpoint.
+
+    Verifies the x-elastic-signature HMAC over the RAW body (same scheme as the AI
+    agent), then returns the parsed JSON. Raises the appropriate HTTPException on
+    any failure so callers never see an unauthenticated or malformed payload.
     """
     # Fail closed if no secret is configured — never accept unauthenticated blocks.
     if not HMAC_SECRET:
         raise HTTPException(status_code=503, detail="Broker secret not configured")
 
-    # Verify HMAC signature
     signature_header = request.headers.get("x-elastic-signature")
     if not signature_header:
         raise HTTPException(status_code=401, detail="Missing signature header")
-    
-    # Read the raw body for HMAC verification
+
+    # The raw body is what was signed — verify before parsing.
     body = await request.body()
-    
-    # Calculate expected signature
     expected_mac = hmac.new(HMAC_SECRET, body, hashlib.sha256).hexdigest()
-    
-    # Use hmac.compare_digest to prevent timing attacks
     if not hmac.compare_digest(f"sha256={expected_mac}", signature_header):
         raise HTTPException(status_code=401, detail="Invalid signature")
 
-    # Parse JSON payload
     try:
-        payload = await request.json()
+        return json.loads(body)
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid JSON payload")
+
+
+@app.post("/webhook/alert")
+async def receive_alert(request: Request, background_tasks: BackgroundTasks):
+    """
+    Receives webhook payloads from Kibana when a critical alert fires.
+    """
+    payload = await _verify_and_parse(request)
 
     # Extract the attacker IP from the Kibana alert payload
     # Payload structure depends on the specific Kibana Watcher/Alert action
@@ -126,6 +131,55 @@ async def receive_alert(request: Request, background_tasks: BackgroundTasks):
     print(f"[*] Drafted block for {attacker_ip} (action {action['id']}) — awaiting approval.")
     return {"status": "success",
             "message": f"IP {attacker_ip} drafted for human approval (action {action['id']})."}
+
+
+@app.post("/webhook/dispatch")
+async def dispatch_block(request: Request):
+    """Authenticated IMMEDIATE dispatch for an already-approved block (#109).
+
+    The AI agent can't run isolate.sh from its slim container (no ssh/sudo), so it
+    routes containment here. The agent performs the CDP §12.3 human-of-record gate
+    upstream (autonomous opt-in OR a human /approve), so — unlike /webhook/alert —
+    this endpoint does NOT re-queue for approval; it dispatches now.
+
+    Still defence-in-depth: §12.4 exclusion and WS0.3 tenant scoping are re-checked
+    here, and the dispatch is recorded to the approval queue as an audit line.
+    Authentication is the same HMAC scheme; only a holder of HIVE_MIND_SECRET (the
+    agent) can reach it.
+    """
+    payload = await _verify_and_parse(request)
+
+    attacker_ip = payload.get("attacker_ip")
+    if not attacker_ip:
+        raise HTTPException(status_code=400, detail="Payload missing attacker_ip")
+    approver = str(payload.get("approver", "soc-ai-agent"))
+
+    # §12.4: refuse protected infrastructure, signed or not.
+    if is_excluded_ip(attacker_ip):
+        print(f"[!] REFUSED dispatch: {attacker_ip} is on the exclusion list.")
+        return {"status": "refused", "executed": False,
+                "message": f"IP {attacker_ip} is on the exclusion list — no block dispatched."}
+
+    # WS0.3: only this tenant's routers are ever touched; unknown tenant => no-op.
+    tenant = safe_tenant(payload.get("tenant_id"))
+    routers = inv.get_routers_for_tenant(tenant)
+    if not routers:
+        print(f"[!] No routers for tenant '{tenant}' — refusing to dispatch {attacker_ip}.")
+        return {"status": "no_routers", "executed": False,
+                "message": f"No routers configured for tenant '{tenant}' — nothing to block."}
+
+    count = await dispatch_block_to_all(routers, attacker_ip)
+    _append_action({
+        "id": uuid.uuid4().hex[:12], "ts": time.time(), "status": "executed",
+        "approver": approver, "tenant": tenant, "attacker_ip": attacker_ip,
+        "result": f"{count}/{len(routers)} routers",
+    })
+    print(f"[*] Dispatched block for {attacker_ip} on tenant '{tenant}' "
+          f"({count}/{len(routers)} routers) — approver={approver}.")
+    return {"status": "executed", "executed": True, "tenant": tenant,
+            "router_count": len(routers), "success_count": count,
+            "message": f"IP {attacker_ip} blocked on {count}/{len(routers)} "
+                       f"router(s) for tenant '{tenant}'."}
 
 
 @app.get("/pending")

--- a/scripts/hive-mind-broker/dispatcher.py
+++ b/scripts/hive-mind-broker/dispatcher.py
@@ -6,10 +6,23 @@ import os
 from pathlib import Path
 
 # CDP §12.4: permanent exclusion list — IPs the broker may never block.
-EXCLUSION_LIST = os.environ.get(
-    "EXCLUSION_LIST",
-    str(Path(__file__).resolve().parents[2] / "governance" / "exclusion_list.txt"),
-)
+def _default_exclusion_path() -> str:
+    """Locate governance/exclusion_list.txt by walking up from this file.
+
+    A fixed parents[N] breaks across layouts: in the repo this file lives at
+    scripts/hive-mind-broker/, but in the container it is /app/dispatcher.py (only
+    two parents) — parents[2] raised IndexError at import and crash-looped the
+    broker. Walking the parents finds it in both, with a container-mount fallback.
+    """
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "governance" / "exclusion_list.txt"
+        if candidate.is_file():
+            return str(candidate)
+    return "/governance/exclusion_list.txt"
+
+
+EXCLUSION_LIST = os.environ.get("EXCLUSION_LIST") or _default_exclusion_path()
 
 
 def load_excluded_ips() -> set:

--- a/scripts/hive-mind-broker/test_app.py
+++ b/scripts/hive-mind-broker/test_app.py
@@ -94,6 +94,58 @@ def test_excluded_ip_refused(_no_real_ssh):
     assert client.get("/pending").json()["count"] == 0
 
 
+def _post_dispatch(payload, sign=True, tamper=False):
+    body = json.dumps(payload).encode("utf-8")
+    headers = {}
+    if sign:
+        sig = _sign(body)
+        if tamper:
+            sig = sig[:-1] + ("0" if sig[-1] != "0" else "1")
+        headers["x-elastic-signature"] = sig
+    return client.post("/webhook/dispatch", data=body, headers=headers)
+
+
+# --- #109: /webhook/dispatch — immediate, pre-approved block -------------------
+def test_dispatch_missing_signature():
+    assert client.post("/webhook/dispatch", json={"attacker_ip": "9.9.9.9"}).status_code == 401
+
+
+def test_dispatch_invalid_signature():
+    assert _post_dispatch({"attacker_ip": "9.9.9.9"}, tamper=True).status_code == 401
+
+
+def test_dispatch_missing_ip():
+    assert _post_dispatch({"tenant_id": TENANT}).status_code == 400
+
+
+def test_dispatch_executes_to_tenant_routers(_no_real_ssh):
+    r = _post_dispatch({"attacker_ip": "9.9.9.9", "tenant_id": TENANT})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["executed"] is True and body["status"] == "executed"
+    _no_real_ssh.assert_awaited_once()                 # actually dispatched, no draft
+    routers_arg = _no_real_ssh.await_args[0][0]
+    assert routers_arg and all(rt.get("tenant") == TENANT for rt in routers_arg)
+    # Recorded as executed (not left pending).
+    assert client.get("/pending").json()["count"] == 0
+
+
+def test_dispatch_excluded_ip_refused(_no_real_ssh):
+    r = _post_dispatch({"attacker_ip": EXCLUDED_IP, "tenant_id": TENANT})
+    assert r.status_code == 200
+    assert r.json()["executed"] is False
+    assert "exclusion list" in r.json()["message"].lower()
+    _no_real_ssh.assert_not_awaited()
+
+
+def test_dispatch_unknown_tenant_is_no_op(_no_real_ssh):
+    r = _post_dispatch({"attacker_ip": "9.9.9.9", "tenant_id": "ghost-tenant"})
+    assert r.status_code == 200
+    assert r.json()["executed"] is False
+    assert "no routers" in r.json()["message"].lower()
+    _no_real_ssh.assert_not_awaited()
+
+
 def test_approve_dispatches_only_to_tenant_routers(_no_real_ssh):
     draft = _post({"attacker_ip": "9.9.9.9", "tenant_id": TENANT}).json()
     # pull the drafted id

--- a/scripts/setup/.env.example
+++ b/scripts/setup/.env.example
@@ -42,18 +42,26 @@ LLM_MODEL=gpt-4
 # Discord webhook for SOC channel notifications (fallback for 'unassigned').
 DISCORD_WEBHOOK_URL=
 
-# --- Per-tenant response & notifications (WS0.3) ---
+# --- Per-tenant notifications (WS0.3) ---
 # One set per tenant slug, suffixed UPPER_SNAKE (home-smith -> HOME_SMITH).
-# When a tenant's containment executes (autonomous OR human-approved), the agent
-# resolves that tenant's router from ROUTER_HOST_*; if unset, it refuses rather
-# than touching a default or another tenant's router. Notify vars fall back to
-# the global topic/webhook above.
-# ROUTER_HOST_HOME_SMITH=192.168.1.1
-# ROUTER_USER_HOME_SMITH=root
-# ROUTER_KEY_HOME_SMITH=/keys/id_ed25519_home_smith
+# Notify vars fall back to the global topic/webhook above.
+# (#109: per-tenant ROUTER_HOST_* on the agent is GONE — the hive-mind-broker now
+#  owns router resolution via its inventory.yaml; see below.)
 # NTFY_TOPIC_HOME_SMITH=subsoc-home-smith
 # DISCORD_WEBHOOK_URL_HOME_SMITH=https://discord.com/api/webhooks/...
 
-# --- Hive-Mind broker (router block dispatcher; runs separately) ---
+# --- Hive-Mind broker (router block dispatcher; #109) ---
+# The slim AI agent has no ssh/sudo, so it routes containment to the broker over an
+# authenticated webhook. The broker owns the per-tenant router inventory
+# (scripts/hive-mind-broker/inventory.yaml — copy from inventory.example.yaml) and
+# applies the nftables block.
 # Shared secret for HMAC-signing broker webhook requests. openssl rand -hex 32
+# Must be IDENTICAL on the agent and the broker (both read HIVE_MIND_SECRET).
 HIVE_MIND_SECRET=changeme_broker_secret
+# Broker URL the agent dispatches to (default: the compose service name).
+# BROKER_URL=http://hive_mind_broker:8000
+# Host dir holding the broker's router SSH key(s), mounted read-only at /root/.ssh.
+# HIVE_MIND_SSH_DIR=~/.ssh
+# Legacy auto-block on the broker's /webhook/alert (Kibana path). Keep false — the
+# agent is the approval authority; /webhook/dispatch is the agent's execute path.
+# AUTONOMOUS_BLOCK_ENABLED=false

--- a/scripts/setup/ai_agent/agent_app.py
+++ b/scripts/setup/ai_agent/agent_app.py
@@ -8,7 +8,6 @@ import hashlib
 import ipaddress
 import threading
 import requests
-import subprocess
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -47,10 +46,23 @@ ES_VERIFY          = ES_CA if (ES_CA and Path(ES_CA).is_file()) else False
 AUTONOMOUS_ISOLATION = os.environ.get("AUTONOMOUS_ISOLATION", "false").lower() == "true"
 
 # CDP §12.4: permanent exclusion list — assets the SOAR may never isolate.
-EXCLUSION_LIST = os.environ.get(
-    "EXCLUSION_LIST",
-    str((Path(__file__).resolve().parents[3] / "governance" / "exclusion_list.txt")),
-)
+def _default_exclusion_path() -> str:
+    """Locate governance/exclusion_list.txt by walking up from this file.
+
+    A fixed parents[N] breaks across layouts: in the repo this file lives at
+    scripts/setup/ai_agent/, but in the container it is /app/agent_app.py (only two
+    parents) — parents[3] raised IndexError at import and crash-looped the agent.
+    Walking the parents finds it in both, and falls back to the container mount path.
+    """
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "governance" / "exclusion_list.txt"
+        if candidate.is_file():
+            return str(candidate)
+    return "/governance/exclusion_list.txt"
+
+
+EXCLUSION_LIST = os.environ.get("EXCLUSION_LIST") or _default_exclusion_path()
 
 # Human-approval queue (pending isolation actions awaiting a human-of-record).
 APPROVAL_QUEUE = os.environ.get(
@@ -59,9 +71,14 @@ APPROVAL_QUEUE = os.environ.get(
 )
 _queue_lock = threading.Lock()
 
-# Absolute path to isolate.sh — resolved at import time so subprocess.run works
-# regardless of Flask's current working directory.
-ISOLATE_SCRIPT = str((Path(__file__).resolve().parent.parent / "isolate.sh"))
+# Hive-Mind broker — the router-block dispatcher (#109). The agent runs in a slim
+# container with no ssh/sudo, so it can't run isolate.sh against a router itself.
+# Instead it routes containment to the broker over an authenticated (HMAC) webhook;
+# the broker owns the per-tenant router inventory and executes the block.
+BROKER_URL    = os.environ.get("BROKER_URL", "http://hive_mind_broker:8000")
+# Shared secret for signing broker requests — MUST equal the broker's
+# HIVE_MIND_SECRET. If unset, _execute_isolation fails closed (never dispatches).
+HIVE_MIND_SECRET = os.environ.get("HIVE_MIND_SECRET", "").encode("utf-8")
 
 # --- Webhook authentication (WS0.2) ------------------------------------------
 # /alert triggers device isolation, so it MUST be authenticated. Callers sign the
@@ -72,7 +89,7 @@ ISOLATE_SCRIPT = str((Path(__file__).resolve().parent.parent / "isolate.sh"))
 HMAC_HEADER = "x-elastic-signature"
 HMAC_SECRET = os.environ.get("SOC_AGENT_HMAC_SECRET", "").encode("utf-8")
 
-# Validation patterns for anything that reaches the isolate.sh subprocess.
+# Validation patterns for anything that reaches the broker / response path.
 _MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
 
 
@@ -114,29 +131,46 @@ def _tenant_env_suffix(tenant: str) -> str:
     return tenant.upper().replace("-", "_")
 
 
-def resolve_router(tenant: str):
-    """Resolve a tenant's OpenWrt router SSH target from env (WS0.3).
+def dispatch_block_via_broker(attacker_ip: str, tenant: str, source_mac: str = ""):
+    """Route an approved containment to the hive-mind-broker (#109).
 
-    A named tenant MUST have ROUTER_HOST_<TENANT>; if absent, returns None so the
-    caller refuses to isolate (never on a default or another tenant's router). The
-    'unassigned' tenant falls back to the global OPENWRT_* env (an empty host lets
-    isolate.sh apply its built-in default). Returns {host,user,key} or None.
+    The agent's slim container has no ssh/sudo, so it cannot run isolate.sh against
+    a router. The broker can: it owns the per-tenant router inventory and applies an
+    nftables drop. We sign the request with HIVE_MIND_SECRET (same HMAC scheme as
+    /alert) and POST it to the broker's authenticated /webhook/dispatch — which
+    executes immediately because the agent already performed the §12.3 approval gate.
+
+    Fails CLOSED: with no secret configured we never dispatch. Returns (ok, detail).
     """
-    if tenant == "unassigned":
-        return {
-            "host": os.environ.get("OPENWRT_HOST", ""),
-            "user": os.environ.get("OPENWRT_USER", ""),
-            "key":  os.environ.get("SSH_KEY", ""),
-        }
-    suffix = _tenant_env_suffix(tenant)
-    host = os.environ.get(f"ROUTER_HOST_{suffix}", "")
-    if not host:
-        return None
-    return {
-        "host": host,
-        "user": os.environ.get(f"ROUTER_USER_{suffix}", "root"),
-        "key":  os.environ.get(f"ROUTER_KEY_{suffix}", ""),
-    }
+    if not HIVE_MIND_SECRET:
+        return False, "HIVE_MIND_SECRET unset — refusing to dispatch (broker unreachable/unsigned)"
+    body = json.dumps({
+        "attacker_ip": attacker_ip,
+        "tenant_id":   tenant,
+        "source_mac":  source_mac,
+        "approver":    "soc-ai-agent",
+    }).encode("utf-8")
+    sig = "sha256=" + hmac.new(HIVE_MIND_SECRET, body, hashlib.sha256).hexdigest()
+    try:
+        resp = requests.post(
+            f"{BROKER_URL}/webhook/dispatch",
+            data=body,
+            headers={"Content-Type": "application/json", HMAC_HEADER: sig},
+            timeout=15,
+        )
+    except Exception as exc:  # noqa: BLE001 - never let response handling crash
+        app.logger.error("broker dispatch failed: %s", exc)
+        return False, f"broker unreachable: {exc}"
+
+    detail = resp.text[:300]
+    try:
+        data = resp.json()
+        detail = data.get("message", detail)
+    except Exception:
+        data = {}
+    # The block actually happened only if the broker reached >=1 router.
+    ok = resp.status_code == 200 and bool(data.get("executed")) and data.get("success_count", 0) >= 1
+    return ok, detail
 
 
 def ntfy_topic_for(tenant: str) -> str:
@@ -361,36 +395,25 @@ def _read_queue():
 # 3c. ISOLATION EXECUTION — only ever reached after a guard (flag or approval)
 # =============================================================================
 def _execute_isolation(mac: str, ip: str = "", tenant: str = "unassigned"):
-    """Run isolate.sh for a format-validated MAC. Returns (ok: bool, detail: str).
+    """Quarantine an attacker by routing the block through the hive-mind-broker (#109).
 
-    isolate.sh is MAC-only, so without a valid MAC we never invoke the subprocess.
-    The exclusion list is re-checked here (defence in depth, CDP §12.4) so neither
-    the autonomous path nor a human approval can ever quarantine protected infra.
+    The agent runs in a slim container with no ssh/sudo, so it can't isolate a router
+    directly; the broker does it. The broker blocks by IP (nftables drop), so a usable
+    source IP is required — `mac` is carried along only for the audit trail.
 
-    WS0.3: the tenant's router is resolved and passed to isolate.sh as positional
-    args (they survive `sudo`, which strips env). A NAMED tenant with no configured
-    router is refused — we never isolate on a default or another tenant's router.
+    The §12.4 exclusion list is re-checked here (defence in depth) so neither the
+    autonomous path nor a human approval can ever quarantine protected infra. WS0.3
+    tenant scoping (which routers get the block) is enforced by the broker from its
+    own per-tenant inventory; a NAMED tenant with no router yields a clean refusal
+    rather than touching another tenant's router.
     """
-    if not is_valid_mac(mac):
-        return False, f"no valid MAC to isolate (got {mac!r}); manual action required"
     excluded = is_excluded(mac=mac, ip=ip)
     if excluded:
         return False, f"{excluded} is on the permanent exclusion list — refused"
-    router = resolve_router(tenant)
-    if router is None:
-        return False, (f"no router configured for tenant '{tenant}' "
-                       f"(set ROUTER_HOST_{_tenant_env_suffix(tenant)}); manual isolation required")
-    try:
-        result = subprocess.run(
-            ["sudo", ISOLATE_SCRIPT, mac,
-             router.get("host", ""), router.get("user", ""), router.get("key", "")],
-            check=False,
-        )
-    except Exception as exc:  # noqa: BLE001 - never let response handling crash
-        app.logger.error("isolate.sh invocation failed: %s", exc)
-        return False, f"isolate.sh error: {exc}"
-    ok = result.returncode == 0
-    return ok, ("isolated" if ok else f"isolate.sh exited {result.returncode}")
+    if not is_valid_ip(ip):
+        return False, (f"no valid IP to block (got {ip!r}); the broker blocks by IP — "
+                       f"manual action required")
+    return dispatch_block_via_broker(ip, tenant, source_mac=mac)
 
 
 # =============================================================================
@@ -447,8 +470,8 @@ def handle_kibana_webhook():
     target_mac  = str(data.get("source_mac", "")).strip()
     raw_details = data.get("raw_log",    "No log data provided")
 
-    # Validate anything that could reach the OS / isolate.sh. Invalid values are
-    # blanked (never passed through) so the subprocess only ever sees a clean MAC.
+    # Validate anything that feeds the response path. Invalid values are blanked
+    # (never passed through) so the broker only ever sees a clean MAC/IP.
     valid_mac = target_mac if is_valid_mac(target_mac) else ""
     safe_ip   = target_ip if is_valid_ip(target_ip) else "unknown"
     tenant    = safe_tenant(data.get("tenant_id"))  # WS0.3: scopes response + notify

--- a/scripts/setup/docker-compose.yml
+++ b/scripts/setup/docker-compose.yml
@@ -181,6 +181,8 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
+      hive-mind-broker:
+        condition: service_started
     environment:
       # SOAR feedback loop writes to ES over HTTPS, authenticated. Reuses the
       # least-privilege logstash_internal writer (WS3.2 will split per-component
@@ -192,6 +194,11 @@ services:
       # Shared secret for HMAC-signed /alert requests (WS0.2). Required — the
       # endpoint fails closed (503/401) if unset or the signature is wrong.
       - SOC_AGENT_HMAC_SECRET=${SOC_AGENT_HMAC_SECRET}
+      # #109: route quarantine through the broker (the slim agent has no ssh/sudo).
+      # The agent signs /webhook/dispatch with HIVE_MIND_SECRET (must equal the
+      # broker's). If unset, _execute_isolation fails closed (never dispatches).
+      - BROKER_URL=${BROKER_URL:-http://hive_mind_broker:8000}
+      - HIVE_MIND_SECRET=${HIVE_MIND_SECRET:-}
       # Notification / LLM secrets (WS0.4) — sourced from .env, no code defaults.
       # Unset values degrade gracefully (push/triage skipped).
       - NTFY_TOPIC=${NTFY_TOPIC:-}
@@ -199,12 +206,48 @@ services:
       - LLM_API_URL=${LLM_API_URL:-https://api.openai.com/v1/chat/completions}
       - LLM_MODEL=${LLM_MODEL:-gpt-4}
       - DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL:-}
+      # §12.4 exclusion list, mounted read-only below (without this the agent could
+      # not enforce the never-isolate list inside the container).
+      - EXCLUSION_LIST=/governance/exclusion_list.txt
     ports:
       # Bound to localhost only — the agent is NOT reachable from the LAN. /alert
       # additionally requires a valid HMAC signature.
       - "127.0.0.1:5000:5000"
     volumes:
       - certs:/certs:ro
+      - ../../governance:/governance:ro
+    networks:
+      - soc-mesh-net
+    restart: unless-stopped
+
+  # --- Hive-Mind broker: authenticated router-block dispatcher (#109) ----------
+  # The slim AI agent can't ssh/sudo a router, so it routes containment here over
+  # an HMAC webhook. The broker owns the per-tenant router inventory and applies
+  # the nftables block. Not LAN-exposed; only the agent (holding HIVE_MIND_SECRET)
+  # can reach /webhook/dispatch.
+  hive-mind-broker:
+    build:
+      context: ../hive-mind-broker
+    container_name: hive_mind_broker
+    environment:
+      # Must equal the agent's HIVE_MIND_SECRET. Broker fails closed (503) if unset.
+      - HIVE_MIND_SECRET=${HIVE_MIND_SECRET:-}
+      # §12.4 exclusion list, mounted from the repo's governance dir (below).
+      - EXCLUSION_LIST=/governance/exclusion_list.txt
+      # Legacy auto-block on /webhook/alert stays OFF; the agent owns approval.
+      - AUTONOMOUS_BLOCK_ENABLED=${AUTONOMOUS_BLOCK_ENABLED:-false}
+    volumes:
+      # Host-specific secrets — mounted read-only, never baked into the image.
+      # inventory.yaml is gitignored; copy it from inventory.example.yaml first.
+      - ../hive-mind-broker/inventory.yaml:/app/inventory.yaml:ro
+      - ../../governance:/governance:ro
+      # SSH key(s) the broker uses to reach routers (path per inventory.yaml).
+      # Compose does NOT expand `~`, so default to an absolute ${HOME}/.ssh; set
+      # HIVE_MIND_SSH_DIR to an absolute path to override (required on Windows hosts).
+      - ${HIVE_MIND_SSH_DIR:-${HOME}/.ssh}:/root/.ssh:ro
+    ports:
+      # Localhost only — for debugging/verification; the agent uses the service name.
+      - "127.0.0.1:8000:8000"
     networks:
       - soc-mesh-net
     restart: unless-stopped

--- a/scripts/setup/isolate.sh
+++ b/scripts/setup/isolate.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 # =============================================================================
-# isolate.sh — Suburban-SOC SOAR Quarantine Script
+# isolate.sh — Suburban-SOC MAC-based device isolation (STANDALONE / MANUAL TOOL)
 # Phase C: OpenWrt uci MAC-based device isolation
+#
+# NOTE (#109): this script is NO LONGER on the automated response path. The AI
+# agent runs in a slim container with no ssh/sudo, so it now routes containment to
+# the hive-mind-broker (scripts/hive-mind-broker/), which blocks by IP via nftables.
+# This script is kept as a STANDALONE operator tool for MAC-level quarantine — a
+# capability the broker's IP-block does not provide. Run it by hand on a host that
+# has SSH access to the router; nothing invokes it automatically.
 #
 # Usage:
 #   ./isolate.sh <MAC_ADDRESS> [ROUTER_HOST] [ROUTER_USER] [SSH_KEY]

--- a/tests/ai_agent/test_alert_auth.py
+++ b/tests/ai_agent/test_alert_auth.py
@@ -10,9 +10,11 @@ Covers WS0.2 (HMAC auth + MAC validation) and the CDP §12.3/§12.4 response mod
     human-in-the-loop posture for a destructive, irreversible action);
   * autonomous execution happens ONLY when an operator opts in
     (AUTONOMOUS_ISOLATION=true);
-  * a malicious/invalid MAC never reaches the isolate.sh subprocess;
+  * a malicious/invalid MAC never reaches the response path;
   * §12.4 protected assets are never isolated and never even drafted;
-  * a drafted action can be listed (/pending) and executed by a human (/approve).
+  * a drafted action can be listed (/pending) and executed by a human (/approve);
+  * execution routes containment to the hive-mind-broker over HMAC (#109) — the
+    slim agent never shells out to isolate.sh.
 
 Run:  python tests/ai_agent/test_alert_auth.py     (or: pytest tests/ai_agent)
 """
@@ -64,10 +66,12 @@ class AlertResponseTests(unittest.TestCase):
         self._qpatch = mock.patch.object(agent_app, "APPROVAL_QUEUE", self._qfile.name)
         self._qpatch.start()
 
-        # Neutralize outbound side-effects. subprocess.run returns success (rc=0)
-        # so the autonomous/approve paths see isolate.sh "succeed".
-        self.mock_run = mock.patch.object(agent_app.subprocess, "run").start()
-        self.mock_run.return_value.returncode = 0
+        # Neutralize outbound side-effects. The broker dispatch is mocked to report
+        # a successful block, so the autonomous/approve paths see containment succeed
+        # without any real HTTP/SSH. Default return: (ok, detail).
+        self.mock_dispatch = mock.patch.object(
+            agent_app, "dispatch_block_via_broker",
+            return_value=(True, "IP blocked on 1/1 router(s)")).start()
         for fn in ("analyze_alert_with_ai", "send_soc_alert",
                    "send_discord_alert", "log_soar_action"):
             mock.patch.object(agent_app, fn, return_value="stub").start()
@@ -88,12 +92,12 @@ class AlertResponseTests(unittest.TestCase):
     def test_missing_signature_rejected(self):
         r = self._post({"severity": "critical", "source_mac": GOOD_MAC}, sign=False)
         self.assertEqual(r.status_code, 401)
-        self.mock_run.assert_not_called()
+        self.mock_dispatch.assert_not_called()
 
     def test_invalid_signature_rejected(self):
         r = self._post({"severity": "critical", "source_mac": GOOD_MAC}, tamper=True)
         self.assertEqual(r.status_code, 401)
-        self.mock_run.assert_not_called()
+        self.mock_dispatch.assert_not_called()
 
     # --- §12.3 draft-by-default (autonomous OFF) -----------------------------
     def test_critical_valid_mac_drafts_not_executes_by_default(self):
@@ -101,33 +105,34 @@ class AlertResponseTests(unittest.TestCase):
                         "source_mac": GOOD_MAC})
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.get_json()["status"], "drafted")
-        self.mock_run.assert_not_called()          # NEVER auto-executes by default
+        self.mock_dispatch.assert_not_called()     # NEVER auto-dispatches by default
         # The drafted action is queued for approval.
         pending = self.client.get("/pending").get_json()["pending"]
         self.assertTrue(any(a["target_mac"] == GOOD_MAC for a in pending))
 
-    def test_malicious_mac_never_reaches_subprocess(self):
+    def test_malicious_mac_never_dispatches(self):
         r = self._post({"severity": "critical", "source_ip": "1.2.3.4",
                         "source_mac": "x; rm -rf / #"})
         self.assertEqual(r.status_code, 200)
-        self.mock_run.assert_not_called()
+        self.mock_dispatch.assert_not_called()
 
     # --- §12.3 autonomous path (opt-in) --------------------------------------
-    def test_autonomous_flag_executes_isolation(self):
+    def test_autonomous_flag_dispatches_to_broker(self):
         with mock.patch.object(agent_app, "AUTONOMOUS_ISOLATION", True):
             r = self._post({"severity": "critical", "source_ip": "1.2.3.4",
                             "source_mac": GOOD_MAC})
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.get_json()["status"], "auto_isolated")
-        self.mock_run.assert_called_once()
-        self.assertIn(GOOD_MAC, self.mock_run.call_args[0][0])
+        self.mock_dispatch.assert_called_once()
+        # The broker blocks by IP — the attacker IP is the first positional arg.
+        self.assertEqual(self.mock_dispatch.call_args[0][0], "1.2.3.4")
 
     def test_autonomous_flag_still_blocks_invalid_mac(self):
         with mock.patch.object(agent_app, "AUTONOMOUS_ISOLATION", True):
             r = self._post({"severity": "critical", "source_ip": "1.2.3.4",
                             "source_mac": "not-a-mac"})
         self.assertEqual(r.status_code, 200)
-        self.mock_run.assert_not_called()          # no valid MAC -> never executes
+        self.mock_dispatch.assert_not_called()     # no valid MAC -> never dispatches
 
     # --- §12.4 exclusion list ------------------------------------------------
     def test_excluded_asset_never_acted_on(self):
@@ -136,47 +141,44 @@ class AlertResponseTests(unittest.TestCase):
                             "source_mac": GOOD_MAC})
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.get_json()["status"], "no_action_protected_asset")
-        self.mock_run.assert_not_called()          # protected asset, even with flag on
+        self.mock_dispatch.assert_not_called()     # protected asset, even with flag on
         # And nothing was drafted for it either.
         pending = self.client.get("/pending").get_json()["pending"]
         self.assertFalse(any(a["target_ip"] == EXCLUDED_IP for a in pending))
 
     # --- approval flow: human executes a drafted action ----------------------
-    def test_pending_then_approve_executes(self):
+    def test_pending_then_approve_dispatches(self):
         draft = self._post({"severity": "critical", "source_ip": "1.2.3.4",
                             "source_mac": GOOD_MAC}).get_json()
         action_id = draft["action_id"]
-        self.mock_run.assert_not_called()          # still not executed at draft time
+        self.mock_dispatch.assert_not_called()     # still not executed at draft time
 
         r = self._post({"id": action_id, "approver": "analyst1"}, path="/approve")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.get_json()["status"], "executed")
-        self.mock_run.assert_called_once()         # the human approval executes it
-        self.assertIn(GOOD_MAC, self.mock_run.call_args[0][0])
+        self.mock_dispatch.assert_called_once()    # the human approval dispatches it
+        self.assertEqual(self.mock_dispatch.call_args[0][0], "1.2.3.4")
 
-    # --- WS0.3 tenant-scoped isolation routing -------------------------------
-    def test_named_tenant_router_used_on_autonomous(self):
-        # The tenant's router is resolved and passed to isolate.sh.
-        with mock.patch.object(agent_app, "AUTONOMOUS_ISOLATION", True), \
-             mock.patch.dict(os.environ, {"ROUTER_HOST_HOME_SMITH": "192.168.9.1"}):
+    # --- WS0.3 tenant-scoped routing (the broker owns router resolution) ------
+    def test_named_tenant_passed_to_broker_on_autonomous(self):
+        # The agent forwards the tenant; the broker maps it to that tenant's routers.
+        with mock.patch.object(agent_app, "AUTONOMOUS_ISOLATION", True):
             r = self._post({"severity": "critical", "source_ip": "1.2.3.4",
                             "source_mac": GOOD_MAC, "tenant_id": "home-smith"})
         self.assertEqual(r.get_json()["status"], "auto_isolated")
-        self.mock_run.assert_called_once()
-        passed = self.mock_run.call_args[0][0]
-        self.assertIn(GOOD_MAC, passed)
-        self.assertIn("192.168.9.1", passed)       # tenant's router, not a default
+        self.mock_dispatch.assert_called_once()
+        # dispatch_block_via_broker(attacker_ip, tenant, source_mac=...)
+        self.assertEqual(self.mock_dispatch.call_args[0][1], "home-smith")
 
-    def test_named_tenant_without_router_refuses(self):
-        # A named tenant with no ROUTER_HOST_* must never isolate on a default
-        # or another tenant's router — even with autonomy enabled.
-        with mock.patch.object(agent_app, "AUTONOMOUS_ISOLATION", True), \
-             mock.patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("ROUTER_HOST_NEIGHBOR_JONES", None)
+    def test_broker_refusal_surfaces_as_isolation_failed(self):
+        # When the broker reports no routers for the tenant (it owns inventory),
+        # the agent reports isolation_failed — never a silent success.
+        self.mock_dispatch.return_value = (False, "no routers for tenant 'neighbor-jones'")
+        with mock.patch.object(agent_app, "AUTONOMOUS_ISOLATION", True):
             r = self._post({"severity": "critical", "source_ip": "1.2.3.4",
                             "source_mac": GOOD_MAC, "tenant_id": "neighbor-jones"})
         self.assertEqual(r.get_json()["status"], "isolation_failed")
-        self.mock_run.assert_not_called()
+        self.mock_dispatch.assert_called_once()
 
 
 class TenantResolverTests(unittest.TestCase):
@@ -187,16 +189,12 @@ class TenantResolverTests(unittest.TestCase):
         self.assertEqual(agent_app.safe_tenant("bad slug!"), "unassigned")
         self.assertEqual(agent_app.safe_tenant(None), "unassigned")
 
-    def test_resolve_router_named_requires_host(self):
-        with mock.patch.dict(os.environ, {"ROUTER_HOST_HOME_SMITH": "10.0.0.9"}):
-            self.assertEqual(agent_app.resolve_router("home-smith")["host"], "10.0.0.9")
-        with mock.patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("ROUTER_HOST_NOBODY", None)
-            self.assertIsNone(agent_app.resolve_router("nobody"))
-
-    def test_resolve_router_unassigned_uses_global(self):
-        with mock.patch.dict(os.environ, {"OPENWRT_HOST": "192.168.1.1"}):
-            self.assertEqual(agent_app.resolve_router("unassigned")["host"], "192.168.1.1")
+    def test_dispatch_fails_closed_without_secret(self):
+        # #109: no HIVE_MIND_SECRET => the agent never dispatches (fails closed).
+        with mock.patch.object(agent_app, "HIVE_MIND_SECRET", b""):
+            ok, detail = agent_app.dispatch_block_via_broker("1.2.3.4", "home-smith")
+        self.assertFalse(ok)
+        self.assertIn("HIVE_MIND_SECRET", detail)
 
     def test_notify_resolution_prefers_tenant_then_global(self):
         with mock.patch.dict(os.environ, {"NTFY_TOPIC_HOME_SMITH": "tenant-topic"}):

--- a/tests/ai_agent/verify_alert_live.sh
+++ b/tests/ai_agent/verify_alert_live.sh
@@ -10,8 +10,10 @@
 #      so it exercises auth + the signing format WITHOUT triggering a real
 #      router SSH/quarantine.
 #
-# Optional (RUN_QUARANTINE=1): a signed critical alert WITH a valid MAC, which
-#   WILL invoke `sudo isolate.sh` and attempt to SSH the router. Off by default.
+# Optional (RUN_QUARANTINE=1): a signed critical alert WITH a valid MAC. By
+#   default (autonomous OFF) the agent DRAFTS the action for approval (200) — no
+#   router is touched. With AUTONOMOUS_ISOLATION=true the agent dispatches the block
+#   to the hive-mind-broker over HMAC (#109); it never shells out to isolate.sh.
 #
 # Usage:
 #   cd ~/projects/Suburban-SOC/scripts/setup      # for .env
@@ -67,9 +69,12 @@ check "tampered signature rejected" 401 "$BODY" "sha256=deadbeef"
 LS_BODY='{"severity":"critical","source_ip":"203.0.113.5","source_mac":""}'
 check "valid signature accepted (Logstash scheme)" 200 "$LS_BODY" "sha256=$(sign "$LS_BODY")"
 
-# 4. OPTIONAL: signed + valid MAC -> 200 AND triggers real isolate.sh (SSH).
+# 4. OPTIONAL: signed + valid MAC -> 200. By default this is DRAFTED for approval
+#    (no router action). With AUTONOMOUS_ISOLATION=true the agent dispatches the
+#    block to the hive-mind-broker over HMAC (#109) — never isolate.sh.
 if [[ "${RUN_QUARANTINE:-0}" == "1" ]]; then
-  echo "[!] RUN_QUARANTINE=1 — this will invoke sudo isolate.sh and SSH the router."
+  echo "[!] RUN_QUARANTINE=1 — critical+MAC alert. Drafts by default; with"
+  echo "    AUTONOMOUS_ISOLATION=true it dispatches to the hive-mind-broker."
   Q_BODY='{"severity":"critical","source_ip":"203.0.113.5","source_mac":"AA:BB:CC:DD:EE:FF"}'
   check "valid signature + valid MAC accepted" 200 "$Q_BODY" "sha256=$(sign "$Q_BODY")"
 fi


### PR DESCRIPTION
Closes #109 (Milestone 7 — the last open M7 issue).

## Problem
The AI-agent container (`python:3.11-slim`) has no `ssh`/`sudo`, so its direct `subprocess.run(["sudo", isolate.sh, ...])` could never actually quarantine a host — and, as found here, **the agent container was crash-looping at import and never served `/alert` at all**. This wires containment through the existing `hive-mind-broker`, which owns the per-tenant router inventory and can reach routers.

## Design (chosen: dedicated dispatch endpoint)
- **Broker** — new HMAC-authed `POST /webhook/dispatch` that dispatches a block **immediately** (no draft queue), because the agent already performs the CDP §12.3 human-of-record gate upstream (autonomous opt-in or human `/approve`). It still re-checks §12.4 exclusion + WS0.3 tenant scoping and records an audit line. The draft-by-default `/webhook/alert` (Kibana path) is untouched. HMAC verification refactored into `_verify_and_parse`.
- **Agent** — `_execute_isolation` no longer shells out. It signs the request with `HIVE_MIND_SECRET` and POSTs the broker (`dispatch_block_via_broker`); the broker blocks by **IP**. `resolve_router`/`ROUTER_HOST_*` removed — the broker owns router resolution now.
- **Deploy** — new broker **Dockerfile** + **`hive-mind-broker` compose service** (the broker existed only as code, never deployed); agent gets `BROKER_URL` + `HIVE_MIND_SECRET`.

## Pre-existing bugs fixed (in scope — the container path was dead)
- **Crash-loop:** the §12.4 exclusion-list default used a fixed `parents[N]` that overflows at `/app` (`IndexError` at import) — eagerly evaluated even when `EXCLUSION_LIST` env is set. Both `agent_app.py` (`parents[3]`) and `dispatcher.py` (`parents[2]`) were affected. Replaced with a parents-walk that works in the repo **and** the container.
- **§12.4 unenforceable in-container:** the agent never mounted `governance/`. Added the read-only mount + `EXCLUSION_LIST` env.
- **Compose `~` bug:** Docker Compose does not expand `~` in bind mounts → changed the broker SSH-key mount to `${HOME}/.ssh` (override with `HIVE_MIND_SSH_DIR`).

## Validation
Unit: **agent 13/13, broker 14/14** (added `/webhook/dispatch` auth / exclusion / tenant cases).

Live (running stack), `/webhook/dispatch`:
| Case | Result |
|---|---|
| unsigned / tampered HMAC | **401** |
| signed, §12.4 excluded IP | refused, `executed:false` |
| signed, unknown tenant | `no_routers`, `executed:false` (no broadcast) |
| signed, valid tenant `home-smith` | routed to that tenant's router; SSH to the unreachable test router → `0/1` (no false success) |
| agent container → broker (real code path) | signs + reaches broker over the docker net; defense-in-depth refuses excluded/invalid IP locally |

Also confirmed both containers now start clean (broker: "Application startup complete"; agent: "Serving Flask app"). The only unprovable step is the final nftables-over-SSH to a real OpenWrt router (none in this env) — covered by the broker's unit mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)