### PR TITLE
feat(soar): WS2.3 alert triage & case tracking via Kibana Cases (#99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ M1–M6 are the completed MVP; M7–M10 follow the four phases of the
 | M6 | Presentation | ✅ Complete |
 | M7 | Platform Security & Multi-Tenancy Foundation (Phase 0) | ✅ Complete (8/8 issues) |
 | M8 | Detection Plane — NIST CSF Coverage & ATT&CK Depth (Phase 1) | ✅ Complete (5/5) |
-| M9 | Operational Maturity (SOC-CMM Level 3) (Phase 2) | 🚧 In progress — 1/5 (WS2.1) |
+| M9 | Operational Maturity (SOC-CMM Level 3) (Phase 2) | 🚧 In progress — 2/5 (WS2.1, WS2.3) |
 | M10 | SOC 2 Type II Technical Control Readiness (Phase 3) | 📋 Planned |
 
 ### M7 — Phase 0 workstream breakdown

--- a/scripts/setup/.env.example
+++ b/scripts/setup/.env.example
@@ -30,6 +30,10 @@ KIBANA_ENCRYPTION_KEY=changeme_must_be_at_least_32_chars_long
 # Shared secret for HMAC-signing the SOAR /alert webhook (Logstash -> AI agent).
 # openssl rand -hex 32
 SOC_AGENT_HMAC_SECRET=changeme_soar_webhook_secret
+# WS2.3: password for the least-privilege `soc_agent` Kibana user the agent uses to
+# open/close tracked Cases. Set it to enable case tracking; blank = setup skips the
+# user and the agent skips cases (alert handling still works). openssl rand -hex 24
+SOC_AGENT_KIBANA_PASSWORD=changeme_soc_agent_kibana_password
 
 # --- AI agent notifications & LLM triage (optional; blank = feature disabled) ---
 # ntfy topic for mobile push alerts. Pick a long, unguessable value.

--- a/scripts/setup/ai_agent/agent_app.py
+++ b/scripts/setup/ai_agent/agent_app.py
@@ -34,6 +34,15 @@ LLM_MODEL          = os.environ.get("LLM_MODEL",          "gpt-4")
 # on every /alert; the dead SOAR trigger + the pre-#109 crash-loop hid it.)
 LLM_ALLOW_HOSTED   = os.environ.get("LLM_ALLOW_HOSTED",   "false").lower() == "true"
 DISCORD_WEBHOOK_URL = os.environ.get("DISCORD_WEBHOOK_URL", "")
+# WS2.3: Kibana Cases — every /alert becomes a tracked case (state/owner/timeline),
+# tenant-scoped to the alert's Kibana space, with the AI summary + SOAR action
+# attached and closeable with a disposition. Needs a Kibana user holding the
+# generalCases feature privilege (provisioned as `soc_agent` by docker-compose setup).
+# Unset creds degrade gracefully — case tracking is skipped, /alert still works.
+KIBANA_URL         = os.environ.get("KIBANA_URL",         "http://kibana:5601")
+KIBANA_AGENT_USER  = os.environ.get("KIBANA_AGENT_USER",  "")
+KIBANA_AGENT_PASS  = os.environ.get("KIBANA_AGENT_PASS",  "")
+CASES_OWNER        = "cases"  # generic Stack Cases (generalCases feature)
 # Elasticsearch endpoint for the SOAR feedback loop (Executive Dashboard metrics).
 # Defaults to the Docker-network service name used by docker-compose.yml.
 # Security is enabled (WS0.1): connect over HTTPS with a least-privilege user and
@@ -463,6 +472,81 @@ def log_soar_action(action_type, target_ip, target_mac, ai_summary, severity, te
 
 
 # =============================================================================
+# 3.6 ALERT TRIAGE & CASE TRACKING — Kibana Cases (WS2.3)
+# =============================================================================
+def _kibana_base(tenant: str) -> str:
+    """Kibana base URL for the tenant's space (WS0.3). 'unassigned' -> default space."""
+    if tenant and tenant != "unassigned":
+        return f"{KIBANA_URL}/s/{tenant}"
+    return KIBANA_URL
+
+
+def _cases_enabled() -> bool:
+    return bool(KIBANA_AGENT_USER and KIBANA_AGENT_PASS)
+
+
+def _kibana(method, path, tenant, **kw):
+    return requests.request(
+        method, f"{_kibana_base(tenant)}{path}",
+        headers={"kbn-xsrf": "true", "Content-Type": "application/json"},
+        auth=(KIBANA_AGENT_USER, KIBANA_AGENT_PASS), timeout=8, **kw)
+
+
+def create_case(tenant, severity, ai_summary, source_ip, source_mac, extra_tags=None):
+    """Open a Kibana case for an alert (tenant-scoped). Returns case id, or None.
+
+    Fail-safe: case tracking never breaks alert handling — failures are logged.
+    """
+    if not _cases_enabled():
+        return None
+    body = {
+        "title": f"[{str(severity).upper()}] SOC alert — {source_ip or source_mac or 'unknown'} ({tenant})",
+        "description": ("**Auto-opened by the Suburban-SOC AI agent.**\n\n"
+                        f"- Tenant: `{tenant}`\n- Severity: `{severity}`\n"
+                        f"- Source IP: `{source_ip}`\n- Source MAC: `{source_mac or 'N/A'}`\n\n"
+                        f"**AI triage**\n\n{ai_summary}"),
+        "tags": ["suburban-soc", str(tenant), str(severity)] + list(extra_tags or []),
+        "connector": {"id": "none", "name": "none", "type": ".none", "fields": None},
+        "settings": {"syncAlerts": False},
+        "owner": CASES_OWNER,
+    }
+    try:
+        r = _kibana("POST", "/api/cases", tenant, json=body)
+        if r.status_code == 200:
+            return r.json().get("id")
+        app.logger.error("Kibana case create -> HTTP %s: %s", r.status_code, r.text[:200])
+    except Exception as e:  # noqa: BLE001 - case tracking must never crash /alert
+        app.logger.error("Kibana case create failed: %s", e)
+    return None
+
+
+def add_case_comment(tenant, case_id, comment):
+    """Append a timeline comment (the SOAR decision/action) to a case."""
+    if not (_cases_enabled() and case_id):
+        return
+    try:
+        _kibana("POST", f"/api/cases/{case_id}/comments", tenant,
+                json={"type": "user", "comment": comment, "owner": CASES_OWNER})
+    except Exception as e:  # noqa: BLE001
+        app.logger.error("Kibana case comment failed: %s", e)
+
+
+def close_case(tenant, case_id, disposition):
+    """Close a case with a disposition (recorded as a tag + a closing comment)."""
+    if not (_cases_enabled() and case_id):
+        return
+    try:
+        cur = _kibana("GET", f"/api/cases/{case_id}", tenant).json()
+        tags = list(dict.fromkeys((cur.get("tags") or []) + [f"disposition:{disposition}"]))
+        _kibana("PATCH", "/api/cases", tenant, json={"cases": [{
+            "id": case_id, "version": cur.get("version"),
+            "status": "closed", "tags": tags}]})
+        add_case_comment(tenant, case_id, f"Closed — disposition: **{disposition}**.")
+    except Exception as e:  # noqa: BLE001
+        app.logger.error("Kibana case close failed: %s", e)
+
+
+# =============================================================================
 # 4. WEBHOOK LISTENER — real-time alert triage
 # =============================================================================
 @app.route("/alert", methods=["POST"])
@@ -490,6 +574,11 @@ def handle_kibana_webhook():
     # Step 1: AI triage
     ai_summary = analyze_alert_with_ai(raw_details)
 
+    # WS2.3: open a tracked Kibana case for this alert (tenant-scoped). The SOAR
+    # decision is appended as a timeline comment in each branch below; /approve and
+    # the autonomous/excluded paths close it with a disposition.
+    case_id = create_case(tenant, severity, ai_summary, safe_ip, valid_mac)
+
     # Step 2 — §12.4: never act on protected infrastructure, not even to draft.
     # Checked first so neither the autonomous path nor a draft can target it.
     excluded = is_excluded(ip=target_ip, mac=target_mac)
@@ -507,10 +596,14 @@ def handle_kibana_webhook():
             tenant=tenant,
         )
         log_soar_action("analyst_review", safe_ip, valid_mac, ai_summary, severity, tenant=tenant)
+        add_case_comment(tenant, case_id,
+                         f"§12.4: alert targets PROTECTED asset `{excluded}` — no action taken.")
+        close_case(tenant, case_id, "no_action_protected_asset")
         return jsonify({
             "status": "no_action_protected_asset",
             "asset": excluded,
             "ai_analysis": ai_summary,
+            "case_id": case_id,
         }), 200
 
     # Step 3 — §12.3: autonomous containment is OFF by default (it is destructive
@@ -535,10 +628,16 @@ def handle_kibana_webhook():
             "quarantine_mac" if ok else "analyst_review",
             safe_ip, valid_mac, ai_summary, severity, tenant=tenant,
         )
+        add_case_comment(tenant, case_id,
+                         f"Autonomous isolation {'SUCCEEDED' if ok else 'FAILED'} for "
+                         f"`{safe_ip}` / `{valid_mac}` — {detail}")
+        if ok:
+            close_case(tenant, case_id, "true_positive_contained")
         return jsonify({
             "status": "auto_isolated" if ok else "isolation_failed",
             "detail": detail,
             "ai_analysis": ai_summary,
+            "case_id": case_id,
         }), (200 if ok else 200)
 
     # Step 4 — default: DRAFT the action and queue it for a human-of-record, who
@@ -554,8 +653,12 @@ def handle_kibana_webhook():
         "target_mac": valid_mac,
         "ai_summary": ai_summary,
         "recommended_action": "isolate (MAC)" if valid_mac else "review (no valid MAC)",
+        "case_id": case_id,
     }
     _append_pending_action(action)
+    add_case_comment(tenant, case_id,
+                     f"Response DRAFTED ({action['recommended_action']}) — awaiting human "
+                     f"approval via POST /approve (id={action['id']}).")
     send_soc_alert(
         title=f"{severity.upper()}: Response DRAFTED — approval required",
         message=(
@@ -572,6 +675,7 @@ def handle_kibana_webhook():
         "status": "drafted",
         "action_id": action["id"],
         "ai_analysis": ai_summary,
+        "case_id": case_id,
     }), 200
 
 
@@ -616,8 +720,15 @@ def approve_action():
         "approver": approver,
         "result": detail,
     })
+    # WS2.3: record the human decision on the case and close it with a disposition.
+    case_id = action.get("case_id")
+    add_case_comment(action_tenant, case_id,
+                     f"Approved by **{approver}** → isolation {'executed' if ok else 'FAILED'}: {detail}")
+    if ok:
+        close_case(action_tenant, case_id, "true_positive_contained")
     code = 200 if ok else 422
-    return jsonify({"status": "executed" if ok else "blocked", "detail": detail, "approver": approver}), code
+    return jsonify({"status": "executed" if ok else "blocked", "detail": detail,
+                    "approver": approver, "case_id": case_id}), code
 
 
 # =============================================================================

--- a/scripts/setup/docker-compose.yml
+++ b/scripts/setup/docker-compose.yml
@@ -80,6 +80,11 @@ services:
         curl -s -X PUT --cacert config/certs/ca/ca.crt -u "elastic:${ELASTIC_PASSWORD}" -H "Content-Type: application/json" https://elasticsearch:9200/_security/role/logstash_writer -d "{\"cluster\":[\"monitor\",\"manage_index_templates\",\"manage_ilm\"],\"indices\":[{\"names\":[\"logstash-*\",\"soar-actions-*\"],\"privileges\":[\"create_index\",\"create\",\"write\",\"manage\"]}]}" > /dev/null;
         echo "Provisioning logstash_internal user";
         curl -s -X PUT --cacert config/certs/ca/ca.crt -u "elastic:${ELASTIC_PASSWORD}" -H "Content-Type: application/json" https://elasticsearch:9200/_security/user/logstash_internal -d "{\"password\":\"${LOGSTASH_PASSWORD}\",\"roles\":[\"logstash_writer\"],\"full_name\":\"Logstash writer (Suburban-SOC)\"}" > /dev/null;
+        if [ x${SOC_AGENT_KIBANA_PASSWORD} != x ]; then
+          echo "Provisioning soc_agent_cases role + soc_agent user (WS2.3 Kibana Cases)";
+          curl -s -X PUT --cacert config/certs/ca/ca.crt -u "elastic:${ELASTIC_PASSWORD}" -H "Content-Type: application/json" https://elasticsearch:9200/_security/role/soc_agent_cases -d "{\"applications\":[{\"application\":\"kibana-.kibana\",\"privileges\":[\"feature_generalCases.all\"],\"resources\":[\"*\"]}]}" > /dev/null;
+          curl -s -X PUT --cacert config/certs/ca/ca.crt -u "elastic:${ELASTIC_PASSWORD}" -H "Content-Type: application/json" https://elasticsearch:9200/_security/user/soc_agent -d "{\"password\":\"${SOC_AGENT_KIBANA_PASSWORD}\",\"roles\":[\"soc_agent_cases\"],\"full_name\":\"SOC AI agent (Kibana Cases)\"}" > /dev/null;
+        fi;
         echo "Setup complete.";
       '
     healthcheck:
@@ -209,6 +214,12 @@ services:
       - ES_USER=logstash_internal
       - ES_PASS=${LOGSTASH_PASSWORD}
       - ES_CA=/certs/ca/ca.crt
+      # WS2.3: Kibana Cases — the agent opens/updates a tracked case per /alert as the
+      # least-privilege `soc_agent` user (generalCases feature). Unset password =>
+      # case tracking is skipped (alert handling still works).
+      - KIBANA_URL=http://kibana:5601
+      - KIBANA_AGENT_USER=soc_agent
+      - KIBANA_AGENT_PASS=${SOC_AGENT_KIBANA_PASSWORD:-}
       # Shared secret for HMAC-signed /alert requests (WS0.2). Required — the
       # endpoint fails closed (503/401) if unset or the signature is wrong.
       - SOC_AGENT_HMAC_SECRET=${SOC_AGENT_HMAC_SECRET}

--- a/tests/ai_agent/test_alert_auth.py
+++ b/tests/ai_agent/test_alert_auth.py
@@ -75,6 +75,12 @@ class AlertResponseTests(unittest.TestCase):
         for fn in ("analyze_alert_with_ai", "send_soc_alert",
                    "send_discord_alert", "log_soar_action"):
             mock.patch.object(agent_app, fn, return_value="stub").start()
+        # WS2.3: stub Kibana Cases — create returns a fake id; comment/close are
+        # tracked so tests can assert the case lifecycle without a live Kibana.
+        self.mock_create_case = mock.patch.object(
+            agent_app, "create_case", return_value="case-abc123").start()
+        self.mock_case_comment = mock.patch.object(agent_app, "add_case_comment").start()
+        self.mock_close_case = mock.patch.object(agent_app, "close_case").start()
         self.addCleanup(mock.patch.stopall)
         self.addCleanup(lambda: os.unlink(self._qfile.name))
 
@@ -169,6 +175,26 @@ class AlertResponseTests(unittest.TestCase):
         self.mock_dispatch.assert_called_once()
         # dispatch_block_via_broker(attacker_ip, tenant, source_mac=...)
         self.assertEqual(self.mock_dispatch.call_args[0][1], "home-smith")
+
+    # --- WS2.3 alert triage & case tracking ----------------------------------
+    def test_alert_opens_tracked_case(self):
+        r = self._post({"severity": "critical", "source_ip": "1.2.3.4",
+                        "source_mac": GOOD_MAC, "tenant_id": "home-smith"})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.get_json()["case_id"], "case-abc123")
+        self.mock_create_case.assert_called_once()
+        # the SOAR decision is appended to the case timeline
+        self.assertTrue(self.mock_case_comment.called)
+
+    def test_approve_closes_case_with_disposition(self):
+        draft = self._post({"severity": "critical", "source_ip": "1.2.3.4",
+                            "source_mac": GOOD_MAC}).get_json()
+        r = self._post({"id": draft["action_id"], "approver": "analyst1"}, path="/approve")
+        self.assertEqual(r.get_json()["status"], "executed")
+        self.assertEqual(r.get_json()["case_id"], "case-abc123")
+        # approval closes the case with a disposition
+        self.mock_close_case.assert_called_with("unassigned", "case-abc123",
+                                                "true_positive_contained")
 
     def test_broker_refusal_surfaces_as_isolation_failed(self):
         # When the broker reports no routers for the tenant (it owns inventory),


### PR DESCRIPTION
Closes #99 (WS2.3 — Alert triage & case tracking). M9 → 2/5.

Each `/alert` now becomes a **tracked Kibana Case** (state / owner / timeline), tenant-scoped, with the AI triage + SOAR action recorded and closeable with a disposition — instead of a fire-and-forget ntfy/Discord ping.

## What
- **`agent_app.py`** — `create_case` / `add_case_comment` / `close_case` helpers (Kibana Cases API; tenant → Kibana space). `/alert` opens a case after triage; each branch (excluded / autonomous / draft) records its decision as a **timeline comment**; the excluded + successful-containment paths **close** with a disposition; `/approve` comments the human decision and closes on success. `case_id` flows through the draft action and every response. **Fail-safe** — case tracking never breaks alert handling.
- **`docker-compose.yml`** — `setup` provisions a least-privilege **`soc_agent_cases`** role (`feature_generalCases.all`, all spaces, via ES application privilege — no Kibana dependency at setup time) + a `soc_agent` user; the agent gets `KIBANA_URL` + `KIBANA_AGENT_USER/PASS`. Gated on `SOC_AGENT_KIBANA_PASSWORD`.
- **`.env.example`** — `SOC_AGENT_KIBANA_PASSWORD` (blank ⇒ case tracking skipped, alerts still work).
- **tests** — agent suite **16/16** (added: `/alert` opens a case; `/approve` closes with disposition).

## Validated live
- Confirmed the Cases API auth model first: an ES-API role with `feature_generalCases.all` lets a non-superuser create cases (200).
- A signed `/alert` on a protected asset opens **`[CRITICAL] SOC alert — 192.168.1.1`**, records the §12.4 timeline comment, and **closes** the case with `disposition:no_action_protected_asset` + a close comment (verified via `totalComment` + `/comments/_find`).

## Acceptance (#99)
- [x] Kibana Cases for alert state/owner/timeline (tenant-scoped via spaces)
- [x] AI triage summary + SOAR action attached from `agent_app.py`
- [x] Closeable with a disposition

> Note: the close-on-containment path is unit-tested (mocked) and exercised live via the excluded-asset path; closing on a *successful* broker block needs a reachable OpenWrt router (same constraint as #109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)