### PR TITLE
fix(#165): distinguish measurement errors from legitimate no-data in SLO/hunts

### DIFF
--- a/.github/workflows/soar-tests.yml
+++ b/.github/workflows/soar-tests.yml
@@ -42,6 +42,9 @@ jobs:
       - name: AI agent — HMAC auth, exclusion list, approval flow (WS0.2 / §12.3 / §12.4 / P0-2)
         run: python tests/ai_agent/test_alert_auth.py
 
+      - name: SLO metrics — measurement-error visibility (audit #165 / NIST SI-11)
+        run: python tests/ai_agent/test_slo_metrics.py
+
       - name: Hive-mind broker — HMAC, dispatch, tenant scoping (P0-2)
         working-directory: scripts/hive-mind-broker
         run: |

--- a/planned_execution.md
+++ b/planned_execution.md
@@ -9,20 +9,56 @@ Status: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
 
 ## NEXT UP
 
-**Phase: SOP-147 dashboard validation — COMPLETE. Open-issue backlog is empty.**
+**Phase: Structural Health Review Remediation — Priority 1 (Critical).**
+Source: repo-wide structural/NIST-CSF-2.0/SP-800-53-Rev.5-aligned review,
+2026-07-08 — 14 issues filed (#164-#177) and linked to
+[Project Board #17](https://github.com/users/voltron-1/projects/17).
 
-Next unstarted item: none. Define the next phase with the owner.
+Next unstarted item: **#166** — Bash admin tooling skips TLS verification
+(`curl -k`) while sending ES credentials (SC-8).
 
-- [x] **#160** — zeek.ssl SNI/Cipher panels ECS-normalized + rendering live ([PR #162](https://github.com/voltron-1/Suburban_SOC/pull/162), merged; issue closed).
-- [x] **#161** — Failed SSH by Country geoip/grok fix + rendering live ([PR #162](https://github.com/voltron-1/Suburban_SOC/pull/162), merged; issue closed).
+- [~] **#164** — Broker: unvalidated `attacker_ip` reached the `nft`/SSH command
+  sink (NIST SP 800-53 Rev.5 SI-10 / CSF 2.0 PR.PS-06). Fixed + tested on branch
+  `remediation/issue-164-nist` (commit `beaac0b`); broker suite 23→29 tests, all
+  passing. [PR #178](https://github.com/voltron-1/Suburban_SOC/pull/178) opened
+  — awaiting review/merge.
+- [~] **#165** — SLO metrics & threat hunts silently swallowed ES errors as false
+  negatives (SI-11). Fixed + tested on branch `remediation/issue-165-nist`
+  (commit `46b81cb`); 20 new tests, all passing (real CI confirmed via
+  `soar-tests.yml` for the slo_metrics half — `run_hunts.py` has no CI path yet,
+  tracked under #168). [PR #179](https://github.com/voltron-1/Suburban_SOC/pull/179)
+  opened — awaiting review/merge. Deferred `agent_app.py:696` (audit-write
+  visibility) to a follow-up — no metrics/health surface to hook a counter into yet.
+- [ ] **#166** — Bash admin tooling skips TLS verification (`curl -k`) while
+  sending ES credentials (SC-8).
+- [ ] **#167** — Unhardened systemd units + `elastic` superuser default in host
+  automation (AC-6, CM-7).
 
-Evidence: `findings/20260707-160-161-logstash-ecs-geoip.md`. Pipeline config reloaded on the
-running Logstash (container restarted) — forward enrichment active.
+P2 (next sprint, #168-#172) and P3 (backlog, #173-#177) are tracked on
+[Project Board #17](https://github.com/users/voltron-1/projects/17); not
+individually sequenced here until the P1 critical items above clear.
+
+Note: #164 and #165 are on independent branches off the same `origin/main`
+commit, each with its own `planned_execution.md` edit — expect a trivial merge
+conflict in this file when the second PR merges; resolve by keeping both
+items' status lines.
 
 ---
 
 ## LAST SESSION — 2026-07-08
 
+- Principal-engineer structural health review of the full repo (architecture map,
+  robustness/access-control gap analysis mapped to NIST CSF 2.0 + SP 800-53
+  Rev.5, sustainability/test/resource-management lenses). Filed 14 issues
+  (#164-#177: P1 critical ×4, P2 medium ×5, P3 low ×5) with evidence, control
+  mappings, and acceptance criteria; labeled by priority/nist-compliance/
+  tech-debt/security; linked to [Project Board #17](https://github.com/users/voltron-1/projects/17).
+- Remediation in progress: **#164** (unvalidated `attacker_ip` in hive-mind-broker
+  reaching the `nft`/SSH sink — SI-10/PR.PS-06), branch `remediation/issue-164-nist`,
+  [PR #178](https://github.com/voltron-1/Suburban_SOC/pull/178). **#165** (SLO
+  metrics/threat hunts silent ES-failure swallowing — SI-11), branch
+  `remediation/issue-165-nist`, [PR #179](https://github.com/voltron-1/Suburban_SOC/pull/179).
+  Neither merged yet.
 - #160/#161: shipped pipeline ECS fixes + HIGH source.ip-spoof hardening (parallel
   code-reviewer + security-auditor); **PR #162 merged, both issues closed.** Live investigation
   found two extra root causes the issues missed: (1) panels bucket on `.keyword` subfields

--- a/scripts/setup/ai_agent/slo_metrics.py
+++ b/scripts/setup/ai_agent/slo_metrics.py
@@ -71,6 +71,13 @@ ES_CA = os.environ.get("ES_CA", "/certs/ca/ca.crt")
 ES_VERIFY = ES_CA if ES_CA else True
 
 
+class MetricUnavailable(Exception):
+    """Raised when a metric could not be measured because the ES/Kibana request
+    failed (or, for metric_coverage, the local file couldn't be read) — distinct
+    from a legitimate empty/zero result (audit #165 / NIST SI-11). A down or
+    unreachable dependency must never be reported as a benign 'n/a'."""
+
+
 def es(method, path, body=None):
     return requests.request(
         method, f"{ES_URL}{path}", auth=(ES_USER, ES_PASS), verify=ES_VERIFY,
@@ -86,9 +93,13 @@ def kb(path):
 def _count(index, query):
     try:
         r = es("POST", f"/{index}/_count", {"query": query})
-        return r.json().get("count", 0) if r.status_code == 200 else 0
-    except Exception:
-        return 0
+        if r.status_code != 200:
+            raise MetricUnavailable(f"{index} count returned HTTP {r.status_code}")
+        return r.json().get("count", 0)
+    except MetricUnavailable:
+        raise
+    except Exception as e:
+        raise MetricUnavailable(f"{index} count request failed: {e}") from e
 
 
 def metric_mttd():
@@ -98,9 +109,13 @@ def metric_mttd():
             "query": {"range": {"@timestamp": {"gte": WINDOW}}}}
     try:
         r = es("POST", "/.alerts-security.alerts-*/_search", body)
+        if r.status_code != 200:
+            raise MetricUnavailable(f"mttd search returned HTTP {r.status_code}")
         hits = r.json().get("hits", {}).get("hits", [])
-    except Exception:
-        hits = []
+    except MetricUnavailable:
+        raise
+    except Exception as e:
+        raise MetricUnavailable(f"mttd search failed: {e}") from e
     deltas = []
     for h in hits:
         s = h.get("_source", {})
@@ -113,7 +128,7 @@ def metric_mttd():
             if d >= 0:
                 deltas.append(d)
         except Exception:
-            continue
+            continue  # a single malformed hit is skipped — not a measurement error
     return round(sum(deltas) / len(deltas), 2) if deltas else None
 
 
@@ -125,18 +140,22 @@ def metric_mttr():
         "aggs": {"avg_lat": {"avg": {"field": "response.latency_seconds"}}}}
     try:
         r = es("POST", "/soar-actions-*/_search", body)
+        if r.status_code != 200:
+            raise MetricUnavailable(f"mttr search returned HTTP {r.status_code}")
         v = r.json().get("aggregations", {}).get("avg_lat", {}).get("value")
         return round(v / 60.0, 3) if v is not None else None
-    except Exception:
-        return None
+    except MetricUnavailable:
+        raise
+    except Exception as e:
+        raise MetricUnavailable(f"mttr search failed: {e}") from e
 
 
 def metric_coverage():
     p = REPO / "docs" / "detections" / "attack-coverage.json"
     try:
         return float(len(json.loads(p.read_text(encoding="utf-8")).get("techniques", [])))
-    except Exception:
-        return None
+    except Exception as e:
+        raise MetricUnavailable(f"attack-coverage.json unreadable: {e}") from e
 
 
 def metric_false_positive_pct():
@@ -146,8 +165,8 @@ def metric_false_positive_pct():
         fp = kb("/api/cases/_find?perPage=1&status=closed&tags=disposition:false_positive"
                 ).json().get("total", 0)
         return round(100.0 * fp / total, 2) if total else 0.0
-    except Exception:
-        return None
+    except Exception as e:
+        raise MetricUnavailable(f"cases query failed: {e}") from e
 
 
 def metric_ingest_lag_seconds():
@@ -158,8 +177,8 @@ def metric_ingest_lag_seconds():
             return None
         newest = datetime.fromisoformat(hits[0]["_source"]["@timestamp"].replace("Z", "+00:00"))
         return round((datetime.now(timezone.utc) - newest).total_seconds(), 1)
-    except Exception:
-        return None
+    except Exception as e:
+        raise MetricUnavailable(f"ingest-lag search failed: {e}") from e
 
 
 def metric_parse_error_pct():
@@ -173,14 +192,25 @@ def main():
     if not ES_PASS:
         print("ERROR: ES_PASS / ELASTIC_PASSWORD required", file=sys.stderr)
         sys.exit(1)
-    values = {
-        "mttd_minutes": metric_mttd(),
-        "mttr_minutes": metric_mttr(),
-        "coverage_techniques": metric_coverage(),
-        "false_positive_pct": metric_false_positive_pct(),
-        "ingest_lag_seconds": metric_ingest_lag_seconds(),
-        "parse_error_pct": metric_parse_error_pct(),
+
+    metric_fns = {
+        "mttd_minutes": metric_mttd,
+        "mttr_minutes": metric_mttr,
+        "coverage_techniques": metric_coverage,
+        "false_positive_pct": metric_false_positive_pct,
+        "ingest_lag_seconds": metric_ingest_lag_seconds,
+        "parse_error_pct": metric_parse_error_pct,
     }
+    values, errors = {}, {}
+    for name, fn in metric_fns.items():
+        try:
+            values[name] = fn()
+        except MetricUnavailable as e:
+            # audit #165 / NIST SI-11: a measurement failure must never look
+            # like a benign "n/a" or a healthy "0" — it is always a breach.
+            values[name] = None
+            errors[name] = str(e)
+
     now = datetime.now(timezone.utc).isoformat()
     doc = {"@timestamp": now, "slo": {}}
     breaches = []
@@ -189,7 +219,10 @@ def main():
     for name, val in values.items():
         target = TARGETS[name]
         lower = LOWER_BETTER[name]
-        if val is None:
+        if name in errors:
+            breach = True
+            status = "ERROR(unmeasurable)"
+        elif val is None:
             # Fail closed for liveness-critical metrics: unmeasurable == breach.
             breach = name in BREACH_IF_NA
             status = "BREACH(no-data)" if breach else "n/a"
@@ -198,17 +231,22 @@ def main():
             status = "BREACH" if breach else "ok"
         if breach:
             breaches.append(name)
-        doc["slo"][name] = {"value": val, "target": target,
-                            "comparator": "<=" if lower else ">=", "breach": breach}
+        entry = {"value": val, "target": target,
+                 "comparator": "<=" if lower else ">=", "breach": breach}
+        if name in errors:
+            entry["error"] = errors[name]
+        doc["slo"][name] = entry
         print(f"  {name.ljust(20)} {str(val):>10}  {('<=' if lower else '>=')+str(target):>8}  {status}")
     doc["breach_count"] = len(breaches)
     doc["status"] = "breach" if breaches else "ok"
 
     # Index for the SLO dashboard.
+    index_failed = False
     try:
         es("POST", "/soc-slo-metrics/_doc", doc)
         print(f"  -> indexed to soc-slo-metrics (breaches: {len(breaches)})")
     except Exception as e:
+        index_failed = True
         print(f"  -> ES index failed: {e}", file=sys.stderr)
 
     # Alert on breach (best-effort).
@@ -221,6 +259,12 @@ def main():
         except Exception:
             pass
 
+    # audit #165 / NIST SI-11: a measurement error (or a failure to persist the
+    # doc at all) is a harder failure than a routine target breach — exit 3 so
+    # slo-metrics.service (SuccessExitStatus=0 2) correctly reports a failed
+    # run instead of blending it into "successful run, breach".
+    if errors or index_failed:
+        sys.exit(3)
     sys.exit(2 if breaches else 0)
 
 

--- a/scripts/setup/run_hunts.py
+++ b/scripts/setup/run_hunts.py
@@ -42,6 +42,12 @@ ES_CA = os.environ.get("ES_CA", "/certs/ca/ca.crt")
 ES_VERIFY = ES_CA if ES_CA else True
 
 
+class HuntQueryUnavailable(Exception):
+    """Raised when a hunt's ES query could not be executed — distinct from a
+    genuine zero-match count (audit #165 / NIST SI-11). A down or unreachable
+    Elasticsearch must never be reported as 'no findings'."""
+
+
 def es_count(index, query_string):
     body = {"query": {"bool": {"filter": [
         {"query_string": {"query": query_string}},
@@ -50,9 +56,13 @@ def es_count(index, query_string):
         r = requests.post(f"{ES_URL}/{index}/_count", auth=(ES_USER, ES_PASS),
                           verify=ES_VERIFY, headers={"Content-Type": "application/json"},
                           data=json.dumps(body), timeout=20)
-        return r.json().get("count", 0) if r.status_code == 200 else 0
-    except Exception:
-        return 0
+        if r.status_code != 200:
+            raise HuntQueryUnavailable(f"{index} count returned HTTP {r.status_code}")
+        return r.json().get("count", 0)
+    except HuntQueryUnavailable:
+        raise
+    except Exception as e:
+        raise HuntQueryUnavailable(f"{index} count request failed: {e}") from e
 
 
 def main():
@@ -64,13 +74,18 @@ def main():
         print("No hunts found in hunts/", file=sys.stderr)
         sys.exit(1)
     now = datetime.now(timezone.utc).isoformat()
-    bulk, findings = [], 0
+    bulk, findings, hunt_errors = [], 0, 0
     print(f"Threat hunts @ {now}  (window {WINDOW})")
     print(f"  {'hunt'.ljust(10)} {'attack'.ljust(12)} {'count':>7}  finding")
     for path in hunts:
         h = yaml.safe_load(path.read_text(encoding="utf-8"))
         idx = h.get("index", "logstash-security-*")
-        count = es_count(idx, h.get("query", "*"))
+        try:
+            count = es_count(idx, h.get("query", "*"))
+        except HuntQueryUnavailable as e:
+            hunt_errors += 1
+            print(f"  {str(h.get('id','')).ljust(10)} ERROR: {e}", file=sys.stderr)
+            continue  # never fabricate a "0 matches" finding for an unreachable query
         threshold = int(h.get("threshold", 1))
         finding = count >= threshold
         if finding:
@@ -84,14 +99,21 @@ def main():
                "threshold": threshold, "finding": finding}
         bulk.append('{"index":{"_index":"soc-hunts"}}')
         bulk.append(json.dumps(doc))
+    index_failed = False
     if bulk:
         try:
             requests.post(f"{ES_URL}/_bulk", auth=(ES_USER, ES_PASS), verify=ES_VERIFY,
                           headers={"Content-Type": "application/x-ndjson"},
                           data="\n".join(bulk) + "\n", timeout=20)
-            print(f"  -> indexed {len(hunts)} hunt results to soc-hunts ({findings} findings)")
+            print(f"  -> indexed {len(bulk) // 2} hunt results to soc-hunts ({findings} findings)")
         except Exception as e:
+            index_failed = True
             print(f"  -> ES index failed: {e}", file=sys.stderr)
+    if index_failed:
+        sys.exit(3)
+    if hunt_errors:
+        print(f"  -> {hunt_errors}/{len(hunts)} hunt(s) failed to query — see stderr", file=sys.stderr)
+        sys.exit(2)
     sys.exit(0)
 
 

--- a/tests/ai_agent/test_slo_metrics.py
+++ b/tests/ai_agent/test_slo_metrics.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+SLO metrics — measurement-error visibility tests (audit #165 / NIST SI-11).
+
+slo_metrics.py must distinguish "ES/Kibana unreachable" from "genuinely no
+data this window": a down dependency must always surface as an error/breach,
+never silently collapse into a healthy-looking None/0 reading.
+
+Run:  python tests/ai_agent/test_slo_metrics.py     (or: pytest tests/ai_agent)
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# ES_PASS is read at import time; must be truthy or main() exits(1) immediately.
+os.environ["ES_PASS"] = "unit_test_pass"
+
+AGENT_DIR = Path(__file__).resolve().parents[2] / "scripts" / "setup" / "ai_agent"
+sys.path.insert(0, str(AGENT_DIR))
+
+import slo_metrics  # noqa: E402
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+class MetricFunctionTests(unittest.TestCase):
+    """Each metric must raise MetricUnavailable on a real failure, but still
+    return the same legitimate value (None/0) as before on genuine no-data."""
+
+    def test_count_raises_on_request_exception(self):
+        with mock.patch.object(slo_metrics, "es", side_effect=ConnectionError("refused")):
+            with self.assertRaises(slo_metrics.MetricUnavailable):
+                slo_metrics._count("logstash-security-*", {"match_all": {}})
+
+    def test_count_raises_on_non_200(self):
+        with mock.patch.object(slo_metrics, "es", return_value=_FakeResponse(503)):
+            with self.assertRaises(slo_metrics.MetricUnavailable):
+                slo_metrics._count("logstash-security-*", {"match_all": {}})
+
+    def test_count_returns_real_zero_when_es_is_healthy(self):
+        with mock.patch.object(slo_metrics, "es", return_value=_FakeResponse(200, {"count": 0})):
+            self.assertEqual(slo_metrics._count("logstash-security-*", {"match_all": {}}), 0)
+
+    def test_mttd_raises_on_request_failure(self):
+        with mock.patch.object(slo_metrics, "es", side_effect=TimeoutError("timed out")):
+            with self.assertRaises(slo_metrics.MetricUnavailable):
+                slo_metrics.metric_mttd()
+
+    def test_mttd_returns_none_on_genuinely_empty_window(self):
+        # Regression guard: a healthy ES with zero alerts must NOT be treated
+        # as a measurement error — that would be a false alarm.
+        with mock.patch.object(slo_metrics, "es",
+                               return_value=_FakeResponse(200, {"hits": {"hits": []}})):
+            self.assertIsNone(slo_metrics.metric_mttd())
+
+    def test_mttr_raises_on_non_200(self):
+        with mock.patch.object(slo_metrics, "es", return_value=_FakeResponse(500)):
+            with self.assertRaises(slo_metrics.MetricUnavailable):
+                slo_metrics.metric_mttr()
+
+    def test_mttr_returns_none_on_empty_aggregation(self):
+        with mock.patch.object(slo_metrics, "es",
+                               return_value=_FakeResponse(200, {"aggregations": {"avg_lat": {}}})):
+            self.assertIsNone(slo_metrics.metric_mttr())
+
+    def test_coverage_raises_on_missing_file(self):
+        with mock.patch.object(slo_metrics, "REPO", Path("/nonexistent-path-for-test")):
+            with self.assertRaises(slo_metrics.MetricUnavailable):
+                slo_metrics.metric_coverage()
+
+    def test_false_positive_pct_raises_on_kibana_failure(self):
+        with mock.patch.object(slo_metrics, "kb", side_effect=ConnectionError("refused")):
+            with self.assertRaises(slo_metrics.MetricUnavailable):
+                slo_metrics.metric_false_positive_pct()
+
+    def test_ingest_lag_raises_on_request_failure(self):
+        with mock.patch.object(slo_metrics, "es", side_effect=ConnectionError("refused")):
+            with self.assertRaises(slo_metrics.MetricUnavailable):
+                slo_metrics.metric_ingest_lag_seconds()
+
+    def test_ingest_lag_returns_none_when_no_docs_yet(self):
+        with mock.patch.object(slo_metrics, "es",
+                               return_value=_FakeResponse(200, {"hits": {"hits": []}})):
+            self.assertIsNone(slo_metrics.metric_ingest_lag_seconds())
+
+    def test_parse_error_pct_propagates_count_failure(self):
+        with mock.patch.object(slo_metrics, "es", side_effect=ConnectionError("refused")):
+            with self.assertRaises(slo_metrics.MetricUnavailable):
+                slo_metrics.metric_parse_error_pct()
+
+
+class MainExitCodeTests(unittest.TestCase):
+    """End-to-end: main() must exit 3 (not the routine breach code 2) when a
+    metric could not be measured, and must still behave exactly as before for
+    a genuinely healthy, quiet system."""
+
+    def _run_main_capturing_exit(self):
+        try:
+            slo_metrics.main()
+        except SystemExit as e:
+            return e.code
+        return None
+
+    def test_total_es_outage_exits_3_not_2(self):
+        with mock.patch.object(slo_metrics, "es", side_effect=ConnectionError("refused")), \
+             mock.patch.object(slo_metrics, "kb", side_effect=ConnectionError("refused")), \
+             mock.patch.object(slo_metrics, "metric_coverage",
+                               side_effect=slo_metrics.MetricUnavailable("no file")), \
+             mock.patch.object(slo_metrics, "NTFY_TOPIC", ""):
+            code = self._run_main_capturing_exit()
+        self.assertEqual(code, 3)
+
+    def test_healthy_quiet_system_exits_0(self):
+        # Fresh ingest doc (healthy pipeline) but otherwise empty windows —
+        # the pre-#165 baseline behavior for a quiet, working SOC.
+        import datetime as _dt
+        now_iso = _dt.datetime.now(_dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+        def fake_es(method, path, body=None):
+            if path == "/logstash-security-*/_search":
+                return _FakeResponse(200, {"hits": {"hits": [{"_source": {"@timestamp": now_iso}}]}})
+            return _FakeResponse(200, {"hits": {"hits": []}, "aggregations": {"avg_lat": {}}})
+
+        with mock.patch.object(slo_metrics, "es", side_effect=fake_es), \
+             mock.patch.object(slo_metrics, "kb", return_value=_FakeResponse(200, {"total": 0})), \
+             mock.patch.object(slo_metrics, "metric_coverage", return_value=12.0), \
+             mock.patch.object(slo_metrics, "NTFY_TOPIC", ""):
+            code = self._run_main_capturing_exit()
+        self.assertEqual(code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/hunts/test_run_hunts.py
+++ b/tests/hunts/test_run_hunts.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Threat-hunt runner — measurement-error visibility tests (audit #165 / NIST SI-11).
+
+run_hunts.py must distinguish "a hunt's ES query failed" from "a hunt
+genuinely found 0 matches", and must exit non-zero if any hunt failed to
+query or the final bulk index write failed — it must never silently exit 0.
+
+Run:  python tests/hunts/test_run_hunts.py     (or: pytest tests/hunts)
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# ES_PASS is read at import time; must be truthy or main() exits(1) immediately.
+os.environ["ES_PASS"] = "unit_test_pass"
+
+SETUP_DIR = Path(__file__).resolve().parents[2] / "scripts" / "setup"
+sys.path.insert(0, str(SETUP_DIR))
+
+import run_hunts  # noqa: E402
+
+
+HUNT_A = """
+id: HUNT-TEST-A
+title: Test hunt A
+attack: ["T1110"]
+index: logstash-security-*
+query: "*"
+threshold: 1
+"""
+
+HUNT_B = """
+id: HUNT-TEST-B
+title: Test hunt B
+attack: ["T1046"]
+index: logstash-security-*
+query: "*"
+threshold: 1
+"""
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+class EsCountTests(unittest.TestCase):
+    def test_raises_on_request_exception(self):
+        with mock.patch.object(run_hunts.requests, "post", side_effect=ConnectionError("refused")):
+            with self.assertRaises(run_hunts.HuntQueryUnavailable):
+                run_hunts.es_count("logstash-security-*", "*")
+
+    def test_raises_on_non_200(self):
+        with mock.patch.object(run_hunts.requests, "post", return_value=_FakeResponse(503)):
+            with self.assertRaises(run_hunts.HuntQueryUnavailable):
+                run_hunts.es_count("logstash-security-*", "*")
+
+    def test_returns_real_zero_when_es_is_healthy(self):
+        with mock.patch.object(run_hunts.requests, "post",
+                               return_value=_FakeResponse(200, {"count": 0})):
+            self.assertEqual(run_hunts.es_count("logstash-security-*", "*"), 0)
+
+
+class MainExitCodeTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        hunts_dir = Path(self._tmp.name)
+        (hunts_dir / "HUNT-TEST-A.yml").write_text(HUNT_A, encoding="utf-8")
+        (hunts_dir / "HUNT-TEST-B.yml").write_text(HUNT_B, encoding="utf-8")
+        self._hunts_patch = mock.patch.object(run_hunts, "HUNTS_DIR", hunts_dir)
+        self._hunts_patch.start()
+
+    def tearDown(self):
+        self._hunts_patch.stop()
+        self._tmp.cleanup()
+
+    def _run_main_capturing_exit(self):
+        try:
+            run_hunts.main()
+        except SystemExit as e:
+            return e.code
+        return None
+
+    def test_all_hunts_healthy_exits_0(self):
+        with mock.patch.object(run_hunts.requests, "post") as post:
+            post.side_effect = [
+                _FakeResponse(200, {"count": 0}),   # HUNT-TEST-A query
+                _FakeResponse(200, {"count": 0}),   # HUNT-TEST-B query
+                _FakeResponse(200, {}),             # bulk index
+            ]
+            code = self._run_main_capturing_exit()
+        self.assertEqual(code, 0)
+
+    def test_one_hunt_query_failure_exits_2_and_skips_that_hunt(self):
+        with mock.patch.object(run_hunts.requests, "post") as post:
+            post.side_effect = [
+                ConnectionError("refused"),         # HUNT-TEST-A query fails
+                _FakeResponse(200, {"count": 0}),   # HUNT-TEST-B query succeeds
+                _FakeResponse(200, {}),             # bulk index (only B's doc)
+            ]
+            code = self._run_main_capturing_exit()
+        self.assertEqual(code, 2)
+        # Only HUNT-TEST-B's doc pair should have been bulk-indexed — a failed
+        # hunt must never fabricate a "0 matches" finding.
+        bulk_call = post.call_args_list[-1]
+        sent = bulk_call.kwargs["data"]
+        self.assertIn("HUNT-TEST-B", sent)
+        self.assertNotIn("HUNT-TEST-A", sent)
+
+    def test_bulk_index_failure_exits_3(self):
+        with mock.patch.object(run_hunts.requests, "post") as post:
+            post.side_effect = [
+                _FakeResponse(200, {"count": 0}),
+                _FakeResponse(200, {"count": 0}),
+                ConnectionError("refused"),         # bulk index fails
+            ]
+            code = self._run_main_capturing_exit()
+        self.assertEqual(code, 3)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- `slo_metrics.py` and `run_hunts.py` swallowed every ES/Kibana request exception into `None`/`0` — indistinguishable from a genuinely healthy "no data" reading. A total outage looked identical to a quiet, working SOC.
- Adds `MetricUnavailable`/`HuntQueryUnavailable`, raised by every ES/Kibana-calling function on a request exception or non-200 status, instead of swallowing.
- `slo_metrics.py`: an errored metric is always `breach: true` plus a new `error` field on that metric's doc entry (existing `value`/`target`/`comparator`/`breach` fields/types unchanged). New exit code **3** (measurement error or index-write failure), distinct from exit 2 (a real target breach). `slo-metrics.service`'s `SuccessExitStatus=0 2` already treats any other code as failure — **no unit-file change needed**; a total ES outage now correctly fails the systemd unit instead of blending into "successful run, breach."
- `run_hunts.py`: a hunt whose query fails is skipped (never fabricates a "0 matches" finding), counted, and causes exit 2; a failed final bulk-index write causes exit 3 (previously: printed and fell through to `sys.exit(0)`).
- A genuinely quiet system (zero alerts, zero cases, fresh ingest) still reports exactly as before — only real failures change behavior.
- Control mapping: NIST SP 800-53 Rev.5 SI-11 (Error Handling); NIST CSF 2.0 DE.CM-09.

## Deferred
`agent_app.py:696`'s audit-write swallow is a separate, deliberate "must never raise" tradeoff (auditing must not break alert handling) with no existing metrics/health endpoint to expose a counter on — left for a follow-up rather than bolting on a one-off surface.

## Test plan
- [x] 20 new tests, all passing (`tests/ai_agent/test_slo_metrics.py`, `tests/hunts/test_run_hunts.py`), fully mocked — no live ES required
- [x] Regression guards included: a genuinely empty search window still returns `None`/"n/a" (not an error); a genuinely healthy quiet system still exits 0
- [x] Wired `test_slo_metrics.py` into `soar-tests.yml`, which already triggers on `scripts/setup/ai_agent/**`
- [ ] `test_run_hunts.py` is not wired into any CI workflow yet — `scripts/setup/run_hunts.py` isn't covered by any existing path-filtered workflow; closing that gap is issue #168's scope, not this one
- [x] Grep-confirmed neither script is imported as a module anywhere; the only exit-code consumer is `slo-metrics.service`, whose config doesn't need to change

Fixes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)