### PR TITLE
feat(reliability): WS2.5 HA + restore-tested backups + self-monitoring — completes M9 (#101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ M1–M6 are the completed MVP; M7–M10 follow the four phases of the
 | M6 | Presentation | ✅ Complete |
 | M7 | Platform Security & Multi-Tenancy Foundation (Phase 0) | ✅ Complete (8/8 issues) |
 | M8 | Detection Plane — NIST CSF Coverage & ATT&CK Depth (Phase 1) | ✅ Complete (5/5) |
-| M9 | Operational Maturity (SOC-CMM Level 3) (Phase 2) | 🚧 In progress — 4/5 (WS2.1–2.4) |
+| M9 | Operational Maturity (SOC-CMM Level 3) (Phase 2) | ✅ Complete (5/5) |
 | M10 | SOC 2 Type II Technical Control Readiness (Phase 3) | 📋 Planned |
 
 ### M7 — Phase 0 workstream breakdown

--- a/configs/elasticsearch/snapshot/s3-repository.json
+++ b/configs/elasticsearch/snapshot/s3-repository.json
@@ -1,0 +1,10 @@
+{
+  "type": "s3",
+  "settings": {
+    "bucket": "suburban-soc-snapshots",
+    "endpoint": "${S3_ENDPOINT}",
+    "protocol": "https",
+    "path_style_access": true,
+    "compress": true
+  }
+}

--- a/configs/monitoring/reliability.cron
+++ b/configs/monitoring/reliability.cron
@@ -1,0 +1,13 @@
+# =============================================================================
+# Suburban-SOC reliability schedule (WS2.5)
+#
+# Install on the SOC host (adjust the repo path):
+#   crontab -l 2>/dev/null | cat - configs/monitoring/reliability.cron | crontab -
+# Env (ES creds, NTFY_TOPIC) is read from scripts/setup/.env by each script.
+# =============================================================================
+
+# Self-monitoring: alert if any component is DOWN (the SOC detects its own outages).
+*/5 * * * * cd "$HOME/projects/Suburban-SOC" && ./scripts/setup/stack_health.sh >> /var/log/suburban-soc-health.log 2>&1
+
+# Restore-test the backups daily (a backup you never restore is not a backup).
+0 2 * * * cd "$HOME/projects/Suburban-SOC" && ./scripts/setup/restore_test.sh >> /var/log/suburban-soc-restore.log 2>&1

--- a/docs/SOP-005-reliability.md
+++ b/docs/SOP-005-reliability.md
@@ -1,0 +1,97 @@
+# SOP-005 — Reliability of the SOC Stack (WS2.5)
+
+**Status:** Active · **Milestone:** M9 (Operational Maturity / SOC-CMM L3) ·
+**Workstream:** WS2.5 · **Owner:** SOC Operator
+
+## Purpose
+A paying customer needs uptime and recoverable evidence. This SOP covers the three
+reliability pillars and the drills that prove them: **HA**, **restore-tested backups**,
+and **self-monitoring**.
+
+---
+
+## 1. High Availability — multi-node Elasticsearch
+
+The dev stack (`docker-compose.yml`) is single-node (no HA). Production runs the
+**3-node** topology in `scripts/setup/docker-compose.ha.yml` (3 master+data nodes, TLS,
+auto-generated per-node certs).
+
+```bash
+cd scripts/setup
+docker compose -f docker-compose.ha.yml up -d
+curl -sk -u elastic:$ELASTIC_PASSWORD https://localhost:9200/_cluster/health   # status:green nodes:3
+```
+
+**Index replicas ≥ 1 are required for HA** (so a node loss keeps a copy). Set on the
+templates / data streams:
+```bash
+curl -sk -u elastic:$ELASTIC_PASSWORD -X PUT \
+  https://localhost:9200/logstash-security-*/_settings -d '{"index":{"number_of_replicas":1}}'
+```
+(The WS0.5 single-node templates pin `replicas:0`; bump to `1` on the HA cluster.)
+
+### Kill-a-node drill (validated)
+```bash
+docker compose -f docker-compose.ha.yml stop es02
+curl -sk -u elastic:$ELASTIC_PASSWORD https://localhost:9200/_cluster/health
+```
+**Validated result:** with a replicated index, stopping a node leaves the cluster
+**serving** — status goes `green → yellow` (degraded, not `red`), node count `3 → 2`,
+and **all data stays readable (no loss)**. Restarting the node re-greens the cluster.
+`yellow` here = "operational, one replica short", which is the HA win: an outage does
+not stop the SOC or lose evidence.
+
+---
+
+## 2. Restore-tested backups
+
+Automated snapshots are configured in WS0.5 (SLM policy `suburban-soc-daily-snapshots`).
+A backup is only real once restored — `scripts/setup/restore_test.sh` proves it:
+
+```bash
+./scripts/setup/restore_test.sh            # canary round-trip (snapshot -> restore -> verify count)
+./scripts/setup/restore_test.sh <index>    # restore-test a real index into a scratch copy
+```
+**Validated:** 25/25 canary docs snapshot→restore round-tripped from
+`suburban-soc-snapshots`. Scheduled daily via `configs/monitoring/reliability.cron`.
+
+### Object-storage snapshots (production)
+The dev repo is `fs` (`path.repo`). Production points at **S3-compatible object
+storage** (`configs/elasticsearch/snapshot/s3-repository.json`):
+```bash
+# 1. credentials go in the ES keystore (NOT the repo JSON):
+bin/elasticsearch-keystore add s3.client.default.access_key
+bin/elasticsearch-keystore add s3.client.default.secret_key
+# 2. register (S3_ENDPOINT e.g. a MinIO or cloud endpoint):
+curl -sk -u elastic:$ELASTIC_PASSWORD -X PUT \
+  https://localhost:9200/_snapshot/suburban-soc-snapshots \
+  --data-binary @configs/elasticsearch/snapshot/s3-repository.json
+```
+`restore_test.sh` and the SLM policy work unchanged against the S3 repo. For a
+disaster-recovery drill, restore into a **scratch cluster** and verify counts.
+
+---
+
+## 3. Self-monitoring — the SOC detects its own outages
+
+`scripts/setup/stack_health.sh` checks every component (Elasticsearch, Kibana,
+Logstash, AI agent, Hive-Mind broker), records to `soc-health`, and raises an **ntfy
+alert** if anything is DOWN. Scheduled every 5 min (`configs/monitoring/reliability.cron`).
+
+```bash
+./scripts/setup/stack_health.sh    # exit 0 healthy, 2 if any component down
+```
+**Validated:** all-up → `healthy` (exit 0); stopping the broker → `DOWN: broker`
+(exit 2, ntfy alert). Optionally enable Kibana **Stack Monitoring** for historical
+component metrics:
+```bash
+curl -sk -u elastic:$ELASTIC_PASSWORD -X PUT https://localhost:9200/_cluster/settings \
+  -H 'Content-Type: application/json' -d '{"persistent":{"xpack.monitoring.collection.enabled":true}}'
+```
+
+---
+
+## Acceptance (WS2.5, #101)
+- [x] Multi-node ES for HA — kill a node, cluster stays serving (no data loss) — drill validated.
+- [x] Automated snapshots (WS0.5 SLM) with **periodic restore tests** — `restore_test.sh` validated; daily cron; S3 object-storage config for production.
+- [x] Self-monitoring with alerting — `stack_health.sh` detects component-down and alerts — validated.

--- a/scripts/setup/docker-compose.ha.yml
+++ b/scripts/setup/docker-compose.ha.yml
@@ -1,0 +1,155 @@
+# =============================================================================
+# docker-compose.ha.yml — WS2.5: 3-node High-Availability Elasticsearch cluster.
+#
+# The single-node dev stack (docker-compose.yml) is not HA: one ES node, replicas 0.
+# This is the PRODUCTION topology — three master+data nodes with TLS, so a node loss
+# keeps the cluster green and serving (set index replicas >= 1; data survives).
+#
+#   cp .env.example .env   # set ELASTIC_PASSWORD etc.
+#   docker compose -f docker-compose.ha.yml up -d
+#   # verify green 3-node cluster:
+#   curl -sk -u elastic:$ELASTIC_PASSWORD https://localhost:9200/_cluster/health
+#   # kill-a-node drill (cluster stays green if indices have a replica):
+#   docker compose -f docker-compose.ha.yml stop es02
+#
+# Snapshots: point path.repo at object storage in production (see the reliability
+# SOP); the SLM policy from configs/elasticsearch/apply-lifecycle.sh applies as-is.
+# =============================================================================
+
+x-es-common: &es-common
+  image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-9.3.2}
+  environment: &es-env
+    - cluster.name=${CLUSTER_NAME:-suburban-soc-ha}
+    - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+    - bootstrap.memory_lock=true
+    - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+    - xpack.security.enabled=true
+    - xpack.security.http.ssl.enabled=true
+    - xpack.security.transport.ssl.enabled=true
+    - xpack.security.transport.ssl.verification_mode=certificate
+    - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
+    - xpack.security.http.ssl.certificate_authorities=certs/ca/ca.crt
+    - xpack.license.self_generated.type=${LICENSE:-basic}
+    # HA discovery: the three nodes find each other and bootstrap one cluster.
+    - discovery.seed_hosts=es01,es02,es03
+    - cluster.initial_master_nodes=es01,es02,es03
+  ulimits:
+    memlock: { soft: -1, hard: -1 }
+  networks: [ha-net]
+  healthcheck:
+    test: ["CMD-SHELL", "curl -s --cacert config/certs/ca/ca.crt https://localhost:9200 | grep -q 'missing authentication credentials'"]
+    interval: 10s
+    timeout: 10s
+    retries: 30
+    start_period: 60s
+
+services:
+  # One-shot: generate a CA + a cert per node into the shared certs volume.
+  ha-setup:
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-9.3.2}
+    container_name: ha_setup
+    user: "0"
+    volumes:
+      - ha-certs:/usr/share/elasticsearch/config/certs
+    networks: [ha-net]
+    command: >
+      bash -c '
+        if [ x${ELASTIC_PASSWORD} == x ]; then echo "ERROR: set ELASTIC_PASSWORD in .env"; exit 1; fi;
+        if [ ! -f config/certs/ca.zip ]; then
+          bin/elasticsearch-certutil ca --silent --pem -out config/certs/ca.zip;
+          unzip config/certs/ca.zip -d config/certs;
+        fi;
+        if [ ! -f config/certs/certs.zip ]; then
+          printf "instances:\n  - name: es01\n    dns: [es01, localhost]\n  - name: es02\n    dns: [es02, localhost]\n  - name: es03\n    dns: [es03, localhost]\n" > config/certs/instances.yml;
+          bin/elasticsearch-certutil cert --silent --pem -out config/certs/certs.zip --in config/certs/instances.yml --ca-cert config/certs/ca/ca.crt --ca-key config/certs/ca/ca.key;
+          unzip config/certs/certs.zip -d config/certs;
+        fi;
+        chown -R 1000:0 config/certs; find config/certs -type d -exec chmod 750 \{\} \;; find config/certs -type f -exec chmod 640 \{\} \;;
+        echo "HA certs ready.";
+      '
+
+  es01:
+    <<: *es-common
+    container_name: es01
+    depends_on: { ha-setup: { condition: service_completed_successfully } }
+    environment:
+      - node.name=es01
+      - xpack.security.http.ssl.key=certs/es01/es01.key
+      - xpack.security.http.ssl.certificate=certs/es01/es01.crt
+      - xpack.security.transport.ssl.key=certs/es01/es01.key
+      - xpack.security.transport.ssl.certificate=certs/es01/es01.crt
+      - cluster.name=${CLUSTER_NAME:-suburban-soc-ha}
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=true
+      - xpack.security.transport.ssl.enabled=true
+      - xpack.security.transport.ssl.verification_mode=certificate
+      - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
+      - xpack.security.http.ssl.certificate_authorities=certs/ca/ca.crt
+      - xpack.license.self_generated.type=${LICENSE:-basic}
+      - discovery.seed_hosts=es01,es02,es03
+      - cluster.initial_master_nodes=es01,es02,es03
+    ports: ["${ES_PORT:-9200}:9200"]
+    volumes: [ha-certs:/usr/share/elasticsearch/config/certs, ha-es01:/usr/share/elasticsearch/data]
+
+  es02:
+    <<: *es-common
+    container_name: es02
+    depends_on: { ha-setup: { condition: service_completed_successfully } }
+    environment:
+      - node.name=es02
+      - xpack.security.http.ssl.key=certs/es02/es02.key
+      - xpack.security.http.ssl.certificate=certs/es02/es02.crt
+      - xpack.security.transport.ssl.key=certs/es02/es02.key
+      - xpack.security.transport.ssl.certificate=certs/es02/es02.crt
+      - cluster.name=${CLUSTER_NAME:-suburban-soc-ha}
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=true
+      - xpack.security.transport.ssl.enabled=true
+      - xpack.security.transport.ssl.verification_mode=certificate
+      - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
+      - xpack.security.http.ssl.certificate_authorities=certs/ca/ca.crt
+      - xpack.license.self_generated.type=${LICENSE:-basic}
+      - discovery.seed_hosts=es01,es02,es03
+      - cluster.initial_master_nodes=es01,es02,es03
+    volumes: [ha-certs:/usr/share/elasticsearch/config/certs, ha-es02:/usr/share/elasticsearch/data]
+
+  es03:
+    <<: *es-common
+    container_name: es03
+    depends_on: { ha-setup: { condition: service_completed_successfully } }
+    environment:
+      - node.name=es03
+      - xpack.security.http.ssl.key=certs/es03/es03.key
+      - xpack.security.http.ssl.certificate=certs/es03/es03.crt
+      - xpack.security.transport.ssl.key=certs/es03/es03.key
+      - xpack.security.transport.ssl.certificate=certs/es03/es03.crt
+      - cluster.name=${CLUSTER_NAME:-suburban-soc-ha}
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=true
+      - xpack.security.transport.ssl.enabled=true
+      - xpack.security.transport.ssl.verification_mode=certificate
+      - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
+      - xpack.security.http.ssl.certificate_authorities=certs/ca/ca.crt
+      - xpack.license.self_generated.type=${LICENSE:-basic}
+      - discovery.seed_hosts=es01,es02,es03
+      - cluster.initial_master_nodes=es01,es02,es03
+    volumes: [ha-certs:/usr/share/elasticsearch/config/certs, ha-es03:/usr/share/elasticsearch/data]
+
+networks:
+  ha-net:
+    driver: bridge
+
+volumes:
+  ha-certs:
+  ha-es01:
+  ha-es02:
+  ha-es03:

--- a/scripts/setup/restore_test.sh
+++ b/scripts/setup/restore_test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# =============================================================================
+# restore_test.sh — WS2.5: prove backups are RESTORABLE (not just taken).
+#
+# A backup you have never restored is not a backup. This snapshots a deterministic
+# canary index, restores it under a scratch name, verifies the doc count matches,
+# and cleans up — failing loudly if the round-trip doesn't reproduce the data.
+# Run on a schedule alongside the SLM snapshots; a failure means the evidence chain
+# is broken and must be investigated.
+#
+# Usage (env auto-loaded from scripts/setup/.env):
+#   ./restore_test.sh                 # canary round-trip (default)
+#   ./restore_test.sh <real-index>    # restore-test a real index into a scratch copy
+# Env: ES_URL (https://localhost:9200), ES_USER (elastic), ES_PASS/ELASTIC_PASSWORD,
+#      REPO (suburban-soc-snapshots).
+# =============================================================================
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[[ -f "$HERE/.env" ]] && { set -a; . "$HERE/.env"; set +a; }
+ES_URL="${ES_URL:-https://localhost:9200}"
+ES_USER="${ES_USER:-elastic}"
+ES_PASS="${ES_PASS:-${ELASTIC_PASSWORD:-}}"
+REPO="${REPO:-suburban-soc-snapshots}"
+[[ -z "$ES_PASS" ]] && { echo "ERROR: ES_PASS / ELASTIC_PASSWORD required"; exit 1; }
+
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+es() { curl -sk -u "${ES_USER}:${ES_PASS}" -H 'Content-Type: application/json' "$@"; }
+# python-free count (works on minimal images): pull "count":N from the JSON.
+count() { es "$ES_URL/$1/_count" | grep -o '"count":[0-9]*' | head -1 | cut -d: -f2; }
+
+SRC="${1:-soc-restore-canary}"
+SNAP="restoretest-$(es "$ES_URL/_nodes/_local/name" >/dev/null 2>&1; date -u +%s 2>/dev/null || echo run)"
+SCRATCH="${SRC}-restoretest"
+
+cleanup() {
+  es -o /dev/null -X DELETE "$ES_URL/$SCRATCH" >/dev/null 2>&1
+  es -o /dev/null -X DELETE "$ES_URL/_snapshot/$REPO/$SNAP" >/dev/null 2>&1
+  [[ "$SRC" == "soc-restore-canary" ]] && es -o /dev/null -X DELETE "$ES_URL/$SRC" >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+echo "==> Restore test: source=$SRC repo=$REPO"
+
+# 1. Seed the canary (deterministic) if using the default.
+if [[ "$SRC" == "soc-restore-canary" ]]; then
+  es -o /dev/null -X DELETE "$ES_URL/$SRC" >/dev/null 2>&1
+  bulk=""
+  for i in $(seq 1 25); do
+    bulk+='{"index":{}}\n{"@timestamp":"2026-01-01T00:00:00Z","canary":'"$i"'}\n'
+  done
+  # Dedicated curl with ONLY the ndjson content-type (es() hardcodes json; two
+  # Content-Type headers => ES rejects the bulk).
+  printf "$bulk" | curl -sk -u "${ES_USER}:${ES_PASS}" -o /dev/null -X POST \
+    "$ES_URL/$SRC/_bulk" -H 'Content-Type: application/x-ndjson' --data-binary @-
+  es -o /dev/null -X POST "$ES_URL/$SRC/_refresh"
+fi
+SRC_N="$(count "$SRC")"
+[[ "${SRC_N:-0}" -gt 0 ]] || { red "FAIL: source index $SRC has 0 docs"; exit 1; }
+echo "    source docs: $SRC_N"
+
+# 2. Snapshot just this index (wait for completion).
+code=$(es -o /dev/null -w '%{http_code}' -X PUT "$ES_URL/_snapshot/$REPO/$SNAP?wait_for_completion=true" \
+  -d "{\"indices\":\"$SRC\",\"include_global_state\":false}")
+[[ "$code" == "200" ]] || { red "FAIL: snapshot HTTP $code (is the repo registered? run apply-lifecycle.sh)"; exit 1; }
+echo "    snapshot $SNAP created."
+
+# 3. Restore under a scratch name (rename), wait, verify.
+es -o /dev/null -X DELETE "$ES_URL/$SCRATCH" >/dev/null 2>&1
+code=$(es -o /dev/null -w '%{http_code}' -X POST "$ES_URL/_snapshot/$REPO/$SNAP/_restore?wait_for_completion=true" \
+  -d "{\"indices\":\"$SRC\",\"rename_pattern\":\"(.+)\",\"rename_replacement\":\"\$1-restoretest\",\"include_global_state\":false,\"index_settings\":{\"index.number_of_replicas\":0}}")
+[[ "$code" == "200" ]] || { red "FAIL: restore HTTP $code"; exit 1; }
+es -o /dev/null -X POST "$ES_URL/$SCRATCH/_refresh"
+DST_N="$(count "$SCRATCH")"
+
+echo "    restored docs: $DST_N (expected $SRC_N)"
+if [[ "${DST_N:-0}" -eq "${SRC_N:-0}" && "${SRC_N:-0}" -gt 0 ]]; then
+  green "PASS: snapshot round-trip verified — $DST_N/$SRC_N docs restored from $REPO."
+  exit 0
+else
+  red "FAIL: restored $DST_N but expected $SRC_N — backups are NOT reliably restorable."
+  exit 2
+fi

--- a/scripts/setup/stack_health.sh
+++ b/scripts/setup/stack_health.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# =============================================================================
+# stack_health.sh — WS2.5: the SOC monitors its own components.
+#
+# A SOC that can't see its own outages is blind. This checks every component
+# (Elasticsearch, Kibana, Logstash, AI agent, Hive-Mind broker), indexes the result
+# to soc-health, and raises an ntfy alert if anything is DOWN — so the SOC detects
+# its own outages. Run on a schedule (cron).
+#
+# Usage (env auto-loaded from scripts/setup/.env):
+#   ./stack_health.sh
+# Env: ES_URL, KIBANA_URL, ES_USER, ES_PASS/ELASTIC_PASSWORD, NTFY_TOPIC.
+# =============================================================================
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[[ -f "$HERE/.env" ]] && { set -a; . "$HERE/.env"; set +a; }
+ES_URL="${ES_URL:-https://localhost:9200}"
+KIBANA_URL="${KIBANA_URL:-http://localhost:5601}"
+ES_USER="${ES_USER:-elastic}"
+ES_PASS="${ES_PASS:-${ELASTIC_PASSWORD:-}}"
+NTFY_TOPIC="${NTFY_TOPIC:-}"
+
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+
+declare -a DOWN=()
+report() { printf '  %-16s %s\n' "$1" "$2"; }
+
+# Container running? (best-effort; works when docker is on PATH)
+container_up() { docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$1"; }
+
+check() {  # $1=name  $2=ok(0/1)  $3=detail
+  if [[ "$2" -eq 0 ]]; then report "$1" "UP   ($3)"; else report "$1" "DOWN ($3)"; DOWN+=("$1"); fi
+}
+
+echo "==> SOC stack health $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Elasticsearch — cluster health (red counts as down).
+es_status="$(curl -sk -m 6 -u "${ES_USER}:${ES_PASS}" "$ES_URL/_cluster/health" | grep -o '"status":"[a-z]*"' | cut -d'"' -f4)"
+[[ "$es_status" == "green" || "$es_status" == "yellow" ]] && check elasticsearch 0 "$es_status" || check elasticsearch 1 "${es_status:-unreachable}"
+
+# Kibana — overall status level.
+kb_level="$(curl -s -m 6 -u "${ES_USER}:${ES_PASS}" "$KIBANA_URL/api/status" | grep -o '"level":"[a-z]*"' | head -1 | cut -d'"' -f4)"
+[[ "$kb_level" == "available" ]] && check kibana 0 "$kb_level" || check kibana 1 "${kb_level:-unreachable}"
+
+# Logstash — node stats (:9600) if reachable, else container state.
+if curl -s -m 5 "http://localhost:9600/_node/stats/pipelines" 2>/dev/null | grep -q '"pipelines"'; then
+  check logstash 0 "pipeline ok"
+elif container_up logstash; then
+  check logstash 0 "container up"
+else
+  check logstash 1 "no :9600 + container down"
+fi
+
+# AI agent + broker — container state (not LAN-exposed; HMAC-gated).
+container_up soc_ai_agent && check ai_agent 0 "container up" || check ai_agent 1 "container down"
+container_up hive_mind_broker && check broker 0 "container up" || check broker 1 "container down"
+
+now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+status="$([[ ${#DOWN[@]} -eq 0 ]] && echo healthy || echo degraded)"
+# Record to soc-health for the dashboard (best-effort; needs ES up).
+curl -sk -m 6 -u "${ES_USER}:${ES_PASS}" -o /dev/null -X POST "$ES_URL/soc-health/_doc" \
+  -H 'Content-Type: application/json' \
+  -d "{\"@timestamp\":\"$now\",\"status\":\"$status\",\"down_count\":${#DOWN[@]},\"down\":[$(printf '"%s",' "${DOWN[@]}" | sed 's/,$//')]}" 2>/dev/null
+
+echo
+if [[ ${#DOWN[@]} -eq 0 ]]; then
+  green "=== All components healthy. ==="
+  exit 0
+else
+  red "=== DOWN: ${DOWN[*]} ==="
+  if [[ -n "$NTFY_TOPIC" ]]; then
+    curl -s -m 6 -o /dev/null "https://ntfy.sh/${NTFY_TOPIC}" \
+      -H "Title: Suburban-SOC component DOWN" -H "Priority: urgent" -H "Tags: rotating_light,skull" \
+      -d "SOC components DOWN: ${DOWN[*]}" 2>/dev/null
+  fi
+  exit 2
+fi


### PR DESCRIPTION
Closes #101 (WS2.5 — Reliability of the SOC stack). **Completes Milestone 9** (5/5).

The three reliability pillars, each with a **validated drill**.

## 1. HA — multi-node Elasticsearch
`scripts/setup/docker-compose.ha.yml`: a production **3-node** cluster (master+data, TLS, auto per-node certs).
**Kill-a-node drill validated:** formed **green** (3 nodes); with a replicated index, stopping `es02` left the cluster **serving** — `green → yellow`, `3 → 2` nodes, **zero data loss** (the canary doc stayed readable). `yellow` = operational/one-replica-short; restarting the node re-greens.

## 2. Restore-tested backups
`scripts/setup/restore_test.sh`: snapshot → restore-to-scratch → verify-count round-trip. **Validated: 25/25 docs restored** from `suburban-soc-snapshots`. `configs/elasticsearch/snapshot/s3-repository.json` provides the **object-storage (S3/MinIO)** repo for production (keystore creds; `restore_test` + the WS0.5 SLM policy work unchanged against it).

## 3. Self-monitoring
`scripts/setup/stack_health.sh`: checks ES / Kibana / Logstash / agent / broker, records to `soc-health`, **ntfy-alerts on any DOWN**. **Validated:** all-up → `healthy` (exit 0); broker stopped → `DOWN: broker` (exit 2).

Plus `configs/monitoring/reliability.cron` (health every 5 min + restore-test daily) and `docs/SOP-005-reliability.md` (HA topology, all three drills, object-storage snapshots).

## Acceptance (#101)
- [x] Multi-node ES for HA — kill a node, cluster stays serving (no data loss)
- [x] Automated snapshots (WS0.5 SLM) with periodic **restore tests**
- [x] Self-monitoring with component-down **alerting**

> Validated on a real 3-node cluster (33 GB host headroom). Object-storage snapshots are provided as production config + SOP (the dev default remains the `fs` repo, against which the restore test is validated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)