### PR TITLE
fix(#183): bump weasyprint 68.0 -> 69.0 (CVE-2026-49452)

### DIFF
--- a/scripts/setup/ai_agent/requirements.txt
+++ b/scripts/setup/ai_agent/requirements.txt
@@ -4,4 +4,4 @@ flask==3.1.3
 requests==2.33.0
 elasticsearch==8.15.1
 jinja2==3.1.6
-weasyprint==68.0
+weasyprint==69.0


### PR DESCRIPTION
## Summary

- `weasyprint==68.0` in `scripts/setup/ai_agent/requirements.txt` carries a disclosed CSS-injection CVE (CVE-2026-49452 / GHSA-jhhc-3hcp-qhm5), surfaced by the `pip-audit` CI job.
- Checked PyPI's advisory data directly per-release: **68.1 still carries the same advisory** — only 69.0 is clear. Confirmed against WeasyPrint's own changelog, which names 69.0 as the security release for this exact CVE.
- `weekly_ciso_report.py`'s only call site (`HTML(string=rendered).write_pdf(...)`) doesn't touch either of 69.0's two breaking API changes (CLI `--srgb` → `--output-intent`, Python `srgb` → `output_intent`), so no code changes are needed beyond the pin bump.

## Test plan

- [x] `pip-audit -r scripts/setup/ai_agent/requirements.txt` — clean (was: 1 known vulnerability)
- [x] `ruff check .` / `mypy` (repo-wide) — clean
- [x] Live-verified: installed the bumped requirements in a fresh venv and rendered a real PDF via the exact call pattern used in `weekly_ciso_report.py`
- [x] Rebuilt the actual `soc_ai_agent` container against the new pin, confirmed it starts cleanly, and rendered a real PDF *inside* the running container (native lib compatibility confirmed, not just the venv)

Closes #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)