### PR TITLE
fix(#167): least-privilege slo_metrics account + systemd sandboxing

### DIFF
--- a/configs/elasticsearch/roles/slo_metrics_reader.json
+++ b/configs/elasticsearch/roles/slo_metrics_reader.json
@@ -1,0 +1,11 @@
+{
+  "indices": [
+    {"names": [".alerts-security.alerts-*", "soar-actions-*", "logstash-security-*"],
+     "privileges": ["read", "view_index_metadata"]},
+    {"names": ["soc-slo-metrics"],
+     "privileges": ["create_index", "create"]}
+  ],
+  "applications": [
+    {"application": "kibana-.kibana", "privileges": ["feature_generalCases.read"], "resources": ["*"]}
+  ]
+}

--- a/configs/systemd/slo-metrics.service
+++ b/configs/systemd/slo-metrics.service
@@ -16,15 +16,18 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-# Runs as the repo owner so it can read scripts/setup/.env (ELASTIC_PASSWORD) and use the
-# user's Docker Desktop context for the CA extraction below.
+# Runs as the repo owner so it can read scripts/setup/.env and use the user's Docker
+# Desktop context for the CA extraction below.
 User=tjlam
-# slo_metrics.py needs broad READ (.alerts-security.alerts-*, soar-actions-*,
-# logstash-security-*) plus WRITE to soc-slo-metrics, so it runs as the `elastic`
-# superuser — NOT the agent's least-privilege logstash_internal user. ELASTIC_PASSWORD is
-# auto-loaded by the script from scripts/setup/.env; ES_USER defaults to elastic.
+# audit #167 / NIST AC-6: slo_metrics.py needs READ on .alerts-security.alerts-*,
+# soar-actions-*, logstash-security-* plus WRITE to soc-slo-metrics — it now runs as
+# the least-privilege `slo_metrics` user (role: slo_metrics_reader), not the `elastic`
+# superuser. EnvironmentFile loads SLO_METRICS_PASSWORD from .env; ES_PASS below
+# resolves it via systemd's ${VAR} expansion (systemd >= 246).
+EnvironmentFile=/home/tjlam/projects/Suburban-SOC/scripts/setup/.env
 Environment=ES_URL=https://localhost:9200
-Environment=ES_USER=elastic
+Environment=ES_USER=slo_metrics
+Environment=ES_PASS=${SLO_METRICS_PASSWORD}
 Environment=ES_CA=/run/suburban-soc-slo/ca.crt
 # /run/suburban-soc-slo, owned by the service user; auto-removed when the unit stops.
 RuntimeDirectory=suburban-soc-slo
@@ -35,6 +38,28 @@ ExecStart=/usr/bin/python3 /home/tjlam/projects/Suburban-SOC/scripts/setup/ai_ag
 # slo_metrics.py exits 2 when an SLO is breaching — that's a successful run reporting a
 # breach, not a job failure. Treat 0 and 2 as success so the timer isn't marked failed.
 SuccessExitStatus=0 2
+
+# --- Sandboxing (audit #167 / NIST CM-7) ---------------------------------------
+# This unit only makes outbound HTTPS calls (requests) and reads the repo/.env —
+# it needs no special Linux capabilities, kernel access, or namespace privileges.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=true
+ProtectClock=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+ProtectHostname=true
+RestrictNamespaces=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+LockPersonality=true
+RemoveIPC=true
+UMask=0077
+CapabilityBoundingSet=
+SystemCallArchitectures=native
 
 [Install]
 WantedBy=multi-user.target

--- a/configs/systemd/zeek-host-capture.service
+++ b/configs/systemd/zeek-host-capture.service
@@ -46,5 +46,26 @@ ExecStop=-/usr/bin/docker stop -t 10 zeek-host-capture
 Restart=always
 RestartSec=5
 
+# --- Sandboxing (audit #167 / NIST CM-7) ---------------------------------------
+# CONSERVATIVE by design: tcpdump needs raw packet capture and this unit needs
+# the Docker socket, both effectively root-equivalent — User=/CapabilityBoundingSet=
+# are intentionally NOT touched here (see #167 PR discussion: narrowing capabilities
+# blind, with no safe way to live-test against a running capture, risks silently
+# blacking out the only network telemetry source). These directives restrict
+# unrelated attack surface only and don't affect capture or Docker access.
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=read-only
+PrivateTmp=true
+ProtectClock=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+ProtectHostname=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+LockPersonality=true
+
 [Install]
 WantedBy=multi-user.target

--- a/planned_execution.md
+++ b/planned_execution.md
@@ -9,20 +9,75 @@ Status: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
 
 ## NEXT UP
 
-**Phase: SOP-147 dashboard validation — COMPLETE. Open-issue backlog is empty.**
+**Phase: Structural Health Review Remediation — Priority 1 (Critical) COMPLETE
+(pending merge). Priority 2 not yet started.**
+Source: repo-wide structural/NIST-CSF-2.0/SP-800-53-Rev.5-aligned review,
+2026-07-08 — 14 issues filed (#164-#177) and linked to
+[Project Board #17](https://github.com/users/voltron-1/projects/17).
 
-Next unstarted item: none. Define the next phase with the owner.
+Next unstarted item: define P2 order with the owner (#168-#172 — CI lint
+gate, Logstash DLQ, ES client consolidation, broker logging, reporting-plane
+tests), or merge the four open P1 PRs first.
 
-- [x] **#160** — zeek.ssl SNI/Cipher panels ECS-normalized + rendering live ([PR #162](https://github.com/voltron-1/Suburban_SOC/pull/162), merged; issue closed).
-- [x] **#161** — Failed SSH by Country geoip/grok fix + rendering live ([PR #162](https://github.com/voltron-1/Suburban_SOC/pull/162), merged; issue closed).
+- [~] **#164** — Broker: unvalidated `attacker_ip` reached the `nft`/SSH command
+  sink (NIST SP 800-53 Rev.5 SI-10 / CSF 2.0 PR.PS-06). Fixed + tested on branch
+  `remediation/issue-164-nist` (commit `beaac0b`); broker suite 23→29 tests, all
+  passing. [PR #178](https://github.com/voltron-1/Suburban_SOC/pull/178) opened
+  — awaiting review/merge.
+- [~] **#165** — SLO metrics & threat hunts silently swallowed ES errors as false
+  negatives (SI-11). Fixed + tested on branch `remediation/issue-165-nist`
+  (commit `46b81cb`); 20 new tests, all passing (real CI confirmed via
+  `soar-tests.yml` for the slo_metrics half — `run_hunts.py` has no CI path yet,
+  tracked under #168). [PR #179](https://github.com/voltron-1/Suburban_SOC/pull/179)
+  opened — awaiting review/merge. Deferred `agent_app.py:696` (audit-write
+  visibility) to a follow-up — no metrics/health surface to hook a counter into yet.
+- [~] **#166** — Bash admin tooling skipped TLS verification (`curl -k`) while
+  sending ES credentials (SC-8). Fixed + verified end-to-end against the live
+  running stack (no CI path for these scripts) on branch
+  `remediation/issue-166-nist` (commit `70245a9`); also fixed the `lifecycle`
+  compose one-shot, which had no CA mounted and would have broken stack startup
+  once the fail-closed default landed. [PR #180](https://github.com/voltron-1/Suburban_SOC/pull/180)
+  opened — awaiting review/merge. Operator note: any host script relying on the
+  old implicit `-k` fallback now needs `ES_CA=<path>` or `ES_INSECURE=true`.
+- [~] **#167** — Unhardened systemd units + `elastic` superuser default in host
+  automation (AC-6, CM-7). New least-privilege `slo_metrics_reader` ES role +
+  `slo_metrics` user, live-created and verified end-to-end against the running
+  stack (explicit confirmation obtained before mutating the live cluster);
+  `slo-metrics.service` sandboxed (empty CapabilityBoundingSet, ProtectSystem=
+  strict, etc.) and switched off the `elastic` superuser. `zeek-host-capture.
+  service` hardened conservatively only (no capability/User= changes — it's
+  actively capturing real traffic with no safe way to live-test a narrower
+  capability set; does not reach the ≤6.0 target, tracked as a follow-up).
+  `es_common.sh`'s shared `elastic` default deliberately left alone (~15 other
+  legitimate admin-tooling consumers depend on it). Branch
+  `remediation/issue-167-nist` (commit `ee163b9`).
+  [PR #181](https://github.com/voltron-1/Suburban_SOC/pull/181) opened — awaiting
+  review/merge. Template-only change; operator must redeploy both units
+  (`sudo cp ... && systemctl daemon-reload && systemctl restart ...`) to apply.
 
-Evidence: `findings/20260707-160-161-logstash-ecs-geoip.md`. Pipeline config reloaded on the
-running Logstash (container restarted) — forward enrichment active.
+P2 (next sprint, #168-#172) and P3 (backlog, #173-#177) are tracked on
+[Project Board #17](https://github.com/users/voltron-1/projects/17); not
+individually sequenced here until the four P1 PRs above merge.
+
+Note: #164, #165, #166, and #167 are on independent branches off the same
+`origin/main` commit, each with its own `planned_execution.md` edit — expect
+trivial merge conflicts in this file as each PR merges; resolve by keeping all
+items' status lines, and flip each to `[x]` (with its PR link) once merged.
 
 ---
 
 ## LAST SESSION — 2026-07-08
 
+- Principal-engineer structural health review of the full repo (architecture map,
+  robustness/access-control gap analysis mapped to NIST CSF 2.0 + SP 800-53
+  Rev.5, sustainability/test/resource-management lenses). Filed 14 issues
+  (#164-#177: P1 critical ×4, P2 medium ×5, P3 low ×5) with evidence, control
+  mappings, and acceptance criteria; labeled by priority/nist-compliance/
+  tech-debt/security; linked to [Project Board #17](https://github.com/users/voltron-1/projects/17).
+- All four P1 (critical) items fixed, tested, and PR'd this session — see NEXT UP
+  above for branch/commit/PR detail on #164, #165, #166, #167. None merged yet;
+  each PR includes end-to-end verification against the live running stack where
+  no CI path existed to lean on instead.
 - #160/#161: shipped pipeline ECS fixes + HIGH source.ip-spoof hardening (parallel
   code-reviewer + security-auditor); **PR #162 merged, both issues closed.** Live investigation
   found two extra root causes the issues missed: (1) panels bucket on `.keyword` subfields

--- a/scripts/setup/.env.example
+++ b/scripts/setup/.env.example
@@ -34,6 +34,10 @@ SOC_AGENT_HMAC_SECRET=changeme_soar_webhook_secret
 # open/close tracked Cases. Set it to enable case tracking; blank = setup skips the
 # user and the agent skips cases (alert handling still works). openssl rand -hex 24
 SOC_AGENT_KIBANA_PASSWORD=changeme_soc_agent_kibana_password
+# audit #167: password for the least-privilege `slo_metrics` user (role:
+# slo_metrics_reader) — slo-metrics.service uses this instead of the elastic
+# superuser. openssl rand -base64 24
+SLO_METRICS_PASSWORD=changeme_slo_metrics
 
 # --- AI agent notifications & LLM triage (optional; blank = feature disabled) ---
 # ntfy topic for mobile push alerts. Pick a long, unguessable value.

--- a/scripts/setup/docker-compose.yml
+++ b/scripts/setup/docker-compose.yml
@@ -138,6 +138,7 @@ services:
       - KIBANA_PASSWORD=${KIBANA_PASSWORD}
       - LOGSTASH_PASSWORD=${LOGSTASH_PASSWORD}
       - SOC_AGENT_KIBANA_PASSWORD=${SOC_AGENT_KIBANA_PASSWORD:-}
+      - SLO_METRICS_PASSWORD=${SLO_METRICS_PASSWORD:-}
     volumes:
       - certs:/usr/share/elasticsearch/config/certs
     working_dir: /usr/share/elasticsearch
@@ -159,6 +160,11 @@ services:
           echo "Provisioning soc_agent_cases role + soc_agent user (WS2.3 Kibana Cases)";
           curl -s -X PUT --cacert config/certs/ca/ca.crt -u "elastic:${ELASTIC_PASSWORD}" -H "Content-Type: application/json" https://elasticsearch:9200/_security/role/soc_agent_cases -d "{\"applications\":[{\"application\":\"kibana-.kibana\",\"privileges\":[\"feature_generalCases.all\"],\"resources\":[\"*\"]}]}" > /dev/null;
           curl -s -X PUT --cacert config/certs/ca/ca.crt -u "elastic:${ELASTIC_PASSWORD}" -H "Content-Type: application/json" https://elasticsearch:9200/_security/user/soc_agent -d "{\"password\":\"${SOC_AGENT_KIBANA_PASSWORD}\",\"roles\":[\"soc_agent_cases\"],\"full_name\":\"SOC AI agent (Kibana Cases)\"}" > /dev/null;
+        fi;
+        if [ x${SLO_METRICS_PASSWORD} != x ]; then
+          echo "Provisioning slo_metrics_reader role + slo_metrics user (audit #167 — replaces elastic superuser)";
+          curl -s -X PUT --cacert config/certs/ca/ca.crt -u "elastic:${ELASTIC_PASSWORD}" -H "Content-Type: application/json" https://elasticsearch:9200/_security/role/slo_metrics_reader -d "{\"indices\":[{\"names\":[\".alerts-security.alerts-*\",\"soar-actions-*\",\"logstash-security-*\"],\"privileges\":[\"read\",\"view_index_metadata\"]},{\"names\":[\"soc-slo-metrics\"],\"privileges\":[\"create_index\",\"create\"]}],\"applications\":[{\"application\":\"kibana-.kibana\",\"privileges\":[\"feature_generalCases.read\"],\"resources\":[\"*\"]}]}" > /dev/null;
+          curl -s -X PUT --cacert config/certs/ca/ca.crt -u "elastic:${ELASTIC_PASSWORD}" -H "Content-Type: application/json" https://elasticsearch:9200/_security/user/slo_metrics -d "{\"password\":\"${SLO_METRICS_PASSWORD}\",\"roles\":[\"slo_metrics_reader\"],\"full_name\":\"SLO metrics (Suburban-SOC)\"}" > /dev/null;
         fi;
         echo "Provisioning complete.";
       '


### PR DESCRIPTION
## Summary
- `slo-metrics.service` ran as the `elastic` superuser for a job that only needs narrow read access plus one create-only write; neither it nor `zeek-host-capture.service` had any systemd sandboxing directives (baseline `systemd-analyze security`: **9.2** and **9.6**, both UNSAFE).
- New `configs/elasticsearch/roles/slo_metrics_reader.json`: read on `.alerts-security.alerts-*`/`soar-actions-*`/`logstash-security-*`, create-only on `soc-slo-metrics`, read-only Kibana Cases access (`metric_false_positive_pct()` calls the Cases API under the same ES credential — easy to miss, caught by live verification below).
- `docker-compose.yml`'s `provision` one-shot now provisions the role + a `slo_metrics` user when `SLO_METRICS_PASSWORD` is set, mirroring the existing `soc_agent` pattern exactly.
- `slo-metrics.service`: `EnvironmentFile=` + `${VAR}` expansion swaps `ES_USER`/`ES_PASS` to the new account with **zero script changes**; added `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome=read-only`, `PrivateTmp`, the `Protect{Clock,KernelLogs,KernelModules,KernelTunables,ControlGroups,Hostname}` family, `RestrictNamespaces`, `RestrictSUIDSGID`, `RestrictRealtime`, `LockPersonality`, `RemoveIPC`, `UMask=0077`, `CapabilityBoundingSet=` (empty), `SystemCallArchitectures=native` — safe for a `requests`-only HTTPS client with no special capability needs.
- `zeek-host-capture.service`: **conservative hardening only** (the capability-independent subset of the same directives). `User=`/`CapabilityBoundingSet=` intentionally untouched.
- Control mapping: NIST SP 800-53 Rev.5 AC-6 (Least Privilege), CM-7 (Least Functionality).

## Scope refinements from the original issue text
- **`es_common.sh`'s `elastic` default is not removed.** ~15 other consumers (tenant provisioning, template/ILM admin, RBAC role creation, `test_rbac.sh`'s own admin helper) legitimately need it. Only `slo-metrics.service`'s own `ES_USER` is overridden.
- **No new Linux system account created for either unit** — `User=` unchanged for both; that's a host-level `useradd` action outside this PR.
- **`zeek-host-capture.service` does not reach the ≤6.0 exposure target from the original issue.** It needs raw packet capture (`tcpdump`) + Docker socket access, both effectively root-equivalent, and this service is **actively capturing real traffic on this host right now** with no safe way to live-test a narrower capability set (no passwordless sudo available for a non-disruptive `systemd-run` trial, and I won't touch the live installed unit). Capability-scoping for this unit is left as a separate, live-tested follow-up rather than guessed at against a running capture.

## Test plan
- [x] **Live-verified the credential swap end-to-end** (explicit confirmation obtained before mutating the live cluster): applied `slo_metrics_reader` + created the `slo_metrics` user via the ES API on the running cluster, then ran `slo_metrics.py` locally with the new credentials — every read (alerts, soar-actions, logstash-security), the Kibana Cases call, and the write to `soc-slo-metrics` all succeeded (exit 2 — a genuine pre-existing ingest-lag breach on this host, not a permission error)
- [x] `systemd-analyze verify` passes on both edited unit files
- [x] `docker compose config --quiet` validates after the `provision` service edit
- [x] Template-only change — the actually-installed/running units are untouched; redeploying requires the operator's own `sudo cp ... && systemctl daemon-reload && systemctl restart ...`, per each unit's existing documented install steps. Please confirm the post-deploy `systemd-analyze security slo-metrics.service` score once redeployed — I couldn't get a live number without root.

Fixes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)