### PR TITLE
Audit P1 (final): doc accuracy — SOP numbering, repo names, report, KQL doc regen

### DIFF
--- a/.github/workflows/detections.yml
+++ b/.github/workflows/detections.yml
@@ -14,6 +14,7 @@ on:
       - "docs/detections/**"
       - "hunts/**"
       - "scripts/setup/build_attack_coverage.py"
+      - "scripts/setup/build_kql_docs.py"
       - ".github/workflows/detections.yml"
   workflow_dispatch:
 
@@ -52,6 +53,9 @@ jobs:
 
       - name: ATT&CK coverage matrix is in sync with the rules (WS1.5)
         run: python scripts/setup/build_attack_coverage.py --check
+
+      - name: SIEM KQL docs are in sync with the rules (audit P1-18)
+        run: python scripts/setup/build_kql_docs.py --check
 
       - name: Hunt library is well-formed (WS2.2)
         run: |

--- a/audit_repo.sh
+++ b/audit_repo.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # ==============================================================================
-# UIW_SOC - Repository Posture & Agile Gap Analysis
+# Suburban-SOC - Repository Posture & Agile Gap Analysis
 # ==============================================================================
 
-REPO="voltron-1/UIW_SOC"
+REPO="sterlinggarnett/Suburban_SOC"
 
 # ANSI Color Codes for terminal formatting
 GREEN='\033[0;32m'

--- a/docs/SOP-001-pipeline-operations.md
+++ b/docs/SOP-001-pipeline-operations.md
@@ -140,7 +140,7 @@ Starts a Zeek Docker container in `--network host` mode with `NET_ADMIN` and `NE
 
 ---
 
-## SOP-002: Filebeat — Install & Configure
+## SOP-001-F: Filebeat — Install & Configure
 
 **Script:** `scripts/setup/install_filebeat.sh`  
 **Owner:** SA  
@@ -187,7 +187,7 @@ sudo systemctl status filebeat
 
 ---
 
-## SOP-003: Logstash Pipeline
+## SOP-001-G: Logstash Pipeline
 
 **Config:** `configs/logstash.conf`  
 **Owner:** SA / PL  
@@ -213,7 +213,7 @@ export ELASTIC_PASSWORD=your_password_here
 
 ---
 
-## SOP-004: Clear Logs (Reset Environment)
+## SOP-001-H: Clear Logs (Reset Environment)
 
 **Script:** `scripts/setup/clear_logs.sh`  
 **Owner:** SA  
@@ -235,7 +235,7 @@ sudo ./clear_logs.sh
 
 ---
 
-## SOP-005: End-to-End Pipeline Startup Sequence
+## SOP-001-I: End-to-End Pipeline Startup Sequence
 
 Follow this order when starting the full pipeline from scratch:
 
@@ -271,4 +271,4 @@ Follow this order when starting the full pipeline from scratch:
 - [Logstash Config](../configs/logstash.conf)
 - [Zeek ELK Pipeline Docs](../docs/Zeek_ELK_Pipeline.md)
 - [Network Topology](../docs/network_topology.md)
-- [Wiki: Architecture](https://github.com/sterlinggarnett/cis3353_s26_TL_SG_MF/wiki/Architecture)
+- [Wiki: Architecture](https://github.com/sterlinggarnett/Suburban_SOC/wiki/Architecture)

--- a/docs/detections/SIEM_KQL_Documentation.md
+++ b/docs/detections/SIEM_KQL_Documentation.md
@@ -1,161 +1,160 @@
-# Suburban-SOC Detection Engineering: KQL Translation Matrix\n\nThis document contains automated KQL translations generated directly from platform-agnostic Sigma rules using the Elastic Common Schema (ECS) data model.\n\n### LSASS Memory Dump via Comsvcs.dll
-id: 22222222-2222-2222-2222-222222222222
-status: experimental
-description: Detects the use of rundll32.exe to execute the MiniDump function of comsvcs.dll to dump LSASS memory.
-logsource:
-    category: process_creation
-    product: windows
-detection:
-    selection:
-        Image|endswith: '\rundll32.exe'
-        CommandLine|contains|all:
-            - 'comsvcs.dll'
-            - 'MiniDump'
-    condition: selection
-falsepositives:
-    - Rare legitimate debugging operations.
-level: high
-tags:
-    - attack.credential_access
-    - attack.t1003.001\n**Sigma File:** `proc_creation_win_lsass_dump.yml`  \n**Target Query (KQL):**\n```text\nprocess.executable:*\\rundll32.exe AND (process.command_line:*comsvcs.dll* AND process.command_line:*MiniDump*)\n```\n---\n\n### Clearing Windows Event Logs via Wevtutil
-id: 33333333-3333-3333-3333-333333333333
-status: experimental
-description: Detects the use of wevtutil.exe to clear event logs.
-logsource:
-    category: process_creation
-    product: windows
-detection:
-    selection:
-        Image|endswith: '\wevtutil.exe'
-        CommandLine|contains:
-            - ' cl '
-            - ' clear-log '
-    condition: selection
-falsepositives:
-    - IT admin cleanup scripts.
-level: high
-tags:
-    - attack.defense_evasion
-    - attack.t1070.001\n**Sigma File:** `proc_creation_win_clear_event_logs.yml`  \n**Target Query (KQL):**\n```text\nprocess.executable:*\\wevtutil.exe AND (process.command_line:(*\ cl\ * OR *\ clear\-log\ *))\n```\n---\n\n### Scheduled Task Creation via Schtasks
-id: 44444444-4444-4444-4444-444444444444
-status: experimental
-description: Detects the creation of a new scheduled task using schtasks.exe.
-logsource:
-    category: process_creation
-    product: windows
-detection:
-    selection:
-        Image|endswith: '\schtasks.exe'
-        CommandLine|contains|all:
-            - '/create'
-            - '/tn'
-    condition: selection
-falsepositives:
-    - Software installations and updates.
-    - Legitimate administrative tasks.
-level: low
-tags:
-    - attack.execution
-    - attack.persistence
-    - attack.t1053.005\n**Sigma File:** `proc_creation_win_scheduled_task.yml`  \n**Target Query (KQL):**\n```text\nprocess.executable:*\\schtasks.exe AND (process.command_line:*\/create* AND process.command_line:*\/tn*)\n```\n---\n\n### Suspicious System Owner/User Discovery
-id: 55555555-5555-5555-5555-555555555555
-status: experimental
-description: Detects the execution of whoami.exe with the /all flag, commonly used by attackers for reconnaissance.
-logsource:
-    category: process_creation
-    product: windows
-detection:
-    selection:
-        Image|endswith: '\whoami.exe'
-        CommandLine|contains: '/all'
-    condition: selection
-falsepositives:
-    - Administrator troubleshooting.
-level: medium
-tags:
-    - attack.discovery
-    - attack.t1033\n**Sigma File:** `proc_creation_win_user_discovery.yml`  \n**Target Query (KQL):**\n```text\nprocess.executable:*\\whoami.exe AND process.command_line:*\/all*\n```\n---\n\n### Regsvr32 Execution from Remote Server
-id: 66666666-6666-6666-6666-666666666666
-status: experimental
-description: Detects regsvr32.exe attempting to execute a remote script, known as the Squiblydoo bypass.
-logsource:
-    category: process_creation
-    product: windows
-detection:
-    selection:
-        Image|endswith: '\regsvr32.exe'
-        CommandLine|contains|all:
-            - '/i:http'
-            - 'scrobj.dll'
-    condition: selection
-falsepositives:
-    - Highly unlikely.
-level: critical
-tags:
-    - attack.defense_evasion
-    - attack.t1218.010\n**Sigma File:** `proc_creation_win_regsvr32_remote_sct.yml`  \n**Target Query (KQL):**\n```text\nprocess.executable:*\\regsvr32.exe AND (process.command_line:*\/i\:http* AND process.command_line:*scrobj.dll*)\n```\n---\n\n### Malicious File Download via Bitsadmin
-id: 77777777-7777-7777-7777-777777777777
-status: experimental
-description: Detects the use of bitsadmin.exe to download files via the /transfer switch.
-logsource:
-    category: process_creation
-    product: windows
-detection:
-    selection:
-        Image|endswith: '\bitsadmin.exe'
-        CommandLine|contains: '/transfer'
-    condition: selection
-falsepositives:
-    - Legitimate background update processes.
-level: medium
-tags:
-    - attack.command_and_control
-    - attack.t1105\n**Sigma File:** `proc_creation_win_bitsadmin_download.yml`  \n**Target Query (KQL):**\n```text\nprocess.executable:*\\bitsadmin.exe AND process.command_line:*\/transfer*\n```\n---\n\n### WMI Process Call Create
-id: 88888888-8888-8888-8888-888888888888
-status: experimental
-description: Detects the use of WMIC to create a new process, a common technique for local or remote execution.
-logsource:
-    category: process_creation
-    product: windows
-detection:
-    selection:
-        Image|endswith: '\wmic.exe'
-        CommandLine|contains|all:
-            - 'process'
-            - 'call'
-            - 'create'
-    condition: selection
-falsepositives:
-    - Legitimate remote administration.
-level: medium
-tags:
-    - attack.execution
-    - attack.t1047\n**Sigma File:** `proc_creation_win_wmi_process_create.yml`  \n**Target Query (KQL):**\n```text\nprocess.executable:*\\wmic.exe AND (process.command_line:*process* AND process.command_line:*call* AND process.command_line:*create*)\n```\n---\n\n### Local User Account Creation via Net.exe
-id: 99999999-9999-9999-9999-999999999999
-status: experimental
-description: Detects the creation of a local user account using the net user command.
-logsource:
-    category: process_creation
-    product: windows
-detection:
-    selection:
-        Image|endswith:
-            - '\n**Sigma File:** `proc_creation_win_local_acct_create.yml`  \n**Target Query (KQL):**\n```text\n(process.executable:(*\\net.exe OR *\\net1.exe)) AND (process.command_line:*user* AND process.command_line:*\/add*)\n```\n---\n\n### RDP Session Hijacking via Tscon
-id: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
-status: experimental
-description: Detects the use of tscon.exe to hijack an RDP session by passing a destination session ID.
-logsource:
-    category: process_creation
-    product: windows
-detection:
-    selection:
-        Image|endswith: '\tscon.exe'
-        CommandLine|contains: '/dest:'
-    condition: selection
-falsepositives:
-    - IT administrators forcefully connecting to specific sessions.
-level: high
-tags:
-    - attack.privilege_escalation
-    - attack.lateral_movement
-    - attack.t1574\n**Sigma File:** `proc_creation_win_rdp_hijack_tscon.yml`  \n**Target Query (KQL):**\n```text\nprocess.executable:*\\tscon.exe AND process.command_line:*\/dest\:*\n```\n---\n\n
+# Suburban-SOC — SIEM Detection Queries (KQL/Lucene)
+
+> **Generated** by `scripts/setup/build_kql_docs.py` from `rules/sigma/*.yml`
+> through the `configs/detections/suburban-soc-ecs.yml` field pipeline. Do not
+> hand-edit — re-run the generator. Queries target **`process.args`** (this
+> stack's field), NOT the ECS-standard `process.command_line`.
+
+**19 rules.** Each query is the exact Lucene the Sigma rule compiles to.
+
+## Malicious File Download via Bitsadmin
+
+- **Rule:** `proc_creation_win_bitsadmin_download.yml` · **level:** medium · **status:** stable · **ATT&CK:** T1105
+
+```
+process.executable:*\\bitsadmin.exe AND process.args:*\/transfer*
+```
+
+## Payload Decoding via Certutil
+
+- **Rule:** `proc_creation_win_certutil_decode.yml` · **level:** medium · **status:** stable · **ATT&CK:** T1140
+
+```
+process.executable:*\\certutil.exe AND process.args:*decode*
+```
+
+## Clearing Windows Event Logs via Wevtutil
+
+- **Rule:** `proc_creation_win_clear_event_logs.yml` · **level:** high · **status:** stable · **ATT&CK:** T1070.001
+
+```
+process.executable:*\\wevtutil.exe AND (process.args:(*\ cl\ * OR *\ clear\-log\ *))
+```
+
+## Windows Defender Real-Time Protection Disabled
+
+- **Rule:** `proc_creation_win_defender_tamper.yml` · **level:** high · **status:** stable · **ATT&CK:** T1562.001
+
+```
+(process.executable:(*\\powershell.exe OR *\\pwsh.exe)) AND (process.args:*Set\-MpPreference* AND process.args:*Disable*)
+```
+
+## Domain Group Discovery via Net.exe
+
+- **Rule:** `proc_creation_win_domain_group_discovery.yml` · **level:** low · **status:** stable · **ATT&CK:** T1087.002
+
+```
+(process.executable:(*\\net.exe OR *\\net1.exe)) AND (process.args:*group* AND process.args:*\/domain*)
+```
+
+## Local User Account Creation via Net.exe
+
+- **Rule:** `proc_creation_win_local_acct_create.yml` · **level:** medium · **status:** stable · **ATT&CK:** T1136.001
+
+```
+(process.executable:(*\\net.exe OR *\\net1.exe)) AND (process.args:*user* AND process.args:*\/add*)
+```
+
+## LSASS Memory Dump via Comsvcs.dll
+
+- **Rule:** `proc_creation_win_lsass_dump.yml` · **level:** high · **status:** stable · **ATT&CK:** T1003.001
+
+```
+process.executable:*\\rundll32.exe AND (process.args:*comsvcs.dll* AND process.args:*MiniDump*)
+```
+
+## Mshta Remote or Script Payload Execution
+
+- **Rule:** `proc_creation_win_mshta_remote.yml` · **level:** high · **status:** stable · **ATT&CK:** T1218.005
+
+```
+process.executable:*\\mshta.exe AND (process.args:(*http* OR *javascript* OR *vbscript*))
+```
+
+## Domain Controller Discovery via Nltest
+
+- **Rule:** `proc_creation_win_nltest_discovery.yml` · **level:** medium · **status:** stable · **ATT&CK:** T1018
+
+```
+process.executable:*\\nltest.exe AND (process.args:(*\/dclist\:* OR *\/domain_trusts* OR *\/dsgetdc\:*))
+```
+
+## Suspicious PowerShell Encoded Command Execution
+
+- **Rule:** `proc_creation_win_powershell_encoded.yml` · **level:** medium · **status:** stable · **ATT&CK:** T1059.001
+
+```
+(process.executable:(*\\powershell.exe OR *\\pwsh.exe)) AND (process.args:(*\ \-enc* OR *\ \-EncodedCommand* OR *\ \-ec\ *))
+```
+
+## RDP Session Hijacking via Tscon
+
+- **Rule:** `proc_creation_win_rdp_hijack_tscon.yml` · **level:** high · **status:** stable · **ATT&CK:** T1574
+
+```
+process.executable:*\\tscon.exe AND process.args:*\/dest\:*
+```
+
+## SAM Hive Dump via Reg.exe
+
+- **Rule:** `proc_creation_win_reg_save_sam.yml` · **level:** high · **status:** stable · **ATT&CK:** T1003.002
+
+```
+process.executable:*\\reg.exe AND (process.args:*save* AND process.args:*hklm\\sam*)
+```
+
+## Regsvr32 Execution from Remote Server
+
+- **Rule:** `proc_creation_win_regsvr32_remote_sct.yml` · **level:** critical · **status:** stable · **ATT&CK:** T1218.010
+
+```
+process.executable:*\\regsvr32.exe AND (process.args:*\/i\:http* AND process.args:*scrobj.dll*)
+```
+
+## Registry Run Key Persistence via Reg.exe
+
+- **Rule:** `proc_creation_win_run_key_persistence.yml` · **level:** medium · **status:** stable · **ATT&CK:** T1547.001
+
+```
+process.executable:*\\reg.exe AND (process.args:*add* AND process.args:*CurrentVersion\\Run*)
+```
+
+## Scheduled Task Creation via Schtasks
+
+- **Rule:** `proc_creation_win_scheduled_task.yml` · **level:** low · **status:** stable · **ATT&CK:** T1053.005
+
+```
+process.executable:*\\schtasks.exe AND (process.args:*\/create* AND process.args:*\/tn*)
+```
+
+## Windows Service Creation via Sc.exe
+
+- **Rule:** `proc_creation_win_service_creation_sc.yml` · **level:** medium · **status:** stable · **ATT&CK:** T1543.003
+
+```
+process.executable:*\\sc.exe AND (process.args:*create* AND process.args:*binpath*)
+```
+
+## Suspicious System Owner/User Discovery
+
+- **Rule:** `proc_creation_win_user_discovery.yml` · **level:** medium · **status:** stable · **ATT&CK:** T1033
+
+```
+process.executable:*\\whoami.exe AND process.args:*\/all*
+```
+
+## Shadow Copy Deletion via Vssadmin
+
+- **Rule:** `proc_creation_win_vss_delete_shadows.yml` · **level:** high · **status:** stable · **ATT&CK:** T1490
+
+```
+process.executable:*\\vssadmin.exe AND (process.args:*delete* AND process.args:*shadows*)
+```
+
+## WMI Process Call Create
+
+- **Rule:** `proc_creation_win_wmi_process_create.yml` · **level:** medium · **status:** stable · **ATT&CK:** T1047
+
+```
+process.executable:*\\wmic.exe AND (process.args:*process* AND process.args:*call* AND process.args:*create*)
+```

--- a/docs/master_pipeline_guide.md
+++ b/docs/master_pipeline_guide.md
@@ -2,7 +2,7 @@
 
 > **Version 2.0** | Ubuntu 24.04 LTS (noble) | ELK 9.3.2 | Zeek 6.x | May 2026  
 > **Repo:** [voltron-1/Suburban-SOC](https://github.com/voltron-1/Suburban-SOC)  
-> **Upstream:** [sterlinggarnett/cis3353_s26_TL_SG_MF](https://github.com/sterlinggarnett/cis3353_s26_TL_SG_MF)
+> **Upstream:** [sterlinggarnett/Suburban_SOC](https://github.com/sterlinggarnett/Suburban_SOC)
 
 This document contains every bash command needed to deploy and test the Suburban SOC pipeline — from a fresh machine through to verified live data in Kibana.
 
@@ -139,7 +139,7 @@ git clone https://github.com/voltron-1/Suburban-SOC.git
 cd Suburban-SOC
 
 # Add the upstream course repo as a remote
-git remote add upstream https://github.com/sterlinggarnett/cis3353_s26_TL_SG_MF.git
+git remote add upstream https://github.com/sterlinggarnett/Suburban_SOC.git
 
 # Confirm both remotes
 git remote -v

--- a/evidence/README.md
+++ b/evidence/README.md
@@ -4,7 +4,7 @@
 >
 > Screenshots are stored in two locations:
 > - **Repository:** `evidence/screenshots/` (GitHub-hosted, linked below)
-> - **Wiki:** [cis3353_s26_TL_SG_MF Wiki](https://github.com/sterlinggarnett/cis3353_s26_TL_SG_MF/wiki) (drag-and-drop uploads)
+> - **Wiki:** [Suburban_SOC Wiki](https://github.com/sterlinggarnett/Suburban_SOC/wiki) (drag-and-drop uploads)
 
 ---
 
@@ -12,12 +12,12 @@
 
 | # | Description | Type | SHA-256 Hash | Links |
 |---|---|---|---|---|
-| 1 | Kibana GeoIP Map — live network traffic origins plotted by geographic location, confirming Logstash GeoIP enrichment is working end-to-end | Screenshot | `3a8527bd2bd17150b7cbff04bdf95d53ea268f3ba43704580eab9ff3c9ba68db` | [Repo](screenshots/kibana-geoip-map.png) · [Wiki](https://github.com/sterlinggarnett/cis3353_s26_TL_SG_MF/wiki/kibana-geoip-map) |
-| 2 | Kibana Pie Chart — protocol and traffic distribution breakdown, confirming Zeek JSON logs are indexed and queryable in Elasticsearch | Screenshot | `168ba0532de146713b0fee27dbfb537b5c9aa2f29a8b7183472a2406306679a8` | [Repo](screenshots/kibana-pie-chart.png) · [Wiki](https://github.com/sterlinggarnett/cis3353_s26_TL_SG_MF/wiki/kibana-pie-chart) |
-| 3 | Kibana Threat Intelligence Panel — security notice visualization confirming Zeek notice logs are flowing through the full pipeline into Kibana dashboards | Screenshot | `d5971c97d3c75253613d1da44887a0e55eb11350f477e6bce3edddc8d36ee70f` | [Repo](screenshots/kibana-intel-panel.png) · [Wiki](https://github.com/sterlinggarnett/cis3353_s26_TL_SG_MF/wiki/kibana-intel-panel) |
+| 1 | Kibana GeoIP Map — live network traffic origins plotted by geographic location, confirming Logstash GeoIP enrichment is working end-to-end | Screenshot | `3a8527bd2bd17150b7cbff04bdf95d53ea268f3ba43704580eab9ff3c9ba68db` | [Repo](screenshots/kibana-geoip-map.png) · [Wiki](https://github.com/sterlinggarnett/Suburban_SOC/wiki/kibana-geoip-map) |
+| 2 | Kibana Pie Chart — protocol and traffic distribution breakdown, confirming Zeek JSON logs are indexed and queryable in Elasticsearch | Screenshot | `168ba0532de146713b0fee27dbfb537b5c9aa2f29a8b7183472a2406306679a8` | [Repo](screenshots/kibana-pie-chart.png) · [Wiki](https://github.com/sterlinggarnett/Suburban_SOC/wiki/kibana-pie-chart) |
+| 3 | Kibana Threat Intelligence Panel — security notice visualization confirming Zeek notice logs are flowing through the full pipeline into Kibana dashboards | Screenshot | `d5971c97d3c75253613d1da44887a0e55eb11350f477e6bce3edddc8d36ee70f` | [Repo](screenshots/kibana-intel-panel.png) · [Wiki](https://github.com/sterlinggarnett/Suburban_SOC/wiki/kibana-intel-panel) |
 | 4 | Kibana Network Analysis Overview — dashboard displaying source IPs, MAC addresses, and network bytes, confirming custom Logstash ECS mapping | Screenshot | `[Pending User Upload]` | [Repo](screenshots/kibana-network-analysis.png) |
 | 5 | Logstash Pipeline Configuration — documents the Filebeat→Logstash→Elasticsearch connection with GeoIP enrichment, ECS field mapping, and daily index routing | Config File | `04793dccd031899c00d76e768ba7eb59ce997f9255a3e26a76d133d58a81d08a` | [Repo](../configs/logstash.conf) |
-| 6 | Architecture Diagram — full pipeline diagram (OpenWrt → Zeek → Logstash → Elasticsearch → Kibana) with runtime environments and port numbers labeled | Diagram | `e2a59fc5c07432719a484aa7773bda166b46b90634925235fac07bce8064b40f` | [Repo](../docs/architecture-diagram.png) · [Wiki](https://github.com/sterlinggarnett/cis3353_s26_TL_SG_MF/wiki/Architecture) |
+| 6 | Architecture Diagram — full pipeline diagram (OpenWrt → Zeek → Logstash → Elasticsearch → Kibana) with runtime environments and port numbers labeled | Diagram | `e2a59fc5c07432719a484aa7773bda166b46b90634925235fac07bce8064b40f` | [Repo](../docs/architecture-diagram.png) · [Wiki](https://github.com/sterlinggarnett/Suburban_SOC/wiki/Architecture) |
 
 ---
 

--- a/reports/final_report_draft.md
+++ b/reports/final_report_draft.md
@@ -32,13 +32,15 @@ The Suburban-SOC project addresses the growing need for enhanced cybersecurity i
 *   **Kibana Dashboard:** A user-friendly interface visualizes network trends and anomalies, allowing SOC analysts to monitor both real-time and historical security events.
 
 ## SOAR Response Layer
-*   **Trigger:** A Kibana Watcher (`soar_quarantine_alert`, `rules/elastic_watcher/soar_quarantine_alert.json`) polls every minute against `logstash-security-*` and fires on any of three detection paths:
-    *   **IOC C2 Comms** — `zeek.conn` events with a `threat.indicator.domain` field populated.
-    *   **Port Scan** — `zeek.notice` events where `note = Scan::Port_Scan`.
-    *   **SSH Brute Force** — 5 or more `auth_success=false` events from the same `source.ip` in `zeek.ssh` within the polling window (enforced via aggregation `min_doc_count: 5`).
+*   **Trigger:** Two complementary detection paths feed the AI agent's signed `/alert` webhook:
+    *   **Live Intel / C2 (ingest-time)** — `configs/logstash.conf` signs and POSTs `/alert` the moment a Zeek **Intel-framework** match is enriched to `threat.indicator.value` (WS1.1). This replaces the legacy `threat.indicator.domain` path, which the pipeline never populates.
+    *   **Kibana Watcher** (`soar_quarantine_alert`, `rules/elastic_watcher/soar_quarantine_alert.json`) polls every minute against `logstash-security-*` and fires on:
+        *   **Port Scan** — `zeek.notice` events where `note = Scan::Port_Scan`.
+        *   **SSH Brute Force** — 5 or more `auth_success=false` events from the same `source.ip` in `zeek.ssh` within the polling window (`min_doc_count: 5`).
+    *   *(The watcher still carries a legacy `threat.indicator.domain` clause; because that field is unpopulated, live-intel detection runs through the Logstash path above — not the watcher.)*
 *   **AI Triage:** The Flask-based `soc_ai_agent` service (port `5000`) receives the Watcher webhook, calls an LLM (`llama3.1` via local Ollama by default; hosted model gated behind `LLM_ALLOW_HOSTED=true`) to summarize the threat and map it to MITRE ATT&CK, and classifies severity.
 *   **Human-Approval Queue:** Per CDP §12.3, the agent drafts an isolation action and enqueues it for a human-of-record to approve via `POST /approve`. Because `/approve` (and `/pending`) execute/disclose containment, both are HMAC-authenticated to the same bar as `/alert` — the caller signs the request body with `SOC_AGENT_HMAC_SECRET` (`x-elastic-signature`), and an unsigned call fails closed (401). Autonomous execution is gated behind `AUTONOMOUS_ISOLATION=true`.
-*   **Quarantine:** Upon approval (or autonomous flag), `isolate.sh` SSHes into the OpenWrt router and installs a persistent `uci` MAC-based DROP firewall rule (`SOAR_QUARANTINE_<MAC>`). The rule is idempotent and survives DHCP rotation.
+*   **Quarantine:** Upon approval (or the autonomous flag), the slim agent — which has no ssh/sudo — routes containment to the **Hive-Mind Broker** over an HMAC-signed, replay-protected webhook (#109). The broker applies an `nftables` DROP for the attacker IP (`nft add rule inet fw4 input ip saddr <ip> drop`) on the alerting tenant's OpenWrt router(s) from its per-tenant inventory; it never broadcasts across tenants. (The standalone `isolate.sh` MAC-based `uci` rule is the legacy single-router path it replaced.)
 *   **Exclusion List:** The `governance/exclusion_list.txt` prevents the agent from ever isolating core infrastructure (e.g., the gateway itself).
 *   **Notifications:** ntfy mobile push + Discord SOC channel embed delivered in parallel, both carrying device IP, MAC, reason, and the AI-generated analysis.
 *   **Weekly CISO Report:** `POST /weekly-report` triggers an automated pipeline (`weekly_ciso_report.py`) that queries Elasticsearch for alert metrics, computes MTTD and NIST CSF distribution, generates an LLM executive summary, compiles a PDF via WeasyPrint, and delivers it to Slack + ntfy.

--- a/scripts/setup/build_kql_docs.py
+++ b/scripts/setup/build_kql_docs.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Generate docs/detections/SIEM_KQL_Documentation.md from the Sigma rules.
+
+The previous doc was hand-snapshotted, went stale (covered 9 of 19 rules), and —
+worst — emitted process.command_line, which this stack does NOT populate
+(configs/detections/suburban-soc-ecs.yml maps to process.args). Generating the doc
+from rules/sigma/*.yml through that same ECS pipeline keeps the documented queries
+identical to what actually deploys (audit P1-18).
+
+Requires the Sigma toolchain (same as the Detections CI):
+    pip install sigma-cli pysigma-backend-elasticsearch
+Run:
+    python scripts/setup/build_kql_docs.py            # write the doc
+    python scripts/setup/build_kql_docs.py --check    # fail if the doc is stale
+"""
+import glob
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+RULES = sorted(glob.glob(str(ROOT / "rules" / "sigma" / "*.yml")))
+PIPELINE = str(ROOT / "configs" / "detections" / "suburban-soc-ecs.yml")
+OUT = ROOT / "docs" / "detections" / "SIEM_KQL_Documentation.md"
+
+
+def lucene_for(rule_path: str) -> str:
+    """Convert a Sigma rule to a Lucene/KQL query via the suburban-soc-ecs pipeline."""
+    proc = subprocess.run(
+        ["sigma", "convert", "-t", "lucene", "-p", PIPELINE, rule_path],
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        raise SystemExit(f"sigma convert failed for {rule_path}:\n{proc.stderr}")
+    # The CLI prints a "Parsing Sigma rules" banner first; the query is the last
+    # non-empty line.
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip()
+             and not ln.startswith("Parsing")]
+    return lines[-1].strip() if lines else ""
+
+
+def render() -> str:
+    out = [
+        "# Suburban-SOC — SIEM Detection Queries (KQL/Lucene)",
+        "",
+        "> **Generated** by `scripts/setup/build_kql_docs.py` from `rules/sigma/*.yml`",
+        "> through the `configs/detections/suburban-soc-ecs.yml` field pipeline. Do not",
+        "> hand-edit — re-run the generator. Queries target **`process.args`** (this",
+        "> stack's field), NOT the ECS-standard `process.command_line`.",
+        "",
+        f"**{len(RULES)} rules.** Each query is the exact Lucene the Sigma rule compiles to.",
+        "",
+    ]
+    for path in RULES:
+        with open(path, encoding="utf-8") as fh:
+            rule = yaml.safe_load(fh) or {}
+        title = rule.get("title", Path(path).stem)
+        level = rule.get("level", "?")
+        status = rule.get("status", "?")
+        tags = [t.upper().replace("ATTACK.", "") for t in rule.get("tags", [])
+                if str(t).lower().startswith("attack.t")]
+        attack = ", ".join(tags) if tags else "—"
+        out += [
+            f"## {title}",
+            "",
+            f"- **Rule:** `{Path(path).name}` · **level:** {level} · "
+            f"**status:** {status} · **ATT&CK:** {attack}",
+            "",
+            "```",
+            lucene_for(path),
+            "```",
+            "",
+        ]
+    return "\n".join(out)
+
+
+def main():
+    doc = render()
+    if "--check" in sys.argv:
+        current = OUT.read_text(encoding="utf-8") if OUT.exists() else ""
+        if current.strip() != doc.strip():
+            print("SIEM_KQL_Documentation.md is STALE — re-run build_kql_docs.py", file=sys.stderr)
+            sys.exit(1)
+        print("SIEM_KQL_Documentation.md is up to date.")
+        return
+    OUT.write_text(doc, encoding="utf-8")
+    print(f"Wrote {OUT} ({len(RULES)} rules).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The last four P1 items — all documentation accuracy. Completes P1.

| Audit item | Fix |
|---|---|
| **P1-15** | SOP-001's internal `SOP-002/003/004/005` collided with the standalone SOP-003/004/005. Renumbered to `SOP-001-F/G/H/I` (continuing the A–E series; no external refs pointed at them). |
| **P1-16** | Corrected stale repo names to the real slug `sterlinggarnett/Suburban_SOC` — `audit_repo.sh` targeted `voltron-1/UIW_SOC`, and wiki links in SOP-001 / master_pipeline_guide / evidence used the old `cis3353_s26_TL_SG_MF`. |
| **P1-18** | `SIEM_KQL_Documentation.md` was a stale snapshot (9/19 rules, literal `\n`, and `process.command_line` which this stack doesn't populate). Added `scripts/setup/build_kql_docs.py` to generate it from `rules/sigma/*.yml` through the `suburban-soc-ecs` pipeline (→ `process.args`), regenerated it (19 rules), and wired `--check` into the Detections CI so it can't drift again. |
| **P1-14** | The final report draft described a dead `threat.indicator.domain` watcher trigger and direct `isolate.sh` SSH. Corrected to reality: ingest-time Logstash signer on `threat.indicator.value` (WS1.1) + the watcher's port-scan/SSH-brute paths; containment via the hive-mind broker's HMAC/replay-protected nftables DROP (#109). |

## Notes
- P1-18 doc was regenerated with the real Sigma toolchain and verified (`--check` passes; 160 lines, real `process.args`).
- P1-14: the duplicate report copy lives in the **uninitialized `wiki-temp` gitlink submodule** (no `.gitmodules`) and can't be edited from the superproject — flagged in the commit; it needs the same correction (and the orphan gitlink itself is audit P2-4).

## P1 complete
With this PR, **all ~19 P1 items are addressed** (security/pipeline/infra in #142–#144, docs here). Remaining audit work is P2/P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)