### PR TITLE
Audit P1 remediation (batch 1): pipeline ECS, TLS fail-closed, non-root, RBAC, SOAR CI

### DIFF
--- a/.github/workflows/soar-tests.yml
+++ b/.github/workflows/soar-tests.yml
@@ -1,0 +1,51 @@
+name: SOAR Tests
+
+# Audit P1-19: the security-critical SOAR tests gate merges. A regression that
+# breaks fail-closed HMAC auth, the §12.4 exclusion list, the §12.3 approval flow,
+# or WS0.3 tenant scoping on the destructive /alert,/approve,/dispatch path would
+# otherwise merge green — these endpoints execute real router isolation.
+# Runs on any change to the agent/broker code or their tests.
+on:
+  pull_request:
+    paths:
+      - "scripts/setup/ai_agent/**"
+      - "scripts/hive-mind-broker/**"
+      - "tests/ai_agent/**"
+      - "governance/exclusion_list.txt"
+      - ".github/workflows/soar-tests.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  soar-tests:
+    name: SOAR auth / exclusion / approval / tenant-scoping
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # Minimal runtime deps (pinned to the service requirements). The agent test
+      # stubs weekly_ciso_report, so the heavy WeasyPrint/elasticsearch deps are not
+      # needed; network/ES/SSH calls are mocked in the suites.
+      - name: Install test dependencies
+        run: |
+          pip install --quiet \
+            flask==3.1.3 requests==2.33.0 \
+            fastapi==0.121.1 uvicorn==0.34.0 pyyaml==6.0.2 asyncssh==2.18.0 httpx==0.28.1 \
+            pytest
+
+      - name: AI agent — HMAC auth, exclusion list, approval flow (WS0.2 / §12.3 / §12.4 / P0-2)
+        run: python tests/ai_agent/test_alert_auth.py
+
+      - name: Hive-mind broker — HMAC, dispatch, tenant scoping (P0-2)
+        working-directory: scripts/hive-mind-broker
+        run: |
+          # The real inventory.yaml is gitignored; the committed template carries the
+          # `home-smith` tenant + router the tests assert against.
+          cp inventory.example.yaml inventory.yaml
+          python -m pytest test_app.py -q

--- a/configs/elasticsearch/roles/soc_admin.json
+++ b/configs/elasticsearch/roles/soc_admin.json
@@ -1,5 +1,5 @@
 {
-  "cluster": ["monitor","manage_index_templates","manage_ilm","manage_slm","read_slm","manage"],
+  "cluster": ["monitor","manage_index_templates","manage_ilm","manage_slm","read_slm"],
   "indices": [
     {"names": ["logstash-*","soar-actions-*","asset-inventory-*","threat-intel-*","soc-*"],
      "privileges": ["all"]}

--- a/configs/logstash.conf
+++ b/configs/logstash.conf
@@ -114,31 +114,38 @@ filter {
       target => "network_parsed"
     }
     
-    # Map raw fields to ECS Network & Application fields + Zeek IPs
+    # Map raw fields to ECS Network & Application fields + Zeek IPs.
+    # NOTE: targets MUST use Logstash bracket notation ([source][ip]) — a dotted
+    # string target ("source.ip") creates a *flat* field literally named
+    # "source.ip", which the GeoIP conditional below (`if [source][ip]`) never
+    # matches, so GeoIP silently never ran. ECS transport/protocol also follow
+    # Zeek semantics (matching the Beats/Zeek branch above): Zeek `proto` is the
+    # L4 transport (tcp/udp/icmp) and `service` is the application protocol
+    # (dns/http/ssl) — these were previously swapped.
     mutate {
       rename => {
-        "[network_parsed][id.orig_h]"   => "source.ip"
-        "[network_parsed][id.resp_h]"   => "destination.ip"
-        "[network_parsed][id.orig_p]"   => "source.port"
-        "[network_parsed][id.resp_p]"   => "destination.port"
-        "[network_parsed][proto]"       => "network.protocol"
-        "[network_parsed][service]"     => "network.transport"
-        "[network_parsed][query]"       => "dns.question.name"
-        "[network_parsed][qtype_name]"  => "dns.question.type"
-        "[network_parsed][rcode_name]"  => "dns.response.code"
-        "[network_parsed][method]"      => "http.request.method"
-        "[network_parsed][status_code]" => "http.response.status_code"
+        "[network_parsed][id.orig_h]"   => "[source][ip]"
+        "[network_parsed][id.resp_h]"   => "[destination][ip]"
+        "[network_parsed][id.orig_p]"   => "[source][port]"
+        "[network_parsed][id.resp_p]"   => "[destination][port]"
+        "[network_parsed][proto]"       => "[network][transport]"
+        "[network_parsed][service]"     => "[network][protocol]"
+        "[network_parsed][query]"       => "[dns][question][name]"
+        "[network_parsed][qtype_name]"  => "[dns][question][type]"
+        "[network_parsed][rcode_name]"  => "[dns][response][code]"
+        "[network_parsed][method]"      => "[http][request][method]"
+        "[network_parsed][status_code]" => "[http][response][status_code]"
         # Phase A: SOAR MAC enrichment — maps Zeek conn MAC fields to ECS
         # Requires @load policy/protocols/conn/mac-logging in local.zeek
-        "[network_parsed][orig_l2_addr]" => "source.mac"
-        "[network_parsed][resp_l2_addr]" => "destination.mac"
+        "[network_parsed][orig_l2_addr]" => "[source][mac]"
+        "[network_parsed][resp_l2_addr]" => "[destination][mac]"
         # Component 2: SSL/TLS telemetry from Zeek ssl.log (Network Dashboard)
         # Requires @load base/protocols/ssl in local.zeek
-        "[network_parsed][server_name]"       => "tls.client.server_name"
-        "[network_parsed][cipher]"            => "tls.cipher"
-        "[network_parsed][curve]"             => "tls.curve"
-        "[network_parsed][version]"           => "tls.version"
-        "[network_parsed][validation_status]" => "tls.validation_status"
+        "[network_parsed][server_name]"       => "[tls][client][server_name]"
+        "[network_parsed][cipher]"            => "[tls][cipher]"
+        "[network_parsed][curve]"             => "[tls][curve]"
+        "[network_parsed][version]"           => "[tls][version]"
+        "[network_parsed][validation_status]" => "[tls][validation_status]"
         # Component 1: surface Zeek notice/ssh fields for MITRE/NIST tagging
         "[network_parsed][note]"         => "note"
         "[network_parsed][auth_success]" => "auth_success"

--- a/scripts/hive-mind-broker/Dockerfile
+++ b/scripts/hive-mind-broker/Dockerfile
@@ -10,6 +10,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+# Drop root (audit P1-4): run as a dedicated non-root user. The broker writes its
+# approval queue under /app; docker-compose mounts the router SSH key at this user's
+# ~/.ssh (/home/broker/.ssh) — dispatcher.py expanduser()s the inventory key path to
+# the running user's home.
+RUN useradd --create-home --uid 10001 broker && chown -R broker:broker /app
+USER broker
+
 # Router inventory (inventory.yaml) and the SSH key are mounted at runtime by
 # docker-compose — never baked into the image (they are host-specific secrets).
 EXPOSE 8000

--- a/scripts/setup/ai_agent/Dockerfile
+++ b/scripts/setup/ai_agent/Dockerfile
@@ -25,6 +25,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 # 4. Copy the rest of your agent's code into the container
 COPY . .
 
+# 4b. Drop root (audit P1-4): run as a dedicated non-root user. The agent writes its
+#     approval queue under /app and renders PDFs to /tmp, so give the user ownership
+#     of /app. A code-exec bug in the webhook listener then yields an unprivileged
+#     user, not root.
+RUN useradd --create-home --uid 10001 appuser && chown -R appuser:appuser /app
+USER appuser
+
 # 5. Expose port 5000 for Kibana webhooks
 EXPOSE 5000
 

--- a/scripts/setup/ai_agent/agent_app.py
+++ b/scripts/setup/ai_agent/agent_app.py
@@ -51,9 +51,13 @@ ES_HOST            = os.environ.get("ES_HOST",            "https://elasticsearch
 ES_USER            = os.environ.get("ES_USER",            "logstash_internal")
 ES_PASS            = os.environ.get("ES_PASS",            "")
 ES_CA              = os.environ.get("ES_CA",              "/certs/ca/ca.crt")
-# requests `verify` arg: path to the CA bundle if present, else fall back to False
-# (self-signed cert on the internal docker network). Never disable for public ES.
-ES_VERIFY          = ES_CA if (ES_CA and Path(ES_CA).is_file()) else False
+# requests `verify` arg. FAIL CLOSED (audit P1-2): never silently disable TLS
+# verification. If a CA path is configured we hand it to requests — which raises a
+# clear error if the file is missing — instead of the old `else False`, which
+# downgraded every ES call (incl. least-priv creds + audit writes) to an
+# unverified connection whenever the CA wasn't mounted. An explicit empty ES_CA
+# opts into system-trust verification (verify=True); never False.
+ES_VERIFY          = ES_CA if ES_CA else True
 
 # CDP §12.3: autonomous containment is Deferred Scope. The agent DRAFTS a
 # response; a human executes it. Set AUTONOMOUS_ISOLATION=true only to restore

--- a/scripts/setup/ai_agent/slo_metrics.py
+++ b/scripts/setup/ai_agent/slo_metrics.py
@@ -57,9 +57,17 @@ LOWER_BETTER = {
 }
 
 
+# FAIL CLOSED (audit P1-2): verify TLS against the stack CA instead of verify=False.
+# ES_CA defaults to the agent container's mounted CA; set it to your CA path for
+# host/standalone runs, or to "" to verify against the system trust store. requests
+# raises a clear error if the path is missing — we never silently skip verification.
+ES_CA = os.environ.get("ES_CA", "/certs/ca/ca.crt")
+ES_VERIFY = ES_CA if ES_CA else True
+
+
 def es(method, path, body=None):
     return requests.request(
-        method, f"{ES_URL}{path}", auth=(ES_USER, ES_PASS), verify=False,
+        method, f"{ES_URL}{path}", auth=(ES_USER, ES_PASS), verify=ES_VERIFY,
         headers={"Content-Type": "application/json"},
         data=json.dumps(body) if body is not None else None, timeout=15)
 

--- a/scripts/setup/ai_agent/weekly_ciso_report.py
+++ b/scripts/setup/ai_agent/weekly_ciso_report.py
@@ -28,6 +28,9 @@ from elasticsearch import Elasticsearch
 # 0. CONFIGURATION — mirrors agent_app.py env-var conventions
 # ---------------------------------------------------------------------------
 ES_HOST         = os.getenv("ES_HOST",          "https://localhost:9200")
+# FAIL CLOSED (audit P1-2): verify the ES TLS cert against the stack CA instead of
+# verify_certs=False. Set ES_CA to your CA path, or "" to use the system trust store.
+ES_CA           = os.getenv("ES_CA",            "/certs/ca/ca.crt")
 ES_API_KEY      = os.getenv("ES_API_KEY",        "your_es_api_key")
 LLM_API_KEY     = os.getenv("LLM_API_KEY",       "your_api_key_here")   # shared with agent_app
 LLM_API_URL     = os.getenv("LLM_API_URL",       "https://api.openai.com/v1/chat/completions")
@@ -88,7 +91,8 @@ def fetch_and_calculate_metrics() -> dict:
     }
 
     try:
-        es = Elasticsearch(ES_HOST, api_key=ES_API_KEY, verify_certs=False)
+        es = Elasticsearch(ES_HOST, api_key=ES_API_KEY,
+                           verify_certs=True, ca_certs=(ES_CA or None))
         res = es.search(index=".alerts-security.alerts-*", body=query)
         hits = res["hits"]["hits"]
         log.info("Retrieved %d alerts from ES.", len(hits))

--- a/scripts/setup/docker-compose.yml
+++ b/scripts/setup/docker-compose.yml
@@ -26,6 +26,11 @@
 # single source of truth for certs.)
 # =============================================================================
 
+# Explicit Compose project name so this stack never collides with another repo
+# whose compose also lives in a scripts/setup/ directory (Docker otherwise derives
+# the project name "setup" from the folder, cross-wiring the two stacks).
+name: suburban-soc
+
 services:
   # --- One-shot: generate certs, set passwords, provision least-priv users -----
   setup:

--- a/scripts/setup/docker-compose.yml
+++ b/scripts/setup/docker-compose.yml
@@ -335,7 +335,9 @@ services:
       # SSH key(s) the broker uses to reach routers (path per inventory.yaml).
       # Compose does NOT expand `~`, so default to an absolute ${HOME}/.ssh; set
       # HIVE_MIND_SSH_DIR to an absolute path to override (required on Windows hosts).
-      - ${HIVE_MIND_SSH_DIR:-${HOME}/.ssh}:/root/.ssh:ro
+      # Mounted at the non-root `broker` user's home (audit P1-4); dispatcher.py
+      # expanduser()s the inventory ssh_key_path (~/.ssh/...) to /home/broker/.ssh.
+      - ${HIVE_MIND_SSH_DIR:-${HOME}/.ssh}:/home/broker/.ssh:ro
     ports:
       # Localhost only — for debugging/verification; the agent uses the service name.
       - "127.0.0.1:8000:8000"

--- a/scripts/setup/run_hunts.py
+++ b/scripts/setup/run_hunts.py
@@ -36,6 +36,10 @@ ES_URL = os.environ.get("ES_URL", "https://localhost:9200")
 ES_USER = os.environ.get("ES_USER", "elastic")
 ES_PASS = os.environ.get("ES_PASS") or os.environ.get("ELASTIC_PASSWORD", "")
 WINDOW = os.environ.get("HUNT_WINDOW", "now-7d")
+# FAIL CLOSED (audit P1-2): verify TLS against the stack CA, never verify=False.
+# Set ES_CA to your CA path for host/standalone runs, or "" for system trust.
+ES_CA = os.environ.get("ES_CA", "/certs/ca/ca.crt")
+ES_VERIFY = ES_CA if ES_CA else True
 
 
 def es_count(index, query_string):
@@ -44,7 +48,7 @@ def es_count(index, query_string):
         {"range": {"@timestamp": {"gte": WINDOW}}}]}}}
     try:
         r = requests.post(f"{ES_URL}/{index}/_count", auth=(ES_USER, ES_PASS),
-                          verify=False, headers={"Content-Type": "application/json"},
+                          verify=ES_VERIFY, headers={"Content-Type": "application/json"},
                           data=json.dumps(body), timeout=20)
         return r.json().get("count", 0) if r.status_code == 200 else 0
     except Exception:
@@ -82,7 +86,7 @@ def main():
         bulk.append(json.dumps(doc))
     if bulk:
         try:
-            requests.post(f"{ES_URL}/_bulk", auth=(ES_USER, ES_PASS), verify=False,
+            requests.post(f"{ES_URL}/_bulk", auth=(ES_USER, ES_PASS), verify=ES_VERIFY,
                           headers={"Content-Type": "application/x-ndjson"},
                           data="\n".join(bulk) + "\n", timeout=20)
             print(f"  -> indexed {len(hunts)} hunt results to soc-hunts ({findings} findings)")


### PR DESCRIPTION
First batch of **P1 (high)** audit fixes, continuing from the merged P0 PR (#141). Each change was validated — pipeline fixes against the live stack, security/code fixes via the unit suites + container rebuilds.

## Commits

| Commit | Audit item | What |
|---|---|---|
| `fix(infra)` name | (live incident) | Pin Compose project name to `suburban-soc` so volumes are deterministic and don't collide with another `scripts/setup/` repo (root of the orphan-`suburban-soc_certs` confusion). Live volumes were migrated `setup_*`→`suburban-soc_*` first. |
| `fix(pipeline)` | **P1-6, P1-7** | `network_logs` rename block used flat dotted targets (`"source.ip"`) so the GeoIP guard `if [source][ip]` never matched (GeoIP silently off), and mapped Zeek `proto`/`service` swapped. Aligned to bracket notation + correct transport/protocol. **Runtime-validated**: `network.transport=tcp`, `network.protocol=http`, nested IPs, `source.geo` populated. |
| `ci` | **P1-19** | The SOAR auth tests (HMAC fail-closed, exclusion list, approval flow, tenant scoping) ran in no workflow — a regression on the destructive `/approve` path would merge green. Added a `SOAR Tests` workflow (agent + broker). Validated: agent 20/20, broker 17/17. |
| `fix(security)` TLS | **P1-2** | Several ES clients silently disabled TLS verification (`agent_app.py` fell back to `verify=False` when the CA was absent; `slo_metrics.py`/`run_hunts.py`/`weekly_ciso_report.py` hardcoded it). Now fail closed: verify against the stack CA, never `False`. |
| `fix(security)` non-root | **P1-4** | Agent (Flask) and broker (FastAPI) ran as root. Added a non-root user (uid 10001) to both; moved the broker's SSH-key mount to its home. **Validated live**: agent `uid=10001(appuser)` serving 200, broker `uid=10001(broker)`. |
| `fix(rbac)` | **P1-5** | `soc_admin` granted the catch-all cluster `manage` (near-superuser). Dropped it; the specific `manage_*` privileges remain. |

## Still open (not in this PR)
- **P1-1** HMAC replay protection (big cross-cutting change: agent + broker + Logstash signer + signing clients + tests) — recommend its own PR.
- **P1-3** broker SSH `known_hosts=None`; **P1-8** `:5514` TLS; **P1-9** auto-apply templates/ILM; **P1-10** `docker-compose.ha.yml` aspirational; **P1-11** wire/delete the unused role JSON.
- **P1-12…P1-18** documentation accuracy (status overstated, detection counts, repo identity, SOP numbering, stale KQL doc).

## Validation summary
- Live stack healthy throughout (ES + Kibana healthy, Logstash writing to ILM data streams, agent/broker non-root + serving).
- Unit: agent 20/20, broker 17/17. Pipeline change verified end-to-end via injected events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)