### PR TITLE
fix(#166): fail closed on missing TLS CA instead of silently using curl -k

### DIFF
--- a/configs/elasticsearch/apply-lifecycle.sh
+++ b/configs/elasticsearch/apply-lifecycle.sh
@@ -18,7 +18,8 @@
 #   ES_URL=https://localhost:9200 ES_USER=elastic ES_PASS=... ./apply-lifecycle.sh
 #   ./apply-lifecycle.sh --snapshot-now   # also trigger an immediate SLM snapshot
 # Env: ES_URL (default https://localhost:9200), ES_USER (elastic),
-#      ES_PASS / ELASTIC_PASSWORD.
+#      ES_PASS / ELASTIC_PASSWORD, ES_CA (default /certs/ca/ca.crt — FAILS
+#      CLOSED if unreadable; set ES_INSECURE=true to skip verification, lab only).
 # =============================================================================
 set -euo pipefail
 
@@ -26,10 +27,8 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="$HERE/../../scripts/setup/.env"
 [[ -f "$ENV_FILE" ]] && { set -a; . "$ENV_FILE"; set +a; }
 
-ES_URL="${ES_URL:-https://localhost:9200}"
-ES_USER="${ES_USER:-elastic}"
-ES_PASS="${ES_PASS:-${ELASTIC_PASSWORD:-}}"
-[[ -z "$ES_PASS" ]] && { echo "ERROR: set ES_PASS or ELASTIC_PASSWORD"; exit 1; }
+# Shared ES creds + TLS + es() (issue #156; audit #166 — no local -k downgrade).
+source "$HERE/../../scripts/setup/lib/es_common.sh"
 
 SNAPSHOT_NOW=0
 for arg in "$@"; do
@@ -42,9 +41,8 @@ done
 REPO="suburban-soc-snapshots"
 SLM="suburban-soc-daily-snapshots"
 
-curl_es() { curl -sk -u "${ES_USER}:${ES_PASS}" -H 'Content-Type: application/json' "$@"; }
 put() {  # $1=label  $2=path  $3=json-file
-  curl_es -o /dev/null -w "    ${1} -> HTTP %{http_code}\n" -X PUT \
+  esj -o /dev/null -w "    ${1} -> HTTP %{http_code}\n" -X PUT \
     "$ES_URL$2" --data-binary "@$3"
 }
 
@@ -69,7 +67,7 @@ bash "$HERE/apply-templates.sh"
 
 if [[ $SNAPSHOT_NOW -eq 1 ]]; then
   echo "==> Triggering an immediate snapshot via SLM '${SLM}'"
-  curl_es -o /dev/null -w '    execute -> HTTP %{http_code}\n' -X POST "$ES_URL/_slm/policy/${SLM}/_execute"
+  esj -o /dev/null -w '    execute -> HTTP %{http_code}\n' -X POST "$ES_URL/_slm/policy/${SLM}/_execute"
 fi
 
 echo "Done. Data lifecycle installed (ILM + snapshots + data-stream templates)."

--- a/configs/elasticsearch/apply-templates.sh
+++ b/configs/elasticsearch/apply-templates.sh
@@ -15,6 +15,8 @@
 #   ES_URL=https://localhost:9200 ES_USER=elastic ES_PASS=... ./apply-templates.sh
 # Env (auto-loaded from scripts/setup/.env if present):
 #   ES_URL (default https://localhost:9200), ES_USER (elastic), ES_PASS/ELASTIC_PASSWORD
+#   ES_CA (default /certs/ca/ca.crt) — FAILS CLOSED if unreadable; set
+#   ES_INSECURE=true to explicitly skip TLS verification (lab only).
 # =============================================================================
 set -euo pipefail
 
@@ -22,27 +24,23 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="$HERE/../../scripts/setup/.env"
 [[ -f "$ENV_FILE" ]] && { set -a; . "$ENV_FILE"; set +a; }
 
-ES_URL="${ES_URL:-https://localhost:9200}"
-ES_USER="${ES_USER:-elastic}"
-ES_PASS="${ES_PASS:-${ELASTIC_PASSWORD:-}}"
-[[ -z "$ES_PASS" ]] && { echo "ERROR: set ES_PASS or ELASTIC_PASSWORD"; exit 1; }
-
-curl_es() { curl -sk -u "${ES_USER}:${ES_PASS}" -H 'Content-Type: application/json' "$@"; }
+# Shared ES creds + TLS + es() (issue #156; audit #166 — no local -k downgrade).
+source "$HERE/../../scripts/setup/lib/es_common.sh"
 
 echo "==> Installing logstash-security-template"
-curl_es -o /dev/null -w '    -> HTTP %{http_code}\n' -X PUT \
+esj -o /dev/null -w '    -> HTTP %{http_code}\n' -X PUT \
   "$ES_URL/_index_template/logstash-security-template" \
   --data-binary "@$HERE/logstash-security-template.json"
 
 echo "==> Installing soar-actions-template"
-curl_es -o /dev/null -w '    -> HTTP %{http_code}\n' -X PUT \
+esj -o /dev/null -w '    -> HTTP %{http_code}\n' -X PUT \
   "$ES_URL/_index_template/soar-actions-template" \
   --data-binary "@$HERE/soar-actions-template.json"
 
 echo "==> Dropping replicas to 0 on existing indices (single-node -> clears yellow)"
-curl_es -o /dev/null -w '    logstash-security-* -> HTTP %{http_code}\n' -X PUT \
+esj -o /dev/null -w '    logstash-security-* -> HTTP %{http_code}\n' -X PUT \
   "$ES_URL/logstash-security-*/_settings" -d '{"index":{"number_of_replicas":0}}'
-curl_es -o /dev/null -w '    soar-actions-*      -> HTTP %{http_code}\n' -X PUT \
+esj -o /dev/null -w '    soar-actions-*      -> HTTP %{http_code}\n' -X PUT \
   "$ES_URL/soar-actions-*/_settings" -d '{"index":{"number_of_replicas":0}}'
 
 echo "Done."

--- a/planned_execution.md
+++ b/planned_execution.md
@@ -9,20 +9,64 @@ Status: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
 
 ## NEXT UP
 
-**Phase: SOP-147 dashboard validation — COMPLETE. Open-issue backlog is empty.**
+**Phase: Structural Health Review Remediation — Priority 1 (Critical).**
+Source: repo-wide structural/NIST-CSF-2.0/SP-800-53-Rev.5-aligned review,
+2026-07-08 — 14 issues filed (#164-#177) and linked to
+[Project Board #17](https://github.com/users/voltron-1/projects/17).
 
-Next unstarted item: none. Define the next phase with the owner.
+Next unstarted item: **#167** — Unhardened systemd units + `elastic` superuser
+default in host automation (AC-6, CM-7).
 
-- [x] **#160** — zeek.ssl SNI/Cipher panels ECS-normalized + rendering live ([PR #162](https://github.com/voltron-1/Suburban_SOC/pull/162), merged; issue closed).
-- [x] **#161** — Failed SSH by Country geoip/grok fix + rendering live ([PR #162](https://github.com/voltron-1/Suburban_SOC/pull/162), merged; issue closed).
+- [~] **#164** — Broker: unvalidated `attacker_ip` reached the `nft`/SSH command
+  sink (NIST SP 800-53 Rev.5 SI-10 / CSF 2.0 PR.PS-06). Fixed + tested on branch
+  `remediation/issue-164-nist` (commit `beaac0b`); broker suite 23→29 tests, all
+  passing. [PR #178](https://github.com/voltron-1/Suburban_SOC/pull/178) opened
+  — awaiting review/merge.
+- [~] **#165** — SLO metrics & threat hunts silently swallowed ES errors as false
+  negatives (SI-11). Fixed + tested on branch `remediation/issue-165-nist`
+  (commit `46b81cb`); 20 new tests, all passing (real CI confirmed via
+  `soar-tests.yml` for the slo_metrics half — `run_hunts.py` has no CI path yet,
+  tracked under #168). [PR #179](https://github.com/voltron-1/Suburban_SOC/pull/179)
+  opened — awaiting review/merge. Deferred `agent_app.py:696` (audit-write
+  visibility) to a follow-up — no metrics/health surface to hook a counter into yet.
+- [~] **#166** — Bash admin tooling skipped TLS verification (`curl -k`) while
+  sending ES credentials (SC-8). Fixed + verified end-to-end against the live
+  running stack (no CI path for these scripts) on branch
+  `remediation/issue-166-nist` (commit `70245a9`); also fixed the `lifecycle`
+  compose one-shot, which had no CA mounted and would have broken stack startup
+  once the fail-closed default landed. [PR #180](https://github.com/voltron-1/Suburban_SOC/pull/180)
+  opened — awaiting review/merge. Operator note: any host script relying on the
+  old implicit `-k` fallback now needs `ES_CA=<path>` or `ES_INSECURE=true`.
+- [ ] **#167** — Unhardened systemd units + `elastic` superuser default in host
+  automation (AC-6, CM-7).
 
-Evidence: `findings/20260707-160-161-logstash-ecs-geoip.md`. Pipeline config reloaded on the
-running Logstash (container restarted) — forward enrichment active.
+P2 (next sprint, #168-#172) and P3 (backlog, #173-#177) are tracked on
+[Project Board #17](https://github.com/users/voltron-1/projects/17); not
+individually sequenced here until the P1 critical items above clear.
+
+Note: #164, #165, and #166 are on independent branches off the same
+`origin/main` commit, each with its own `planned_execution.md` edit — expect
+trivial merge conflicts in this file as each PR merges; resolve by keeping all
+items' status lines.
 
 ---
 
 ## LAST SESSION — 2026-07-08
 
+- Principal-engineer structural health review of the full repo (architecture map,
+  robustness/access-control gap analysis mapped to NIST CSF 2.0 + SP 800-53
+  Rev.5, sustainability/test/resource-management lenses). Filed 14 issues
+  (#164-#177: P1 critical ×4, P2 medium ×5, P3 low ×5) with evidence, control
+  mappings, and acceptance criteria; labeled by priority/nist-compliance/
+  tech-debt/security; linked to [Project Board #17](https://github.com/users/voltron-1/projects/17).
+- Remediation in progress: **#164** (unvalidated `attacker_ip` in hive-mind-broker
+  reaching the `nft`/SSH sink — SI-10/PR.PS-06), branch `remediation/issue-164-nist`,
+  [PR #178](https://github.com/voltron-1/Suburban_SOC/pull/178). **#165** (SLO
+  metrics/threat hunts silent ES-failure swallowing — SI-11), branch
+  `remediation/issue-165-nist`, [PR #179](https://github.com/voltron-1/Suburban_SOC/pull/179).
+  **#166** (bash tooling `curl -k` TLS skip — SC-8, plus a `lifecycle` compose
+  fix), branch `remediation/issue-166-nist`, [PR #180](https://github.com/voltron-1/Suburban_SOC/pull/180).
+  None merged yet.
 - #160/#161: shipped pipeline ECS fixes + HIGH source.ip-spoof hardening (parallel
   code-reviewer + security-auditor); **PR #162 merged, both issues closed.** Live investigation
   found two extra root causes the issues missed: (1) panels bucket on `.keyword` subfields

--- a/scripts/setup/docker-compose.yml
+++ b/scripts/setup/docker-compose.yml
@@ -293,8 +293,13 @@ services:
       - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
       - ES_URL=https://elasticsearch:9200
       - ES_USER=elastic
+      # audit #166 / NIST SC-8: apply-lifecycle.sh/apply-templates.sh now fail
+      # closed without a readable CA (see scripts/setup/lib/es_common.sh) —
+      # mount + point at the same CA the `roles` one-shot already verifies against.
+      - ES_CA=/certs/ca/ca.crt
     volumes:
       - ../../configs/elasticsearch:/lifecycle:ro
+      - certs:/certs:ro
     networks:
       - soc-mesh-net
     entrypoint: ["/bin/bash", "-c"]

--- a/scripts/setup/lib/es_common.sh
+++ b/scripts/setup/lib/es_common.sh
@@ -20,7 +20,10 @@
 #   ES_URL   default https://localhost:9200
 #   ES_USER  default elastic
 #   ES_PASS  from $ES_PASS, else $ELASTIC_PASSWORD
-#   ES_CA    if set AND the file exists -> curl --cacert <ca>; else -> curl -k
+#   ES_CA    default /certs/ca/ca.crt; if readable -> curl --cacert <ca>.
+#            FAIL CLOSED (audit #166 / NIST SC-8): if no readable CA and
+#            ES_INSECURE isn't "true", this script exits rather than
+#            silently falling back to curl -k.
 #
 # Fails fast (exit 1) when no password resolves, instead of emitting an
 # unauthenticated request that returns a confusing 401. Set ES_REQUIRE_CREDS=0
@@ -51,13 +54,21 @@ if [[ -z "${ES_PASS:-}" ]]; then
   fi
 fi
 
-# Auth + TLS built once. Prefer verifying against the stack CA; fall back to -k
-# only when no readable CA is available (preserves existing localhost behavior).
+# Auth + TLS built once. Prefer verifying against the stack CA. FAIL CLOSED
+# (audit #166 / NIST SC-8): a missing/unreadable CA no longer silently
+# downgrades to -k — set ES_INSECURE=true to explicitly opt out (lab/
+# first-run only), mirroring dispatcher.py's BROKER_INSECURE_SSH pattern.
 ES_AUTH=(-u "${ES_USER}:${ES_PASS}")
-if [[ -n "${ES_CA:-}" && -f "${ES_CA}" ]]; then
+ES_CA="${ES_CA:-/certs/ca/ca.crt}"
+if [[ -f "${ES_CA}" ]]; then
   ES_TLS=(--cacert "${ES_CA}")
-else
+elif [[ "${ES_INSECURE:-false}" == "true" ]]; then
+  echo "WARNING: ES_INSECURE=true and no readable CA at ES_CA=${ES_CA} — TLS verification is DISABLED for ES calls (lab/first-run only; do not use in production)." >&2
   ES_TLS=(-k)
+else
+  echo "ERROR: no readable CA at ES_CA=${ES_CA} — refusing to skip TLS verification." >&2
+  echo "       Set ES_CA to the stack CA path, or ES_INSECURE=true to explicitly accept unverified TLS (lab only)." >&2
+  exit 1
 fi
 
 # Base helper: auth + TLS, NO Content-Type — callers add -H as needed so json

--- a/tests/anomaly_simulation/verify_detections.py
+++ b/tests/anomaly_simulation/verify_detections.py
@@ -90,23 +90,33 @@ def build_checks(lookback_min: int) -> list[Check]:
 def main() -> int:
     # Security is enabled (WS0.1): default to HTTPS + auth. ES_PASS falls back to
     # ELASTIC_PASSWORD so `source ../../scripts/setup/.env` just works. ES_CA points
-    # at an exported ca.crt for strict TLS; without it we skip cert verification
-    # (acceptable only against a local self-signed node).
+    # at an exported ca.crt for strict TLS.
     es_url = os.environ.get("ES_URL", "https://localhost:9200")
     index = os.environ.get("ES_INDEX", "logstash-security-*")
     lookback = int(os.environ.get("LOOKBACK_MIN", "10"))
     user = os.environ.get("ES_USER", "elastic") or None
     password = os.environ.get("ES_PASS") or os.environ.get("ELASTIC_PASSWORD") or None
-    ca = os.environ.get("ES_CA") or None
+    ca = os.environ.get("ES_CA", "/certs/ca/ca.crt")
+    insecure = os.environ.get("ES_INSECURE", "false").lower() == "true"
 
     kwargs: dict[str, Any] = {"hosts": [es_url]}
     if user and password:
         kwargs["basic_auth"] = (user, password)
     if es_url.startswith("https"):
-        if ca:
+        # FAIL CLOSED (audit #166 / NIST SC-8): a missing/unreadable CA no
+        # longer silently skips verification — set ES_INSECURE=true to
+        # explicitly opt out (lab only), mirroring es_common.sh's pattern.
+        if ca and os.path.isfile(ca):
             kwargs["ca_certs"] = ca
-        else:
+        elif insecure:
+            print(f"[!] ES_INSECURE=true and no readable CA at {ca} — TLS "
+                  f"verification DISABLED (lab only).", file=sys.stderr)
             kwargs["verify_certs"] = False
+        else:
+            print(f"[!] ERROR: no readable CA at ES_CA={ca} — refusing to skip "
+                  f"TLS verification. Set ES_CA or ES_INSECURE=true (lab only).",
+                  file=sys.stderr)
+            return 2
 
     es = Elasticsearch(**kwargs)
 

--- a/tests/rbac/test_rbac.sh
+++ b/tests/rbac/test_rbac.sh
@@ -14,7 +14,8 @@ source "$HERE/../../scripts/setup/lib/es_common.sh"
 
 PW="RbacTest123!"; fails=0
 admin() { es "$@"; }   # admin uses the shared es() helper (issue #156)
-as() { local u="$1"; shift; curl -sk -o /dev/null -w '%{http_code}' -u "$u:$PW" "$@"; }
+# audit #166: reuse the shared helper's TLS args instead of hardcoded -sk.
+as() { local u="$1"; shift; curl -s "${ES_TLS[@]}" -o /dev/null -w '%{http_code}' -u "$u:$PW" "$@"; }
 mkuser() { admin -o /dev/null -X PUT "$ES_URL/_security/user/$1" -H 'Content-Type: application/json' -d "{\"password\":\"$PW\",\"roles\":[\"$2\"]}"; }
 rmuser() { admin -o /dev/null -X DELETE "$ES_URL/_security/user/$1"; }
 expect() { # $1=label $2=actual $3=expected


### PR DESCRIPTION
## Summary
- `es_common.sh`, `apply-templates.sh`, `apply-lifecycle.sh`, and `test_rbac.sh` all skipped TLS certificate verification against Elasticsearch by default while transmitting credentials — the opposite of the fail-closed posture already enforced on the Python side (`agent_app.py`'s `ES_VERIFY`, `dispatcher.py`'s `BROKER_INSECURE_SSH`).
- `es_common.sh`: `ES_CA` now defaults to `/certs/ca/ca.crt` (matching the Python scripts' convention); a missing/unreadable CA now exits 1 unless `ES_INSECURE=true` is explicitly set (mirrors `BROKER_INSECURE_SSH`).
- `apply-templates.sh` / `apply-lifecycle.sh`: replaced their standalone `curl_es()` (hardcoded `-sk`, re-derived credentials) with sourcing `es_common.sh` + `esj` — real TLS verification, one source of truth.
- `test_rbac.sh`: its `as()` helper reuses the already-computed `ES_TLS` array instead of a separate hardcoded `-sk`.
- `verify_detections.py`: same `ES_CA`-default / `ES_INSECURE` pattern in Python; refusal returns exit 2 (matching the existing `TransportError` convention).
- `docker-compose.yml`: the `lifecycle` one-shot (runs the two scripts above; `logstash` depends on it completing) had **no certs volume mounted and no `ES_CA` set** — unlike its sibling `roles` service, which already correctly verifies via `--cacert`. Without this addition, hardening the scripts above would have broken stack startup. Mirrors `roles`'s existing, working config exactly.
- Control mapping: NIST SP 800-53 Rev.5 SC-8 (Transmission Confidentiality and Integrity); NIST CSF 2.0 PR.DS-02.

## Intentional behavior change
Any host invocation of these scripts that relied on the implicit `-k` fallback now needs `ES_CA=<path>` or `ES_INSECURE=true` — that's the point of closing SC-8, not a side effect.

## Test plan
None of these scripts run in existing CI, so this was verified end-to-end against the live running stack rather than unit tests:
- [x] `apply-templates.sh` and `apply-lifecycle.sh` both succeed with the real CA (`ES_CA=~/.config/suburban-soc/ca.crt`) — all HTTP 200s
- [x] Both correctly refuse (exit 1) with a bad/missing CA and no opt-out, and warn-and-proceed with `ES_INSECURE=true`
- [x] `test_rbac.sh`'s 6 least-privilege checks all pass with real TLS verification (no `-k`)
- [x] `verify_detections.py` connects and queries successfully with the real CA; correctly exits 2 when the CA is missing and no opt-out is set
- [x] `docker compose config --quiet` validates the compose file; `bash -n` / `py_compile` on every touched script

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)