### PR TITLE
feat(govern): WS3.5 change management — review + CI gates + deploy changelog (#106)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# WS3.5 change management — review routing for security-relevant changes.
+# A PR touching these paths requires review from a code owner (enforced once
+# branch protection + "Require review from Code Owners" is enabled by an admin).
+
+# Detections, response logic, and SOC config are change-controlled.
+/rules/                       @sterlinggarnett @voltron-1
+/configs/                     @sterlinggarnett @voltron-1
+/hunts/                       @sterlinggarnett @voltron-1
+/scripts/setup/ai_agent/      @sterlinggarnett @voltron-1
+/scripts/hive-mind-broker/    @sterlinggarnett @voltron-1
+/.github/                     @sterlinggarnett @voltron-1

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ M1–M6 are the completed MVP; M7–M10 follow the four phases of the
 | M7 | Platform Security & Multi-Tenancy Foundation (Phase 0) | ✅ Complete (8/8 issues) |
 | M8 | Detection Plane — NIST CSF Coverage & ATT&CK Depth (Phase 1) | ✅ Complete (5/5) |
 | M9 | Operational Maturity (SOC-CMM Level 3) (Phase 2) | ✅ Complete (5/5) |
-| M10 | SOC 2 Type II Technical Control Readiness (Phase 3) | 📋 Planned |
+| M10 | SOC 2 Type II Technical Control Readiness (Phase 3) | 🚧 In progress — 1/7 (WS3.5) |
 
 ### M7 — Phase 0 workstream breakdown
 

--- a/docs/SOP-007-change-management.md
+++ b/docs/SOP-007-change-management.md
@@ -1,0 +1,26 @@
+# SOP-007 — Change Management on Detections & Config (WS3.5)
+
+**Status:** Active · **Milestone:** M10 · **Workstream:** WS3.5 · **SOC 2:** Security (change mgmt)
+
+## Purpose
+Nothing that affects detection or response reaches production without a **reviewed,
+CI-passed, recorded** change.
+
+## Controls
+1. **Pull-request review (enforced).** `main` is branch-protected: every change lands
+   via PR with ≥1 approval; stale reviews are dismissed; no force-push/deletion.
+   Enable once (repo admin): `./scripts/setup/setup_branch_protection.sh`.
+   `.github/CODEOWNERS` routes review of `rules/`, `configs/`, `hunts/`, the agent,
+   and the broker to code owners.
+2. **CI gates (required checks).** The `detections` workflow (WS1.2/1.5/2.1/2.2) and
+   `gitleaks` must pass before merge — a broken rule, a drifted ATT&CK matrix, a
+   malformed hunt, or a leaked secret blocks the change.
+3. **Recorded deploys (evidence).** Every deploy is logged by
+   `scripts/setup/deploy_changelog.sh` to `docs/deploy-changelog.md` and the immutable
+   `soc-deploys` index (what / when / actor / commit). `deploy_detections.sh` and
+   `deploy_dashboards.sh` call it automatically.
+
+## Acceptance (#106)
+- [x] PR review + branch protection on rules/configs/response code (script + CODEOWNERS)
+- [x] CI gates required to pass (detections + gitleaks)
+- [x] Deploy changelog emitted (markdown + immutable ES index)

--- a/docs/deploy-changelog.md
+++ b/docs/deploy-changelog.md
@@ -1,0 +1,6 @@
+# Deployment Changelog (WS3.5)
+
+Every deploy is recorded here (auto-appended by deploy_changelog.sh).
+
+| UTC time | component | commit | actor | summary |
+|---|---|---|---|---|

--- a/scripts/setup/deploy_changelog.sh
+++ b/scripts/setup/deploy_changelog.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# =============================================================================
+# deploy_changelog.sh — WS3.5: record every deploy (change management evidence).
+#
+# Appends a timestamped, git-pinned entry to docs/deploy-changelog.md and (if ES is
+# reachable) indexes it to the immutable `soc-deploys` index — so every change that
+# reaches prod is recorded with what/when/who/commit (SOC 2 change management).
+#
+# Called by the deploy scripts:  ./deploy_changelog.sh "<component>" "<summary>"
+# Env (auto-loaded from scripts/setup/.env): ES_URL, ES_USER, ES_PASS/ELASTIC_PASSWORD.
+# =============================================================================
+set -uo pipefail
+COMPONENT="${1:-unknown}"
+SUMMARY="${2:-}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+[[ -f "$HERE/.env" ]] && { set -a; . "$HERE/.env"; set +a; }
+ES_URL="${ES_URL:-https://localhost:9200}"
+ES_USER="${ES_USER:-elastic}"
+ES_PASS="${ES_PASS:-${ELASTIC_PASSWORD:-}}"
+
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+GITREV="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+ACTOR="$(git -C "$REPO_ROOT" config user.name 2>/dev/null || echo "${USER:-unknown}")"
+LOG="$REPO_ROOT/docs/deploy-changelog.md"
+
+# 1. Markdown changelog (created with a header on first run).
+if [[ ! -f "$LOG" ]]; then
+  printf '# Deployment Changelog (WS3.5)\n\nEvery deploy is recorded here (auto-appended by deploy_changelog.sh).\n\n| UTC time | component | commit | actor | summary |\n|---|---|---|---|---|\n' > "$LOG"
+fi
+printf '| %s | %s | `%s` | %s | %s |\n' "$TS" "$COMPONENT" "$GITREV" "$ACTOR" "$SUMMARY" >> "$LOG"
+echo "    changelog: recorded $COMPONENT @ $GITREV"
+
+# 2. Immutable ES record (best-effort).
+if [[ -n "$ES_PASS" ]]; then
+  curl -sk -m 6 -u "${ES_USER}:${ES_PASS}" -o /dev/null -X POST "$ES_URL/soc-deploys/_doc" \
+    -H 'Content-Type: application/json' \
+    -d "{\"@timestamp\":\"$TS\",\"component\":\"$COMPONENT\",\"commit\":\"$GITREV\",\"actor\":\"$ACTOR\",\"summary\":\"$SUMMARY\"}" 2>/dev/null || true
+fi

--- a/scripts/setup/deploy_dashboards.sh
+++ b/scripts/setup/deploy_dashboards.sh
@@ -209,3 +209,5 @@ echo  "  Dashboard IDs       : executive-dashboard, network-dashboard-v3,"
 echo  "                        endpoint-dashboard, dataquality-dashboard,"
 echo  "                        soc-navigation-hub"
 green "========================================================="
+# WS3.5: record the change (deploy changelog evidence).
+bash "$SCRIPT_DIR/deploy_changelog.sh" "dashboards" "imported ${imported}/${#DASHBOARDS[@]} dashboards + data views/watchers" 2>/dev/null || true

--- a/scripts/setup/deploy_detections.sh
+++ b/scripts/setup/deploy_detections.sh
@@ -133,6 +133,8 @@ rc=$?
 echo
 if [[ $rc -eq 0 ]]; then
   green "=== Detection rules deployed. View/triage in Kibana → Security → Rules / Alerts. ==="
+  # WS3.5: record the change (deploy changelog evidence).
+  bash "$SCRIPT_DIR/deploy_changelog.sh" "detections" "deployed ${count:-?} rules to the Elastic Detection Engine" 2>/dev/null || true
 else
   red   "=== Detection rule import reported errors (see above). ==="
 fi

--- a/scripts/setup/setup_branch_protection.sh
+++ b/scripts/setup/setup_branch_protection.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# =============================================================================
+# setup_branch_protection.sh — WS3.5: enforce change management on main.
+#
+# Requires a repo ADMIN token (gh auth login as an admin). Enforces, on `main`:
+#   * PR review required (>=1 approval; stale reviews dismissed)
+#   * CI must pass: the `detections` gate (WS2.1/1.2/1.5) + `gitleaks`
+#   * branch up to date before merge; no force-push / deletion
+# Idempotent — re-run to update.
+# =============================================================================
+set -euo pipefail
+BRANCH="${1:-main}"
+echo "==> Enforcing branch protection on '$BRANCH' (requires admin)"
+gh api -X PUT "repos/:owner/:repo/branches/$BRANCH/protection" \
+  -H 'Accept: application/vnd.github+json' --input - <<JSON
+{
+  "required_status_checks": { "strict": true, "contexts": ["detections", "gitleaks"] },
+  "enforce_admins": false,
+  "required_pull_request_reviews": { "required_approving_review_count": 1, "dismiss_stale_reviews": true },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+JSON
+echo "==> Done. 'main' now requires a reviewed, CI-passed PR."


### PR DESCRIPTION
Closes #106 (WS3.5 — Change management). M10 → 1/7.

Nothing affecting detection/response reaches prod without a **reviewed, CI-passed, recorded** change.

- **`setup_branch_protection.sh`** (admin-run, idempotent) — enforces on `main`: PR review (≥1 approval, dismiss stale) + required CI checks (`detections` + `gitleaks`) + no force-push/deletion.
- **`.github/CODEOWNERS`** — review routing for `rules/`, `configs/`, `hunts/`, agent, broker, `.github`.
- **`deploy_changelog.sh`** — records every deploy (what/when/actor/commit) to `docs/deploy-changelog.md` **and** the immutable `soc-deploys` index; `deploy_detections.sh` + `deploy_dashboards.sh` call it automatically.
- **`docs/SOP-007-change-management.md`**.

## Validated
- Changelog recorder writes the markdown entry **and** indexes to `soc-deploys` (actor `tjlam`, commit captured).
- CI gates (`detections` + `gitleaks`) already run on every PR. Branch protection is scripted (enabling needs a repo admin — the API returns 404 without admin).

## Acceptance (#106)
- [x] PR review + branch protection on rules/config/response code (script + CODEOWNERS)
- [x] CI gates required to pass
- [x] Deploy changelog emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)