### PR TITLE
Audit P1-1: HMAC replay protection on the SOAR webhooks

### DIFF
--- a/configs/logstash.conf
+++ b/configs/logstash.conf
@@ -331,8 +331,12 @@ filter {
           "source_ip"  => event.get("[source][ip]").to_s,
           "source_mac" => event.get("[source][mac]").to_s
         }.to_json
-        sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", secret, body)
+        # audit P1-1: replay protection. Sign "<timestamp>." + body and send the
+        # timestamp in x-elastic-timestamp; the agent rejects stale/replayed signatures.
+        ts = Time.now.to_i.to_s
+        sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", secret, ts + "." + body)
         event.set("[@metadata][soar_body]", body)
+        event.set("[@metadata][soar_ts]", ts)
         event.set("[@metadata][soar_sig]", sig)
       '
     }
@@ -394,12 +398,14 @@ output {
       url => "http://soc_ai_agent:5000/alert"
       http_method => "post"
       # Send the exact pre-signed body built in the filter stage, with the HMAC in
-      # the x-elastic-signature header the agent verifies (WS0.2).
+      # the x-elastic-signature header and the freshness timestamp in
+      # x-elastic-timestamp — both verified by the agent (WS0.2 + audit P1-1).
       format => "message"
       message => "%{[@metadata][soar_body]}"
       content_type => "application/json"
       headers => {
         "x-elastic-signature" => "%{[@metadata][soar_sig]}"
+        "x-elastic-timestamp" => "%{[@metadata][soar_ts]}"
       }
     }
   }

--- a/scripts/hive-mind-broker/app.py
+++ b/scripts/hive-mind-broker/app.py
@@ -20,6 +20,13 @@ inv = Inventory("inventory.yaml")
 # The secret used for HMAC validation. Loaded from the environment with NO
 # insecure default (WS0.4) — if unset, the endpoint fails closed (503).
 HMAC_SECRET = os.getenv("HIVE_MIND_SECRET", "").encode("utf-8")
+# audit P1-1: replay protection. Signed requests carry x-elastic-timestamp; the
+# timestamp must be within +/- HMAC_REPLAY_WINDOW of now, and a signature seen once
+# within that window is refused (nonce cache), so a captured block request cannot
+# be replayed.
+HMAC_REPLAY_WINDOW = int(os.getenv("HMAC_REPLAY_WINDOW", "300"))  # seconds
+_seen_sigs = {}            # signature -> expiry epoch
+_seen_sigs_lock = threading.Lock()
 
 # CDP §12.3: autonomous containment is Deferred Scope. By default the broker
 # DRAFTS a block and queues it for a human-of-record; it does not push it.
@@ -54,8 +61,11 @@ def _read_queue():
 
 
 async def _verify(request: Request) -> bytes:
-    """Fail-closed HMAC gate. Verifies the x-elastic-signature over the RAW body
-    (same scheme as the AI agent) and returns the raw body, or raises HTTPException.
+    """Fail-closed HMAC + timestamp-freshness + replay gate. Verifies
+    sha256=HMAC(secret, '<x-elastic-timestamp>.' + raw_body) (same scheme as the AI
+    agent), requires the timestamp within +/- HMAC_REPLAY_WINDOW of now, and refuses
+    a previously-seen signature — so a captured signed block request cannot be
+    replayed (audit P1-1). Returns the raw body, or raises HTTPException.
 
     Used directly by endpoints that take no JSON body (e.g. GET /pending, which
     signs the empty body) and via _verify_and_parse by the JSON endpoints. Every
@@ -67,14 +77,32 @@ async def _verify(request: Request) -> bytes:
         raise HTTPException(status_code=503, detail="Broker secret not configured")
 
     signature_header = request.headers.get("x-elastic-signature")
-    if not signature_header:
-        raise HTTPException(status_code=401, detail="Missing signature header")
+    timestamp_header = request.headers.get("x-elastic-timestamp")
+    if not signature_header or not timestamp_header:
+        raise HTTPException(status_code=401, detail="Missing signature or timestamp header")
+    try:
+        ts = int(timestamp_header)
+    except ValueError:
+        raise HTTPException(status_code=401, detail="Invalid timestamp")
+    now = int(time.time())
+    if abs(now - ts) > HMAC_REPLAY_WINDOW:
+        raise HTTPException(status_code=401, detail="Timestamp outside replay window")
 
-    # The raw body is what was signed — verify before parsing.
+    # The raw body is what was signed (prefixed by the timestamp) — verify before parsing.
     body = await request.body()
-    expected_mac = hmac.new(HMAC_SECRET, body, hashlib.sha256).hexdigest()
+    signed = f"{timestamp_header}.".encode("utf-8") + body
+    expected_mac = hmac.new(HMAC_SECRET, signed, hashlib.sha256).hexdigest()
     if not hmac.compare_digest(f"sha256={expected_mac}", signature_header):
         raise HTTPException(status_code=401, detail="Invalid signature")
+    # Replay check only AFTER the signature is proven valid (so forged signatures
+    # cannot poison the cache).
+    with _seen_sigs_lock:
+        for s, exp in list(_seen_sigs.items()):
+            if exp <= now:
+                del _seen_sigs[s]
+        if signature_header in _seen_sigs:
+            raise HTTPException(status_code=401, detail="Replayed signature")
+        _seen_sigs[signature_header] = now + HMAC_REPLAY_WINDOW
     return body
 
 

--- a/scripts/hive-mind-broker/test_app.py
+++ b/scripts/hive-mind-broker/test_app.py
@@ -6,6 +6,7 @@ import hmac
 import hashlib
 import json
 import os
+import time
 
 # Set the HMAC secret before importing app (read at import).
 os.environ["HIVE_MIND_SECRET"] = "test_secret"
@@ -20,45 +21,47 @@ TENANT = "home-smith"
 EXCLUDED_IP = "192.168.1.1"
 
 
-def _sign(body: bytes) -> str:
-    return "sha256=" + hmac.new(HMAC_SECRET, body, hashlib.sha256).hexdigest()
+def _sign(body: bytes, ts=None):
+    """Return (timestamp, 'sha256=<hmac>') for the replay-protected scheme: HMAC over
+    '<timestamp>.' + body (audit P1-1)."""
+    ts = ts or str(int(time.time()))
+    sig = "sha256=" + hmac.new(HMAC_SECRET, f"{ts}.".encode() + body, hashlib.sha256).hexdigest()
+    return ts, sig
 
 
-def _post(payload, sign=True, tamper=False):
-    body = json.dumps(payload).encode("utf-8")
+def _signed_headers(body, sign=True, tamper=False, ts=None):
     headers = {}
     if sign:
-        sig = _sign(body)
+        tstamp, sig = _sign(body, ts)
         if tamper:
             sig = sig[:-1] + ("0" if sig[-1] != "0" else "1")
         headers["x-elastic-signature"] = sig
-    return client.post("/webhook/alert", data=body, headers=headers)
+        headers["x-elastic-timestamp"] = tstamp
+    return headers
+
+
+def _post(payload, sign=True, tamper=False, ts=None):
+    body = json.dumps(payload).encode("utf-8")
+    return client.post("/webhook/alert", data=body,
+                       headers=_signed_headers(body, sign, tamper, ts))
 
 
 def _get_pending(sign=True):
     """GET /pending is HMAC-gated; sign the (empty) body like an operator would."""
-    headers = {}
-    if sign:
-        headers["x-elastic-signature"] = _sign(b"")
-    return client.get("/pending", headers=headers)
+    return client.get("/pending", headers=_signed_headers(b"", sign))
 
 
 def _approve(payload, sign=True, tamper=False):
     """POST /approve is HMAC-gated; sign the request body."""
     body = json.dumps(payload).encode("utf-8")
-    headers = {}
-    if sign:
-        sig = _sign(body)
-        if tamper:
-            sig = sig[:-1] + ("0" if sig[-1] != "0" else "1")
-        headers["x-elastic-signature"] = sig
-    return client.post("/approve", data=body, headers=headers)
+    return client.post("/approve", data=body, headers=_signed_headers(body, sign, tamper))
 
 
 @pytest.fixture(autouse=True)
 def _no_real_ssh():
     """Keep the dispatcher from making real SSH calls; reset the queue per test."""
     broker_app._append_action  # touch to ensure import
+    broker_app._seen_sigs.clear()   # isolate the replay/nonce cache per test (P1-1)
     if os.path.exists(broker_app.APPROVAL_QUEUE):
         os.remove(broker_app.APPROVAL_QUEUE)
     with mock.patch.object(broker_app, "dispatch_block_to_all",
@@ -114,15 +117,10 @@ def test_excluded_ip_refused(_no_real_ssh):
     assert _get_pending().json()["count"] == 0
 
 
-def _post_dispatch(payload, sign=True, tamper=False):
+def _post_dispatch(payload, sign=True, tamper=False, ts=None):
     body = json.dumps(payload).encode("utf-8")
-    headers = {}
-    if sign:
-        sig = _sign(body)
-        if tamper:
-            sig = sig[:-1] + ("0" if sig[-1] != "0" else "1")
-        headers["x-elastic-signature"] = sig
-    return client.post("/webhook/dispatch", data=body, headers=headers)
+    return client.post("/webhook/dispatch", data=body,
+                       headers=_signed_headers(body, sign, tamper, ts))
 
 
 # --- #109: /webhook/dispatch — immediate, pre-approved block -------------------
@@ -217,3 +215,32 @@ def test_known_hosts_insecure_opt_out_returns_none():
     import dispatcher
     with mock.patch.object(dispatcher, "INSECURE_SSH", True):
         assert dispatcher._resolve_known_hosts() is None
+
+
+# --- audit P1-1: replay protection on the dispatch path ------------------------
+def test_replayed_dispatch_rejected(_no_real_ssh):
+    # An immediate dispatch is accepted once; replaying the EXACT same body +
+    # timestamp + signature is refused (nonce already seen).
+    payload = {"attacker_ip": "9.9.9.9", "tenant_id": TENANT}
+    ts = str(int(time.time()))
+    first = _post_dispatch(payload, ts=ts)
+    assert first.status_code == 200 and first.json()["executed"] is True
+    replay = _post_dispatch(payload, ts=ts)
+    assert replay.status_code == 401
+    _no_real_ssh.assert_awaited_once()          # the replay never reaches dispatch
+
+
+def test_stale_timestamp_rejected(_no_real_ssh):
+    old = str(int(time.time()) - (broker_app.HMAC_REPLAY_WINDOW + 60))
+    r = _post_dispatch({"attacker_ip": "9.9.9.9", "tenant_id": TENANT}, ts=old)
+    assert r.status_code == 401
+    _no_real_ssh.assert_not_awaited()
+
+
+def test_missing_timestamp_rejected():
+    # A valid signature with no timestamp header is refused.
+    body = json.dumps({"attacker_ip": "9.9.9.9", "tenant_id": TENANT}).encode("utf-8")
+    _, sig = _sign(body)
+    r = client.post("/webhook/dispatch", data=body,
+                    headers={"x-elastic-signature": sig})  # no timestamp
+    assert r.status_code == 401

--- a/scripts/setup/ai_agent/agent_app.py
+++ b/scripts/setup/ai_agent/agent_app.py
@@ -99,28 +99,82 @@ BROKER_URL    = os.environ.get("BROKER_URL", "http://hive_mind_broker:8000")
 # HIVE_MIND_SECRET. If unset, _execute_isolation fails closed (never dispatches).
 HIVE_MIND_SECRET = os.environ.get("HIVE_MIND_SECRET", "").encode("utf-8")
 
-# --- Webhook authentication (WS0.2) ------------------------------------------
-# /alert triggers device isolation, so it MUST be authenticated. Callers sign the
-# raw request body with HMAC-SHA256 and send it in the `x-elastic-signature`
-# header as "sha256=<hexdigest>" (same scheme as the hive-mind-broker). The shared
-# secret comes from the SOC_AGENT_HMAC_SECRET env var — if it is unset the endpoint
-# fails CLOSED (503), never open.
-HMAC_HEADER = "x-elastic-signature"
-HMAC_SECRET = os.environ.get("SOC_AGENT_HMAC_SECRET", "").encode("utf-8")
+# --- Webhook authentication (WS0.2 + audit P1-1 replay protection) -----------
+# /alert triggers device isolation, so it MUST be authenticated AND replay-proof.
+# Callers send two headers:
+#   x-elastic-timestamp: <unix seconds>
+#   x-elastic-signature: sha256=<HMAC-SHA256(secret, "<timestamp>." + raw_body)>
+# The verifier (a) requires the timestamp within +/- HMAC_REPLAY_WINDOW seconds of
+# now and (b) refuses a signature already seen within that window (nonce cache), so
+# a captured signed request cannot be replayed. The shared secret comes from
+# SOC_AGENT_HMAC_SECRET; if unset the endpoint fails CLOSED (503), never open.
+HMAC_HEADER        = "x-elastic-signature"
+HMAC_TS_HEADER     = "x-elastic-timestamp"
+HMAC_SECRET        = os.environ.get("SOC_AGENT_HMAC_SECRET", "").encode("utf-8")
+HMAC_REPLAY_WINDOW = int(os.environ.get("HMAC_REPLAY_WINDOW", "300"))  # seconds
+
+# Replay/nonce cache: signature -> expiry epoch. Bounded by the window (pruned on use).
+_seen_sigs: dict[str, int] = {}
+_seen_sigs_lock = threading.Lock()
 
 # Validation patterns for anything that reaches the broker / response path.
 _MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
 
 
-def verify_signature(raw_body: bytes, signature_header: str | None) -> bool:
-    """Constant-time HMAC-SHA256 verification of the raw request body."""
+def _signed_payload(timestamp: str, raw_body: bytes) -> bytes:
+    """The exact bytes both sides HMAC: '<timestamp>.' + raw_body."""
+    return f"{timestamp}.".encode("utf-8") + raw_body
+
+
+def _nonce_is_fresh(signature: str, now: int) -> bool:
+    """Record a VALID signature; return False if it was already seen (replay)."""
+    with _seen_sigs_lock:
+        for sig, exp in list(_seen_sigs.items()):
+            if exp <= now:
+                del _seen_sigs[sig]
+        if signature in _seen_sigs:
+            return False
+        _seen_sigs[signature] = now + HMAC_REPLAY_WINDOW
+        return True
+
+
+def sign_request(secret: bytes, raw_body: bytes, timestamp: str | None = None):
+    """Build (timestamp, 'sha256=<hmac>') for the replay-protected scheme. Used by
+    the agent's own outbound calls (and mirrored by every other signer)."""
+    ts = timestamp or str(int(time.time()))
+    sig = "sha256=" + hmac.new(secret, _signed_payload(ts, raw_body), hashlib.sha256).hexdigest()
+    return ts, sig
+
+
+def verify_signature(raw_body: bytes, signature_header: str | None,
+                     timestamp_header: str | None = None) -> bool:
+    """Constant-time HMAC verification with timestamp-freshness + replay protection.
+
+    Verifies sha256=HMAC(secret, '<timestamp>.' + raw_body), requires the timestamp
+    within +/- HMAC_REPLAY_WINDOW of now, and refuses a previously-seen signature.
+    """
     if not HMAC_SECRET:
         app.logger.critical("SOC_AGENT_HMAC_SECRET is not set — refusing all signed requests.")
         return False
-    if not signature_header:
+    if not signature_header or not timestamp_header:
         return False
-    expected = "sha256=" + hmac.new(HMAC_SECRET, raw_body, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(expected, signature_header)
+    try:
+        ts = int(timestamp_header)
+    except (TypeError, ValueError):
+        return False
+    now = int(time.time())
+    if abs(now - ts) > HMAC_REPLAY_WINDOW:
+        app.logger.warning("Rejected request: timestamp outside the +/-%ss replay window.", HMAC_REPLAY_WINDOW)
+        return False
+    expected = "sha256=" + hmac.new(HMAC_SECRET, _signed_payload(timestamp_header, raw_body), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, signature_header):
+        return False
+    # Consult/record the nonce cache only AFTER the signature is proven valid, so an
+    # attacker cannot poison it with forged signatures.
+    if not _nonce_is_fresh(signature_header, now):
+        app.logger.warning("Rejected request: replayed signature (already seen within the window).")
+        return False
+    return True
 
 
 def _require_signature():
@@ -135,8 +189,9 @@ def _require_signature():
     body). Returns a Flask (response, status) tuple to abort with on failure, or
     None when the request is authenticated.
     """
-    if not verify_signature(request.get_data(), request.headers.get(HMAC_HEADER)):
-        app.logger.warning("Rejected %s: missing or invalid HMAC signature.", request.path)
+    if not verify_signature(request.get_data(), request.headers.get(HMAC_HEADER),
+                            request.headers.get(HMAC_TS_HEADER)):
+        app.logger.warning("Rejected %s: missing/invalid/replayed HMAC signature.", request.path)
         return jsonify({"status": "unauthorized"}), 401
     return None
 
@@ -187,12 +242,13 @@ def dispatch_block_via_broker(attacker_ip: str, tenant: str, source_mac: str = "
         "source_mac":  source_mac,
         "approver":    "soc-ai-agent",
     }).encode("utf-8")
-    sig = "sha256=" + hmac.new(HIVE_MIND_SECRET, body, hashlib.sha256).hexdigest()
+    ts, sig = sign_request(HIVE_MIND_SECRET, body)  # replay-protected (audit P1-1)
     try:
         resp = requests.post(
             f"{BROKER_URL}/webhook/dispatch",
             data=body,
-            headers={"Content-Type": "application/json", HMAC_HEADER: sig},
+            headers={"Content-Type": "application/json",
+                     HMAC_HEADER: sig, HMAC_TS_HEADER: ts},
             timeout=15,
         )
     except Exception as exc:  # noqa: BLE001 - never let response handling crash
@@ -611,8 +667,9 @@ def handle_kibana_webhook():
     # Step 0: authenticate the request BEFORE doing anything else. The raw body is
     # what was signed, so verify it before parsing.
     raw_body = request.get_data()
-    if not verify_signature(raw_body, request.headers.get(HMAC_HEADER)):
-        app.logger.warning("Rejected /alert: missing or invalid HMAC signature.")
+    if not verify_signature(raw_body, request.headers.get(HMAC_HEADER),
+                            request.headers.get(HMAC_TS_HEADER)):
+        app.logger.warning("Rejected /alert: missing/invalid/replayed HMAC signature.")
         return jsonify({"status": "unauthorized"}), 401
     _t0 = time.time()  # WS2.4: automated-response latency (-> MTTR SLO)
 
@@ -825,10 +882,13 @@ def trigger_weekly_report():
     open endpoint is a cost/DoS amplifier; the caller signs the request body
     (empty body is fine) with SOC_AGENT_HMAC_SECRET.
 
-    Invoke manually (sign the empty body):
-        SIG="sha256=$(printf '' | openssl dgst -sha256 -hmac "$SOC_AGENT_HMAC_SECRET" | awk '{print $2}')"
-        curl -s -X POST -H "x-elastic-signature: $SIG" http://localhost:5000/weekly-report
-    Or schedule via cron with the same signed header.
+    Invoke manually (replay-protected: sign "<timestamp>." + empty body, send both
+    the signature and the timestamp header — audit P1-1):
+        TS=$(date +%s)
+        SIG="sha256=$(printf '%s.' "$TS" | openssl dgst -sha256 -hmac "$SOC_AGENT_HMAC_SECRET" | awk '{print $2}')"
+        curl -s -X POST -H "x-elastic-signature: $SIG" -H "x-elastic-timestamp: $TS" \
+             http://localhost:5000/weekly-report
+    Or schedule via cron with the same signed headers (freshly per run).
     """
     auth_error = _require_signature()
     if auth_error:

--- a/tests/ai_agent/test_alert_auth.py
+++ b/tests/ai_agent/test_alert_auth.py
@@ -22,6 +22,7 @@ Run:  python tests/ai_agent/test_alert_auth.py     (or: pytest tests/ai_agent)
 import os
 import sys
 import json
+import time
 import types
 import hmac
 import hashlib
@@ -50,14 +51,21 @@ EXCLUDED_IP = "192.168.1.1"
 GOOD_MAC = "AA:BB:CC:DD:EE:FF"
 
 
-def _sign(body: bytes) -> str:
-    return "sha256=" + hmac.new(SECRET.encode(), body, hashlib.sha256).hexdigest()
+def _sign(body: bytes, ts=None):
+    """Return (timestamp, 'sha256=<hmac>') for the replay-protected scheme: the HMAC
+    is over '<timestamp>.' + body (audit P1-1)."""
+    ts = ts or str(int(time.time()))
+    sig = "sha256=" + hmac.new(SECRET.encode(), f"{ts}.".encode() + body, hashlib.sha256).hexdigest()
+    return ts, sig
 
 
 class AlertResponseTests(unittest.TestCase):
     def setUp(self):
         agent_app.app.testing = True
         self.client = agent_app.app.test_client()
+        # The replay/nonce cache is module-level (audit P1-1); isolate it per test so
+        # identical signed requests across tests don't trip replay rejection.
+        agent_app._seen_sigs.clear()
 
         # Isolate the approval queue to a throwaway file per test.
         self._qfile = tempfile.NamedTemporaryFile(
@@ -86,21 +94,24 @@ class AlertResponseTests(unittest.TestCase):
         self.addCleanup(mock.patch.stopall)
         self.addCleanup(lambda: os.unlink(self._qfile.name))
 
-    def _post(self, payload, sign=True, tamper=False, path="/alert"):
+    def _post(self, payload, sign=True, tamper=False, path="/alert", ts=None):
         body = json.dumps(payload).encode()
         headers = {"Content-Type": "application/json"}
         if sign:
-            sig = _sign(body)
+            tstamp, sig = _sign(body, ts)
             if tamper:
                 sig = sig[:-1] + ("0" if sig[-1] != "0" else "1")
             headers["x-elastic-signature"] = sig
+            headers["x-elastic-timestamp"] = tstamp
         return self.client.post(path, data=body, headers=headers)
 
     def _get_pending(self, sign=True):
         """GET /pending is HMAC-gated; sign the (empty) body like an operator would."""
         headers = {}
         if sign:
-            headers["x-elastic-signature"] = _sign(b"")
+            tstamp, sig = _sign(b"")
+            headers["x-elastic-signature"] = sig
+            headers["x-elastic-timestamp"] = tstamp
         return self.client.get("/pending", headers=headers)
 
     # --- WS0.2 authentication ------------------------------------------------
@@ -135,6 +146,33 @@ class AlertResponseTests(unittest.TestCase):
 
     def test_pending_unsigned_rejected(self):
         r = self._get_pending(sign=False)
+        self.assertEqual(r.status_code, 401)
+
+    # --- replay protection (audit P1-1) --------------------------------------
+    def test_replayed_alert_rejected(self):
+        # A valid signed /alert is accepted once; replaying the EXACT same body +
+        # timestamp + signature is refused (nonce already seen).
+        payload = {"severity": "critical", "source_ip": "1.2.3.4", "source_mac": GOOD_MAC}
+        ts = str(int(time.time()))
+        first = self._post(payload, ts=ts)
+        self.assertEqual(first.status_code, 200)
+        replay = self._post(payload, ts=ts)              # identical -> identical signature
+        self.assertEqual(replay.status_code, 401)
+
+    def test_stale_timestamp_rejected(self):
+        # A correctly-signed request with a timestamp outside the window is refused.
+        old = str(int(time.time()) - (agent_app.HMAC_REPLAY_WINDOW + 60))
+        r = self._post({"severity": "critical", "source_mac": GOOD_MAC}, ts=old)
+        self.assertEqual(r.status_code, 401)
+        self.mock_dispatch.assert_not_called()
+
+    def test_missing_timestamp_rejected(self):
+        # A valid signature with NO timestamp header is refused (can't prove freshness).
+        body = json.dumps({"severity": "critical"}).encode()
+        _, sig = _sign(body)
+        r = self.client.post("/alert", data=body,
+                             headers={"Content-Type": "application/json",
+                                      "x-elastic-signature": sig})  # no timestamp
         self.assertEqual(r.status_code, 401)
 
     def test_weekly_report_unsigned_rejected(self):

--- a/tests/ai_agent/verify_alert_live.sh
+++ b/tests/ai_agent/verify_alert_live.sh
@@ -36,13 +36,15 @@ if [[ -z "$SECRET" ]]; then
 fi
 
 pass=0; fail=0
-sign() { printf '%s' "$1" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $NF}'; }
+# Replay-protected scheme (audit P1-1): HMAC over "<timestamp>.<body>".
+sign() { printf '%s' "${1}.${2}" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $NF}'; }
 
-# $1=label  $2=expected_code  $3=body  $4=signature-header-value ("" to omit)
+# $1=label  $2=expected_code  $3=body  $4=signature-header ("" to omit)  $5=timestamp ("" to omit)
 check() {
-  local label="$1" want="$2" body="$3" sig="${4:-}"
+  local label="$1" want="$2" body="$3" sig="${4:-}" ts="${5:-}"
   local hdr=(-H "Content-Type: application/json")
   [[ -n "$sig" ]] && hdr+=(-H "x-elastic-signature: $sig")
+  [[ -n "$ts" ]]  && hdr+=(-H "x-elastic-timestamp: $ts")
   local code
   code=$(curl -s -o /dev/null -w '%{http_code}' "${hdr[@]}" \
          --data-binary "$body" "$AGENT_URL/alert" || echo "000")
@@ -59,15 +61,17 @@ echo "[*] Agent: $AGENT_URL"
 check "unsigned request rejected" 401 \
   '{"severity":"critical","source_ip":"203.0.113.5","source_mac":""}' ""
 
-# 2. Tampered signature -> 401
+# 2. Tampered signature (valid timestamp) -> 401
 BODY='{"severity":"critical","source_ip":"203.0.113.5","source_mac":""}'
-check "tampered signature rejected" 401 "$BODY" "sha256=deadbeef"
+check "tampered signature rejected" 401 "$BODY" "sha256=deadbeef" "$(date +%s)"
 
 # 3. Correctly-signed, Logstash-exact body, EMPTY mac -> 200 (no quarantine).
 #    This is byte-for-byte what configs/logstash.conf's ruby filter emits:
-#    {"severity":"critical","source_ip":"<ip>","source_mac":"<mac>"}
+#    {"severity":"critical","source_ip":"<ip>","source_mac":"<mac>"}, signed over
+#    "<timestamp>.<body>" with the freshness timestamp sent alongside (audit P1-1).
 LS_BODY='{"severity":"critical","source_ip":"203.0.113.5","source_mac":""}'
-check "valid signature accepted (Logstash scheme)" 200 "$LS_BODY" "sha256=$(sign "$LS_BODY")"
+LS_TS=$(date +%s)
+check "valid signature accepted (Logstash scheme)" 200 "$LS_BODY" "sha256=$(sign "$LS_TS" "$LS_BODY")" "$LS_TS"
 
 # 4. OPTIONAL: signed + valid MAC -> 200. By default this is DRAFTED for approval
 #    (no router action). With AUTONOMOUS_ISOLATION=true the agent dispatches the
@@ -76,7 +80,8 @@ if [[ "${RUN_QUARANTINE:-0}" == "1" ]]; then
   echo "[!] RUN_QUARANTINE=1 — critical+MAC alert. Drafts by default; with"
   echo "    AUTONOMOUS_ISOLATION=true it dispatches to the hive-mind-broker."
   Q_BODY='{"severity":"critical","source_ip":"203.0.113.5","source_mac":"AA:BB:CC:DD:EE:FF"}'
-  check "valid signature + valid MAC accepted" 200 "$Q_BODY" "sha256=$(sign "$Q_BODY")"
+  Q_TS=$(date +%s)
+  check "valid signature + valid MAC accepted" 200 "$Q_BODY" "sha256=$(sign "$Q_TS" "$Q_BODY")" "$Q_TS"
 fi
 
 echo

--- a/tests/anomaly_simulation/sim_intel_match.sh
+++ b/tests/anomaly_simulation/sim_intel_match.sh
@@ -39,14 +39,17 @@ TENANT="${TENANT:-home-smith}"
 
 es() { curl -sk -u "${ES_USER}:${ES_PASS}" "$@"; }
 
-# /pending is HMAC-gated (audit P0-2). Sign the empty GET body with the same
-# SOC_AGENT_HMAC_SECRET the agent uses and read back the drafted-action count.
+# /pending is HMAC-gated (audit P0-2) with replay protection (audit P1-1): sign
+# "<timestamp>." + empty-body and send both x-elastic-signature and
+# x-elastic-timestamp, using the same SOC_AGENT_HMAC_SECRET the agent uses.
 agent_pending_count() {
-  local sig
+  local ts sig
   if [[ -n "${SOC_AGENT_HMAC_SECRET:-}" ]]; then
-    sig="sha256=$(printf '' | openssl dgst -sha256 -hmac "$SOC_AGENT_HMAC_SECRET" | awk '{print $2}')"
+    ts=$(date +%s)
+    sig="sha256=$(printf '%s.' "$ts" | openssl dgst -sha256 -hmac "$SOC_AGENT_HMAC_SECRET" | awk '{print $2}')"
   fi
-  curl -s --max-time 6 -H "x-elastic-signature: ${sig:-}" "$AGENT_URL/pending" \
+  curl -s --max-time 6 -H "x-elastic-signature: ${sig:-}" -H "x-elastic-timestamp: ${ts:-}" \
+    "$AGENT_URL/pending" \
     | python3 -c 'import sys,json;print(json.load(sys.stdin).get("count",0))' 2>/dev/null || echo 0
 }
 fail=0


### PR DESCRIPTION
Closes the last high-value P1 security item. The agent and broker verified an HMAC over the request **body only** — no timestamp/nonce — so a captured signed `/alert`, `/webhook/dispatch`, or `/approve` request could be replayed indefinitely (re-trigger isolation, re-draft actions, re-list the queue).

## Scheme
Every signed request now carries:
- `x-elastic-timestamp: <unix seconds>`
- `x-elastic-signature: sha256=HMAC(secret, "<timestamp>." + raw_body)`

Verifiers (agent `verify_signature`, broker `_verify`):
1. require the timestamp within ±`HMAC_REPLAY_WINDOW` (default 300s) of now (rejects stale/pre-recorded), and
2. refuse a signature already seen within the window via a pruned in-memory nonce cache — recorded **only after** the signature is proven valid, so forged signatures can't poison it.

## Every signer updated (atomic cutover)
- Logstash Ruby filter → `/alert` (now emits `x-elastic-timestamp`)
- agent → broker `/webhook/dispatch`
- operator clients: `verify_alert_live.sh`, `sim_intel_match.sh`, and the `/weekly-report` curl example

## Validation
- **Unit**: agent 20→23, broker 19→22 (added replay-rejection, stale-timestamp, and missing-timestamp tests on both; module-level nonce cache isolated per test).
- **Live** (rebuilt + recreated agent/broker/logstash):
  - `verify_alert_live.sh`: unsigned 401, tampered 401, valid (Logstash scheme) 200.
  - agent: valid **200**, exact replay **401**, stale-timestamp **401**.
  - broker `/webhook/dispatch`: gate **200**, replay **401**, stale **401**.
  - Logstash still ingests after the Ruby-signer change.

With this, **all P1 *security/pipeline/infra* items are done**; the only P1s left are documentation cleanups (P1-14 wiki report reconciliation, P1-15 SOP numbering, P1-16 doc repo-name consistency, P1-18 regenerate the stale KQL doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)