### PR TITLE
fix(#164): validate attacker_ip before it reaches nft/SSH in hive-mind-broker

### DIFF
--- a/planned_execution.md
+++ b/planned_execution.md
@@ -9,20 +9,45 @@ Status: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
 
 ## NEXT UP
 
-**Phase: SOP-147 dashboard validation — COMPLETE. Open-issue backlog is empty.**
+**Phase: Structural Health Review Remediation — Priority 1 (Critical).**
+Source: repo-wide structural/NIST-CSF-2.0/SP-800-53-Rev.5-aligned review,
+2026-07-08 — 14 issues filed (#164-#177) and linked to
+[Project Board #17](https://github.com/users/voltron-1/projects/17).
 
-Next unstarted item: none. Define the next phase with the owner.
+Next unstarted item: **#165** — SLO metrics & threat hunts silently swallow ES
+errors as false negatives (NIST SI-11).
 
-- [x] **#160** — zeek.ssl SNI/Cipher panels ECS-normalized + rendering live ([PR #162](https://github.com/voltron-1/Suburban_SOC/pull/162), merged; issue closed).
-- [x] **#161** — Failed SSH by Country geoip/grok fix + rendering live ([PR #162](https://github.com/voltron-1/Suburban_SOC/pull/162), merged; issue closed).
+- [~] **#164** — Broker: unvalidated `attacker_ip` reached the `nft`/SSH command
+  sink (NIST SP 800-53 Rev.5 SI-10 / CSF 2.0 PR.PS-06). Fixed + tested on branch
+  `remediation/issue-164-nist` (commit `beaac0b`); broker suite 23→29 tests, all
+  passing. [PR #178](https://github.com/voltron-1/Suburban_SOC/pull/178) opened
+  — awaiting review/merge.
+- [ ] **#165** — SLO metrics & threat hunts silently swallow ES errors as false
+  negatives (SI-11).
+- [ ] **#166** — Bash admin tooling skips TLS verification (`curl -k`) while
+  sending ES credentials (SC-8).
+- [ ] **#167** — Unhardened systemd units + `elastic` superuser default in host
+  automation (AC-6, CM-7).
 
-Evidence: `findings/20260707-160-161-logstash-ecs-geoip.md`. Pipeline config reloaded on the
-running Logstash (container restarted) — forward enrichment active.
+P2 (next sprint, #168-#172) and P3 (backlog, #173-#177) are tracked on
+[Project Board #17](https://github.com/users/voltron-1/projects/17); not
+individually sequenced here until the P1 critical items above clear.
 
 ---
 
 ## LAST SESSION — 2026-07-08
 
+- Principal-engineer structural health review of the full repo (architecture map,
+  robustness/access-control gap analysis mapped to NIST CSF 2.0 + SP 800-53
+  Rev.5, sustainability/test/resource-management lenses). Filed 14 issues
+  (#164-#177: P1 critical ×4, P2 medium ×5, P3 low ×5) with evidence, control
+  mappings, and acceptance criteria; labeled by priority/nist-compliance/
+  tech-debt/security; linked to [Project Board #17](https://github.com/users/voltron-1/projects/17).
+- Started remediation: **#164** fixed (unvalidated `attacker_ip` in
+  hive-mind-broker reaching the `nft`/SSH sink — SI-10/PR.PS-06). Branch
+  `remediation/issue-164-nist`, commit `beaac0b`, broker suite 23→29 passing.
+  [PR #178](https://github.com/voltron-1/Suburban_SOC/pull/178) opened, not
+  yet merged.
 - #160/#161: shipped pipeline ECS fixes + HIGH source.ip-spoof hardening (parallel
   code-reviewer + security-auditor); **PR #162 merged, both issues closed.** Live investigation
   found two extra root causes the issues missed: (1) panels bucket on `.keyword` subfields

--- a/scripts/hive-mind-broker/app.py
+++ b/scripts/hive-mind-broker/app.py
@@ -10,7 +10,7 @@ import re
 import threading
 
 from inventory import Inventory
-from dispatcher import dispatch_block_to_all, is_excluded_ip
+from dispatcher import dispatch_block_to_all, is_excluded_ip, validate_ip
 
 app = FastAPI(title="Hive-Mind Broker")
 
@@ -128,6 +128,10 @@ async def receive_alert(request: Request, background_tasks: BackgroundTasks):
     attacker_ip = payload.get("attacker_ip")
     if not attacker_ip:
         raise HTTPException(status_code=400, detail="Payload missing attacker_ip")
+    try:
+        validate_ip(attacker_ip)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="attacker_ip is not a valid IP address")
 
     # §12.4: refuse to act against protected infrastructure, signed or not.
     if is_excluded_ip(attacker_ip):
@@ -187,6 +191,10 @@ async def dispatch_block(request: Request):
     attacker_ip = payload.get("attacker_ip")
     if not attacker_ip:
         raise HTTPException(status_code=400, detail="Payload missing attacker_ip")
+    try:
+        validate_ip(attacker_ip)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="attacker_ip is not a valid IP address")
     approver = str(payload.get("approver", "soc-ai-agent"))
 
     # §12.4: refuse protected infrastructure, signed or not.
@@ -249,7 +257,14 @@ async def approve(request: Request):
         raise HTTPException(status_code=404, detail=f"no pending action {action_id}")
 
     attacker_ip = action["attacker_ip"]
-    if is_excluded_ip(attacker_ip):  # re-check at execution time
+    try:
+        excluded = is_excluded_ip(attacker_ip)  # re-check at execution time
+    except ValueError:
+        _append_action({"id": action_id, "ts": time.time(), "status": "denied",
+                        "approver": approver, "result": "invalid attacker_ip"})
+        raise HTTPException(status_code=422,
+                            detail=f"invalid attacker_ip in drafted action {action_id}")
+    if excluded:
         _append_action({"id": action_id, "ts": time.time(), "status": "denied",
                         "approver": approver, "result": "exclusion list"})
         raise HTTPException(status_code=422, detail=f"{attacker_ip} is excluded")

--- a/scripts/hive-mind-broker/dispatcher.py
+++ b/scripts/hive-mind-broker/dispatcher.py
@@ -77,15 +77,28 @@ def load_excluded_ips() -> set:
     return ips
 
 
+def validate_ip(attacker_ip) -> "ipaddress._BaseAddress":
+    """Validate attacker_ip is a well-formed IPv4/IPv6 address string.
+
+    Raises ValueError if attacker_ip is not a string, or is not a parseable IP
+    address (audit #164 / NIST SI-10) — callers must reject malformed input
+    rather than letting it reach a firewall command or SSH-executed string."""
+    if not isinstance(attacker_ip, str):
+        raise ValueError(f"attacker_ip must be a string, got {type(attacker_ip).__name__}")
+    return ipaddress.ip_address(attacker_ip)
+
+
 def is_excluded_ip(attacker_ip: str) -> bool:
     """True if attacker_ip falls inside any excluded address/CIDR (v4 or v6).
 
     Fails CLOSED: if the exclusion list can't be read, return True so the broker
-    refuses to dispatch a block for ANY asset until the list is restored (§12.4)."""
-    try:
-        addr = ipaddress.ip_address(attacker_ip)
-    except ValueError:
-        return False
+    refuses to dispatch a block for ANY asset until the list is restored (§12.4).
+
+    Raises ValueError if attacker_ip is not a parseable IP address (audit #164 /
+    NIST SI-10) — a malformed address is refused outright instead of silently
+    being treated as "not excluded", which previously let unvalidated input
+    reach build_nft_command."""
+    addr = validate_ip(attacker_ip)
     try:
         entries = load_excluded_ips()
     except ExclusionListUnavailable:
@@ -103,6 +116,7 @@ def is_excluded_ip(attacker_ip: str) -> bool:
 # Drops traffic from the specified IP on the OpenWrt input chain.
 # Note: For OpenWrt 22.03+, we assume 'inet fw4 input' is the default target chain.
 def build_nft_command(attacker_ip: str) -> str:
+    validate_ip(attacker_ip)  # raises ValueError for malformed input (audit #164 / NIST SI-10)
     return f"nft add rule inet fw4 input ip saddr {attacker_ip} drop"
 
 async def block_ip_on_router(router: dict, attacker_ip: str):

--- a/scripts/hive-mind-broker/test_app.py
+++ b/scripts/hive-mind-broker/test_app.py
@@ -117,6 +117,20 @@ def test_excluded_ip_refused(_no_real_ssh):
     assert _get_pending().json()["count"] == 0
 
 
+# --- audit #164: attacker_ip must be a valid IP before it reaches nft/SSH ------
+def test_alert_injection_string_rejected(_no_real_ssh):
+    r = _post({"attacker_ip": "1.1.1.1 drop; reboot #", "tenant_id": TENANT})
+    assert r.status_code == 400
+    _no_real_ssh.assert_not_awaited()
+    assert _get_pending().json()["count"] == 0
+
+
+def test_alert_hostname_rejected(_no_real_ssh):
+    r = _post({"attacker_ip": "not-an-ip.example.com", "tenant_id": TENANT})
+    assert r.status_code == 400
+    _no_real_ssh.assert_not_awaited()
+
+
 def _post_dispatch(payload, sign=True, tamper=False, ts=None):
     body = json.dumps(payload).encode("utf-8")
     return client.post("/webhook/dispatch", data=body,
@@ -154,6 +168,27 @@ def test_dispatch_excluded_ip_refused(_no_real_ssh):
     assert r.json()["executed"] is False
     assert "exclusion list" in r.json()["message"].lower()
     _no_real_ssh.assert_not_awaited()
+
+
+# --- audit #164: attacker_ip must be a valid IP before it reaches nft/SSH ------
+def test_dispatch_injection_string_rejected(_no_real_ssh):
+    r = _post_dispatch({"attacker_ip": "1.1.1.1 drop; reboot #", "tenant_id": TENANT})
+    assert r.status_code == 400
+    _no_real_ssh.assert_not_awaited()
+
+
+def test_dispatch_hostname_rejected(_no_real_ssh):
+    r = _post_dispatch({"attacker_ip": "not-an-ip.example.com", "tenant_id": TENANT})
+    assert r.status_code == 400
+    _no_real_ssh.assert_not_awaited()
+
+
+def test_dispatch_valid_ipv6_still_dispatches(_no_real_ssh):
+    # Regression guard: the #164 validation must not break legitimate IPv6 input.
+    r = _post_dispatch({"attacker_ip": "2001:db8::dead:beef", "tenant_id": TENANT})
+    assert r.status_code == 200
+    assert r.json()["executed"] is True
+    _no_real_ssh.assert_awaited_once()
 
 
 def test_dispatch_unknown_tenant_is_no_op(_no_real_ssh):
@@ -195,6 +230,20 @@ def test_approve_invalid_signature_rejected(_no_real_ssh):
                  if a["attacker_ip"] == "9.9.9.9"][0]["id"]
     r = _approve({"id": action_id, "approver": "attacker"}, tamper=True)
     assert r.status_code == 401
+    _no_real_ssh.assert_not_awaited()
+
+
+# --- audit #164: a corrupted queue entry must not crash /approve --------------
+def test_approve_corrupted_queue_entry_rejected(_no_real_ssh):
+    # Simulate a drafted action whose attacker_ip was never validated (e.g. a
+    # manually-edited or pre-#164 queue file) rather than relying on _post,
+    # which now validates at draft time and could never produce this state.
+    broker_app._append_action({
+        "id": "deadbeef0001", "ts": time.time(), "status": "pending",
+        "tenant": TENANT, "attacker_ip": "not-an-ip", "router_count": 1,
+    })
+    r = _approve({"id": "deadbeef0001", "approver": "analyst1"})
+    assert r.status_code == 422
     _no_real_ssh.assert_not_awaited()
 
 
@@ -255,4 +304,8 @@ def test_exclusion_supports_cidr_and_ipv6():
         assert dispatcher.is_excluded_ip("10.0.1.5") is False     # outside it
         assert dispatcher.is_excluded_ip("2001:db8::1") is True   # IPv6 in the /32
         assert dispatcher.is_excluded_ip("2001:dead::1") is False
-        assert dispatcher.is_excluded_ip("not-an-ip") is False
+        # audit #164: a malformed address must be REJECTED, not silently
+        # treated as "not excluded" (which previously let it flow on to
+        # build_nft_command / an SSH-executed command).
+        with pytest.raises(ValueError):
+            dispatcher.is_excluded_ip("not-an-ip")


### PR DESCRIPTION
## Summary
- `dispatcher.py` f-string-interpolated `attacker_ip` directly into an `nft` firewall command executed over root SSH, and `is_excluded_ip()` silently returned `False` (not excluded) for a malformed address rather than rejecting it — so unvalidated input from `/webhook/alert`, `/webhook/dispatch`, and `/approve` could reach the command sink.
- Adds `validate_ip()` (string-typed `ipaddress.ip_address`) and calls it at the two webhook boundaries (HTTP 400 on failure) and inside `is_excluded_ip()`/`build_nft_command()` as defense-in-depth. `/approve`'s re-check now converts a malformed queued `attacker_ip` into a 422 instead of an unhandled exception.
- Control mapping: NIST SP 800-53 Rev.5 SI-10 (Information Input Validation); NIST CSF 2.0 PR.PS-06.

## Test plan
- [x] Broker suite: 23 → 29 tests, all passing (`python -m pytest test_app.py -q`, isolated venv mirroring `soar-tests.yml`'s pinned deps)
- [x] New coverage: injection-string + hostname rejection on both webhooks (400, zero SSH dispatch), valid-IPv6 regression guard (still dispatches), corrupted-queue-entry guard on `/approve` (422, not a 500)
- [x] Repo-wide grep confirms `build_nft_command` is the only f-string construction of the nft command, and it now validates first
- [x] Grep-confirmed `dispatcher.py` has no callers outside `app.py`/`test_app.py` — blast radius fully contained

Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)