### PR TITLE
docs: point README + evidence/README at the real-telemetry validation issue (#147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,10 @@ Please see our Wiki for detailed procedures on contributing to this project. We 
 ### 2. Manual Testing:
 * Generating sample PCAP files containing known traffic signatures and verifying their appearance in the Kibana dashboard accurately.
 
+### 3. Evidence & Real-Telemetry Validation:
+* Dashboard and detection evidence must come from **real telemetry, not mock data**. The [`tests/anomaly_simulation/`](tests/anomaly_simulation) suite drives real techniques end-to-end (port scan `T1046`, SSH brute force `T1110`, EICAR download, live intel match), and `verify_detections.py` confirms the signals reached the SIEM.
+* The full re-validation effort - evidence checklist (all dashboards + the detection->SOAR loop + platform integrity), reviewer instructions, and the SOC metrics to record (MTTD / MTTR / coverage / ingest-lag / SLO attainment) - is tracked in **[issue #147](https://github.com/sterlinggarnett/Suburban_SOC/issues/147)**. Some existing `evidence/` screenshots predate this and are being re-captured (audit **P0-4**).
+
 ## License
 This project is licensed under the MIT License. (Make sure you include a `LICENSE` file to accompany this).
 

--- a/evidence/README.md
+++ b/evidence/README.md
@@ -5,6 +5,8 @@
 > Screenshots are stored in two locations:
 > - **Repository:** `evidence/screenshots/` (GitHub-hosted, linked below)
 > - **Wiki:** [Suburban_SOC Wiki](https://github.com/sterlinggarnett/Suburban_SOC/wiki) (drag-and-drop uploads)
+>
+> **Re-capture in progress (audit P0-4).** Some screenshots below predate the security audit and may have been generated from **mock data**. They are being re-captured from **real telemetry** and re-verified per [issue #147](https://github.com/sterlinggarnett/Suburban_SOC/issues/147) (evidence checklist + reviewer instructions). Treat any row not yet re-verified as **PENDING**.
 
 ---
 


### PR DESCRIPTION
Makes the evidence/validation effort discoverable:
- **README** → new "Evidence & Real-Telemetry Validation" subsection in Testing & Validation, linking #147 + the `tests/anomaly_simulation/` suite.
- **evidence/README.md** → a PENDING re-capture banner flagging that existing screenshots predate the audit (P0-4) and are being re-verified per #147.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)