### PR TITLE
fix(#172): reporting-plane test coverage + gunicorn WSGI server (SA-11, SC-5)

### DIFF
--- a/.github/workflows/reporting-coverage.yml
+++ b/.github/workflows/reporting-coverage.yml
@@ -1,0 +1,47 @@
+name: Reporting Plane Coverage
+
+# audit #172 (SA-11): line-coverage gate for the SOC's self-reporting/metrics
+# plane (slo_metrics.py, run_hunts.py, weekly_ciso_report.py), which had zero
+# automated tests. Kept out of soar-tests.yml deliberately — that workflow's
+# own header comment explains it avoids the heavy WeasyPrint/elasticsearch
+# deps by stubbing weekly_ciso_report.py; this workflow exists specifically
+# to exercise the real module, so it needs those deps (and WeasyPrint's
+# native libs, matching scripts/setup/ai_agent/Dockerfile) for real.
+# audit #168 precedent: runs on EVERY PR, no path filter.
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  reporting-coverage:
+    name: pytest-cov >= 70% (slo_metrics / run_hunts / weekly_ciso_report)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      # Matches scripts/setup/ai_agent/Dockerfile — WeasyPrint's cffi/cairo
+      # bindings need these to be *loadable* just to import the module, not
+      # only to render a PDF.
+      - name: Install WeasyPrint native dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libglib2.0-0 libpango-1.0-0 libpangocairo-1.0-0 \
+            libgdk-pixbuf-2.0-0 libcairo2 libffi8 shared-mime-info
+
+      - name: Install Python dependencies
+        run: |
+          pip install --quiet -r scripts/setup/ai_agent/requirements.txt
+          pip install --quiet pyyaml pytest pytest-cov
+
+      - name: Coverage gate (fails under 70% line coverage)
+        run: |
+          pytest tests/ai_agent/test_slo_metrics.py \
+                 tests/ai_agent/test_weekly_ciso_report.py \
+                 tests/hunts/test_run_hunts.py \
+                 --cov=slo_metrics --cov=run_hunts --cov=weekly_ciso_report \
+                 --cov-report=term-missing --cov-fail-under=70

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ __pycache__/
 *.pyc
 .pytest_cache/
 scripts/hive-mind-broker/.pytest_cache/
+.coverage
 
 # Local deployment configurations
 scripts/setup/.env

--- a/plans/20260711-issue-172-reporting-coverage-gunicorn.md
+++ b/plans/20260711-issue-172-reporting-coverage-gunicorn.md
@@ -1,0 +1,91 @@
+# #172 — reporting-plane test coverage + gunicorn (SA-11, SC-5)
+
+## Scope (from issue acceptance criteria)
+
+1. pytest-cov line coverage ≥70% on `slo_metrics.py`, `run_hunts.py`,
+   `weekly_ciso_report.py`, gated in CI.
+2. Agent container runs under `gunicorn` instead of the Werkzeug dev server.
+3. Container healthcheck passes under the new WSGI server.
+4. `tests/ai_agent/test_alert_auth.py` stays green after the server swap.
+
+## Findings from investigation
+
+- The issue's evidence is partly stale: `tests/ai_agent/test_slo_metrics.py`
+  (13 tests) and `tests/hunts/test_run_hunts.py` (6 tests) already exist —
+  added by #165's fix (PR #179) — but both have real coverage gaps (only
+  failure-path branches of several metrics/helpers are tested, not the
+  happy-path branches; `es()`/`kb()`/`main()`'s breach/NTFY paths are
+  untested). Neither test file is wired into ANY CI workflow at all —
+  `soar-tests.yml` only runs `test_alert_auth.py`. `weekly_ciso_report.py`
+  has zero direct tests — `test_alert_auth.py` stubs it out entirely via
+  `sys.modules` injection so `agent_app.py` can import without pulling in
+  weasyprint/elasticsearch/jinja2.
+- Gunicorn's `-w 2` (multi-process) suggested in the issue text would be a
+  **security regression**: `agent_app.py` keeps `_seen_sigs` (HMAC replay
+  nonce cache) and `_queue_lock`-guarded approval-queue writes as in-process
+  state guarded by `threading.Lock` — thread-safe, not process-safe. Two
+  worker *processes* each get an independent `_seen_sigs` dict, so a
+  replayed signature has a real chance of landing on the worker that never
+  saw the original, silently defeating replay protection. Using
+  `--worker-class gthread --workers 1 --threads 4` instead keeps a single
+  process (existing locks stay correct) while still moving off the raw dev
+  server for SC-5/production-readiness. Documenting this deviation clearly
+  since it contradicts the issue's literal suggestion.
+- Importing `weasyprint` requires its native libs (pango/cairo/gdk-pixbuf) to
+  be *loadable*, not just present at render time — so any CI job that
+  imports `weekly_ciso_report.py` needs the same `apt-get install` list as
+  `scripts/setup/ai_agent/Dockerfile`. `soar-tests.yml` deliberately avoids
+  this weight (its own header comment says so) — adding it there would
+  contradict that file's stated design. New dedicated workflow instead:
+  `.github/workflows/reporting-coverage.yml`.
+- No existing healthcheck for the `ai-agent` compose service. All its routes
+  need a signed body or return JSON requiring auth — rather than add a new
+  unauthenticated `/health` route (out of scope) or fight curl's `-f`
+  semantics against an auth-gated route, use a plain TCP-connect check
+  (stdlib `socket`, no new binary/dependency needed in the slim image):
+  confirms gunicorn is bound and accepting connections without touching HTTP
+  auth semantics at all.
+
+## File changes
+
+- `tests/ai_agent/test_slo_metrics.py` — add happy-path tests for
+  `metric_coverage`/`metric_false_positive_pct`/`metric_parse_error_pct`
+  (including the zero-total no-division-by-zero branch), a test that
+  exercises the real `es()`/`kb()` wrappers (mocking `SESSION` instead of
+  the wrapper), and `main()`'s breach-detected (exit 2) + NTFY-sent +
+  NTFY-failure-swallowed paths.
+- `tests/hunts/test_run_hunts.py` — add: no-hunts-found (exit 1),
+  missing-ES_PASS (exit 1, via monkeypatching the module global before
+  calling `main()` directly), and a hunt whose count meets its threshold
+  (finding=True branch).
+- `tests/ai_agent/test_weekly_ciso_report.py` — new file: `_tag_to_nist`
+  (valid/case-variant/malformed tags), `fetch_and_calculate_metrics`
+  (mocked `Elasticsearch` happy path with MTTD+NIST calc, and the
+  connection-failure demo-fallback path), `generate_executive_summary`
+  (hosted-LLM-blocked, local-LLM success, LLM-failure), `create_pdf_report`
+  (real weasyprint render to a temp path — libs are already confirmed
+  working on this host from #183's verification), `send_to_slack`
+  (no-creds, full 3-step happy path, and a failure at each step),
+  `send_ntfy_notification` (success + swallowed-failure), and a
+  `run_reporting_pipeline` wiring test with all sub-functions mocked.
+- `.github/workflows/reporting-coverage.yml` — new workflow: apt-get the
+  weasyprint native libs, `pip install -r scripts/setup/ai_agent/requirements.txt
+  pyyaml pytest pytest-cov`, run pytest-cov against the three target files
+  with `--cov-fail-under=70`.
+- `scripts/setup/ai_agent/requirements.txt` — add `gunicorn`.
+- `scripts/setup/ai_agent/Dockerfile` — CMD →
+  `gunicorn --worker-class gthread --workers 1 --threads 4 --bind 0.0.0.0:5000
+  --access-logfile - --error-logfile - agent_app:app`.
+- `scripts/setup/docker-compose.yml` — add a TCP-connect healthcheck to the
+  `ai-agent` service.
+
+## Verification
+
+- `pytest --cov=... --cov-report=term-missing` locally against all three
+  files, confirm ≥70% each before pushing.
+- `pytest tests/ai_agent/test_alert_auth.py` stays green (acceptance
+  criterion — the stub pattern shouldn't be touched).
+- Live: rebuild `soc_ai_agent`, confirm gunicorn starts (check `docker logs`
+  for the gunicorn banner, not the Werkzeug dev-server warning), confirm the
+  new healthcheck reports healthy, send a real signed `/alert` webhook
+  end-to-end to confirm nothing broke under gunicorn.

--- a/scripts/setup/ai_agent/Dockerfile
+++ b/scripts/setup/ai_agent/Dockerfile
@@ -35,5 +35,16 @@ USER appuser
 # 5. Expose port 5000 for Kibana webhooks
 EXPOSE 5000
 
-# 6. Command to run the application
-CMD ["python", "agent_app.py"]
+# 6. Command to run the application (audit #172, SA-11/SC-5): gunicorn instead
+#    of Werkzeug's single-threaded dev server. Deliberately --workers 1 (a
+#    single PROCESS) rather than the multi-process "-w 2" a naive prod-WSGI
+#    swap would use: agent_app.py's replay-nonce cache (_seen_sigs) and its
+#    approval-queue writer (_queue_lock) are threading.Lock-guarded in-process
+#    state, not cross-process-safe — two worker processes would each keep an
+#    independent nonce cache, so a replayed HMAC signature could land on the
+#    worker that never saw the original and be silently re-accepted.
+#    --worker-class gthread --threads 4 keeps a single process (existing locks
+#    stay correct) while still adding real concurrency over the dev server.
+CMD ["gunicorn", "--worker-class", "gthread", "--workers", "1", "--threads", "4", \
+     "--bind", "0.0.0.0:5000", "--access-logfile", "-", "--error-logfile", "-", \
+     "agent_app:app"]

--- a/scripts/setup/ai_agent/agent_app.py
+++ b/scripts/setup/ai_agent/agent_app.py
@@ -93,6 +93,9 @@ APPROVAL_QUEUE = os.environ.get(
     str((Path(__file__).resolve().parent / "approval_queue.jsonl")),
 )
 _queue_lock = threading.Lock()
+# audit #172: any status other than "pending" means the action is no longer
+# awaiting approval — "claimed" marks one mid-execution (see approve_action).
+_RESOLVED_STATUSES = ("approved", "denied", "claimed")
 
 # Hive-Mind broker — the router-block dispatcher (#109). The agent runs in a slim
 # container with no ssh/sudo, so it can't run isolate.sh against a router itself.
@@ -854,7 +857,7 @@ def list_pending():
         return auth_error
     pending = [a for a in _read_queue() if a.get("status") == "pending"]
     # An action is 'pending' unless a later line resolved it; collapse by id.
-    resolved = {a["id"] for a in _read_queue() if a.get("status") in ("approved", "denied")}
+    resolved = {a["id"] for a in _read_queue() if a.get("status") in _RESOLVED_STATUSES}
     pending = [a for a in pending if a["id"] not in resolved]
     return jsonify({"pending": pending, "count": len(pending)}), 200
 
@@ -879,13 +882,26 @@ def approve_action():
     # Subtract already-resolved ids (audit P2-9) so an action can't be approved (and
     # executed) twice — the queue is append-only, so the original 'pending' line
     # survives after approval. Mirrors list_pending and the broker.
-    queue = _read_queue()
-    resolved = {a["id"] for a in queue if a.get("status") in ("approved", "denied")}
-    pending = {a["id"]: a for a in queue
-               if a.get("status") == "pending" and a["id"] not in resolved}
-    action = pending.get(action_id)
-    if not action:
-        return jsonify({"error": f"no pending action {action_id}"}), 404
+    #
+    # audit #172: the read-check-and-claim below is atomic under _queue_lock. Under
+    # the old single-threaded Werkzeug dev server, requests were implicitly
+    # serialized so this race could never surface; gunicorn's gthread workers make
+    # requests genuinely concurrent, so two POST /approve for the same action_id
+    # (each with its own fresh, valid signature — the replay-nonce cache does not
+    # protect against two *different* signed requests) could otherwise both observe
+    # "pending" and both execute the isolation. Claiming the id atomically here,
+    # before the (slow, network-bound) isolation call, closes that window.
+    with _queue_lock:
+        queue = _read_queue()
+        resolved = {a["id"] for a in queue if a.get("status") in _RESOLVED_STATUSES}
+        pending = {a["id"]: a for a in queue
+                   if a.get("status") == "pending" and a["id"] not in resolved}
+        action = pending.get(action_id)
+        if not action:
+            return jsonify({"error": f"no pending action {action_id}"}), 404
+        with open(APPROVAL_QUEUE, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"id": action_id, "ts": time.time(),
+                                  "status": "claimed", "approver": approver}) + "\n")
 
     _t0 = time.time()
     action_tenant = safe_tenant(action.get("tenant"))

--- a/scripts/setup/ai_agent/requirements.txt
+++ b/scripts/setup/ai_agent/requirements.txt
@@ -5,3 +5,4 @@ requests==2.33.0
 elasticsearch==8.15.1
 jinja2==3.1.6
 weasyprint==69.0
+gunicorn==26.0.0

--- a/scripts/setup/docker-compose.yml
+++ b/scripts/setup/docker-compose.yml
@@ -403,6 +403,18 @@ services:
       context: ./ai_agent
     container_name: soc_ai_agent
     mem_limit: 512m        # audit P2-3
+    # audit #172: GET /weekly-report/status is an existing unauthenticated,
+    # side-effect-free route built for exactly this — unlike a bare TCP
+    # connect, it actually exercises gunicorn's WSGI dispatch (a hung/deadlocked
+    # worker would still accept the TCP connection but never respond, so a
+    # connect-only check could report "healthy" against a dead app). No curl
+    # in the slim image; urllib is stdlib.
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/weekly-report/status', timeout=3).read()\""]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     depends_on:
       elasticsearch:
         condition: service_healthy

--- a/tests/ai_agent/test_alert_auth.py
+++ b/tests/ai_agent/test_alert_auth.py
@@ -253,6 +253,38 @@ class AlertResponseTests(unittest.TestCase):
         self.assertEqual(second.status_code, 404)
         self.mock_dispatch.assert_called_once()    # still exactly one dispatch
 
+    def test_concurrent_approve_of_same_id_dispatches_only_once(self):
+        # audit #172: under gunicorn's gthread workers, /approve requests are
+        # genuinely concurrent (the old single-threaded dev server serialized them
+        # implicitly). Two threads racing to approve the SAME action_id — each with
+        # a distinct, validly-signed request — must still execute isolation exactly
+        # once. A small delay in the mocked dispatch widens the race window so the
+        # unlocked read-check-execute this test guards against would otherwise
+        # reliably let both requests observe "pending" before either resolves it.
+        action_id = self._post({"severity": "critical", "source_ip": "1.2.3.4",
+                                "source_mac": GOOD_MAC}).get_json()["action_id"]
+
+        def _slow_dispatch(*a, **k):
+            time.sleep(0.05)
+            return (True, "IP blocked on 1/1 router(s)")
+        self.mock_dispatch.side_effect = _slow_dispatch
+
+        import threading
+        results = {}
+
+        def _approve(approver):
+            results[approver] = self._post(
+                {"id": action_id, "approver": approver}, path="/approve").status_code
+
+        threads = [threading.Thread(target=_approve, args=(f"racer-{i}",)) for i in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        self.mock_dispatch.assert_called_once()
+        self.assertEqual(sorted(results.values()), [200, 404])
+
     # --- WS0.3 tenant-scoped routing (the broker owns router resolution) ------
     def test_named_tenant_passed_to_broker_on_autonomous(self):
         # The agent forwards the tenant; the broker maps it to that tenant's routers.

--- a/tests/ai_agent/test_slo_metrics.py
+++ b/tests/ai_agent/test_slo_metrics.py
@@ -9,8 +9,11 @@ never silently collapse into a healthy-looking None/0 reading.
 Run:  python tests/ai_agent/test_slo_metrics.py     (or: pytest tests/ai_agent)
 """
 
+import contextlib
+import json
 import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -63,6 +66,25 @@ class MetricFunctionTests(unittest.TestCase):
                                return_value=_FakeResponse(200, {"hits": {"hits": []}})):
             self.assertIsNone(slo_metrics.metric_mttd())
 
+    def test_mttd_averages_real_hits_and_skips_bad_ones(self):
+        hits = [
+            # 10-minute detection delay
+            {"_source": {"kibana.alert.start": "2026-01-01T00:10:00Z",
+                          "kibana.alert.original_time": "2026-01-01T00:00:00Z"}},
+            # 20-minute detection delay
+            {"_source": {"kibana.alert.start": "2026-01-01T01:20:00Z",
+                          "kibana.alert.original_time": "2026-01-01T01:00:00Z"}},
+            # negative delta (clock skew) — must be skipped, not averaged in
+            {"_source": {"kibana.alert.start": "2026-01-01T02:00:00Z",
+                          "kibana.alert.original_time": "2026-01-01T02:30:00Z"}},
+            # malformed timestamp — must be skipped, not raise
+            {"_source": {"kibana.alert.start": "not-a-timestamp",
+                          "kibana.alert.original_time": "2026-01-01T03:00:00Z"}},
+        ]
+        with mock.patch.object(slo_metrics, "es",
+                               return_value=_FakeResponse(200, {"hits": {"hits": hits}})):
+            self.assertEqual(slo_metrics.metric_mttd(), 15.0)  # avg(10, 20)
+
     def test_mttr_raises_on_non_200(self):
         with mock.patch.object(slo_metrics, "es", return_value=_FakeResponse(500)):
             with self.assertRaises(slo_metrics.MetricUnavailable):
@@ -78,10 +100,42 @@ class MetricFunctionTests(unittest.TestCase):
             with self.assertRaises(slo_metrics.MetricUnavailable):
                 slo_metrics.metric_coverage()
 
+    def test_coverage_returns_technique_count_on_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            coverage_path = repo / "docs" / "detections"
+            coverage_path.mkdir(parents=True)
+            (coverage_path / "attack-coverage.json").write_text(
+                json.dumps({"techniques": ["T1110", "T1046", "T1078"]}), encoding="utf-8")
+            with mock.patch.object(slo_metrics, "REPO", repo):
+                self.assertEqual(slo_metrics.metric_coverage(), 3.0)
+
     def test_false_positive_pct_raises_on_kibana_failure(self):
         with mock.patch.object(slo_metrics, "kb", side_effect=ConnectionError("refused")):
             with self.assertRaises(slo_metrics.MetricUnavailable):
                 slo_metrics.metric_false_positive_pct()
+
+    def test_false_positive_pct_computes_percentage_on_success(self):
+        with mock.patch.object(slo_metrics, "kb", side_effect=[
+            _FakeResponse(200, {"total": 20}),
+            _FakeResponse(200, {"total": 4}),
+        ]):
+            self.assertEqual(slo_metrics.metric_false_positive_pct(), 20.0)
+
+    def test_false_positive_pct_zero_total_returns_zero_not_division_error(self):
+        with mock.patch.object(slo_metrics, "kb", side_effect=[
+            _FakeResponse(200, {"total": 0}),
+            _FakeResponse(200, {"total": 0}),
+        ]):
+            self.assertEqual(slo_metrics.metric_false_positive_pct(), 0.0)
+
+    def test_parse_error_pct_computes_percentage_on_success(self):
+        with mock.patch.object(slo_metrics, "_count", side_effect=[200, 2]):
+            self.assertEqual(slo_metrics.metric_parse_error_pct(), 1.0)
+
+    def test_parse_error_pct_zero_total_returns_zero_not_division_error(self):
+        with mock.patch.object(slo_metrics, "_count", side_effect=[0, 0]):
+            self.assertEqual(slo_metrics.metric_parse_error_pct(), 0.0)
 
     def test_ingest_lag_raises_on_request_failure(self):
         with mock.patch.object(slo_metrics, "es", side_effect=ConnectionError("refused")):
@@ -97,6 +151,30 @@ class MetricFunctionTests(unittest.TestCase):
         with mock.patch.object(slo_metrics, "es", side_effect=ConnectionError("refused")):
             with self.assertRaises(slo_metrics.MetricUnavailable):
                 slo_metrics.metric_parse_error_pct()
+
+
+class EsKbWrapperTests(unittest.TestCase):
+    """Cover the real es()/kb() request wrappers — every test above mocks them
+    out entirely, so their own bodies (SESSION.request/get plumbing) were
+    otherwise never exercised."""
+
+    def test_es_wrapper_calls_session_request(self):
+        with mock.patch.object(slo_metrics.SESSION, "request",
+                               return_value=_FakeResponse(200, {"ok": True})) as m:
+            r = slo_metrics.es("POST", "/some-index/_search", {"query": {}})
+        m.assert_called_once()
+        args, kwargs = m.call_args
+        self.assertEqual(args[0], "POST")
+        self.assertTrue(args[1].endswith("/some-index/_search"))
+        self.assertEqual(kwargs["data"], json.dumps({"query": {}}))
+        self.assertEqual(r.json(), {"ok": True})
+
+    def test_kb_wrapper_calls_session_get(self):
+        with mock.patch.object(slo_metrics.SESSION, "get",
+                               return_value=_FakeResponse(200, {"total": 5})) as m:
+            r = slo_metrics.kb("/api/cases/_find")
+        m.assert_called_once()
+        self.assertEqual(r.json(), {"total": 5})
 
 
 class MainExitCodeTests(unittest.TestCase):
@@ -137,6 +215,42 @@ class MainExitCodeTests(unittest.TestCase):
              mock.patch.object(slo_metrics, "NTFY_TOPIC", ""):
             code = self._run_main_capturing_exit()
         self.assertEqual(code, 0)
+
+    def _mock_all_metrics(self, mttd=0.0, mttr=0.0, coverage=12.0, fp_pct=0.0,
+                           ingest_lag=10.0, parse_err=0.0):
+        return [
+            mock.patch.object(slo_metrics, "metric_mttd", return_value=mttd),
+            mock.patch.object(slo_metrics, "metric_mttr", return_value=mttr),
+            mock.patch.object(slo_metrics, "metric_coverage", return_value=coverage),
+            mock.patch.object(slo_metrics, "metric_false_positive_pct", return_value=fp_pct),
+            mock.patch.object(slo_metrics, "metric_ingest_lag_seconds", return_value=ingest_lag),
+            mock.patch.object(slo_metrics, "metric_parse_error_pct", return_value=parse_err),
+            mock.patch.object(slo_metrics, "es", return_value=_FakeResponse(200, {})),
+        ]
+
+    def test_breach_detected_exits_2_and_sends_ntfy(self):
+        # mttd_minutes=999 blows through its <=30min target -> a real breach,
+        # everything else healthy.
+        with contextlib.ExitStack() as stack, \
+             mock.patch.object(slo_metrics, "NTFY_TOPIC", "test-topic"), \
+             mock.patch.object(slo_metrics.requests, "post") as ntfy_post:
+            for p in self._mock_all_metrics(mttd=999.0):
+                stack.enter_context(p)
+            code = self._run_main_capturing_exit()
+        self.assertEqual(code, 2)
+        ntfy_post.assert_called_once()
+        self.assertIn("mttd_minutes", ntfy_post.call_args.kwargs["data"].decode())
+
+    def test_ntfy_failure_is_swallowed_not_fatal(self):
+        # A downed ntfy.sh must not crash main() or change the breach exit code.
+        with contextlib.ExitStack() as stack, \
+             mock.patch.object(slo_metrics, "NTFY_TOPIC", "test-topic"), \
+             mock.patch.object(slo_metrics.requests, "post",
+                               side_effect=ConnectionError("refused")):
+            for p in self._mock_all_metrics(mttd=999.0):
+                stack.enter_context(p)
+            code = self._run_main_capturing_exit()
+        self.assertEqual(code, 2)
 
 
 if __name__ == "__main__":

--- a/tests/ai_agent/test_weekly_ciso_report.py
+++ b/tests/ai_agent/test_weekly_ciso_report.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""
+weekly_ciso_report.py — reporting-plane test coverage (issue #172, SA-11).
+
+Covers NIST tag parsing, ES metrics fetch (+ demo-data fallback), the LLM
+executive summary (+ hosted-egress gate), real PDF rendering, Slack's
+three-step upload, ntfy delivery, and the pipeline orchestrator.
+
+Run:  pytest tests/ai_agent/test_weekly_ciso_report.py
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+AGENT_DIR = Path(__file__).resolve().parents[2] / "scripts" / "setup" / "ai_agent"
+sys.path.insert(0, str(AGENT_DIR))
+
+# test_alert_auth.py unconditionally replaces sys.modules["weekly_ciso_report"]
+# with a stub before importing agent_app (so that import doesn't pull in
+# weasyprint/elasticsearch). In a combined test run that file collects first
+# alphabetically, so without evicting it here this module would silently bind
+# to that stub instead of the real implementation it exists to test.
+sys.modules.pop("weekly_ciso_report", None)
+import weekly_ciso_report as wcr  # noqa: E402
+
+
+class _FakeLLMResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise wcr.requests.exceptions.HTTPError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class TagToNistTests(unittest.TestCase):
+    def test_extracts_valid_nist_tags(self):
+        self.assertEqual(wcr._tag_to_nist(["NIST:Detect", "NIST:Respond"]),
+                          ["Detect", "Respond"])
+
+    def test_case_insensitive_prefix_and_function_name(self):
+        self.assertEqual(wcr._tag_to_nist(["nist:detect"]), ["Detect"])
+
+    def test_ignores_non_nist_tags(self):
+        self.assertEqual(wcr._tag_to_nist(["some-other-tag", "priority:high"]), [])
+
+    def test_ignores_unknown_nist_function(self):
+        self.assertEqual(wcr._tag_to_nist(["NIST:Bogus"]), [])
+
+    def test_empty_tag_list(self):
+        self.assertEqual(wcr._tag_to_nist([]), [])
+
+    def test_non_string_tag_does_not_raise(self):
+        self.assertEqual(wcr._tag_to_nist([123, None]), [])
+
+
+class FetchAndCalculateMetricsTests(unittest.TestCase):
+    def test_es_unreachable_falls_back_to_demo_data(self):
+        with mock.patch.object(wcr, "Elasticsearch", side_effect=ConnectionError("refused")):
+            metrics = wcr.fetch_and_calculate_metrics()
+        self.assertTrue(metrics["demo_mode"])
+        self.assertEqual(metrics["total_alerts"], 342)
+        self.assertIn("nist_breakdown", metrics)
+
+    def test_real_hits_compute_mttd_and_nist_breakdown(self):
+        hits = [
+            {"_source": {"@timestamp": "2026-01-01T00:00:00Z",
+                          "kibana": {"alert": {"start": "2026-01-01T00:10:00Z"}},
+                          "tags": ["NIST:Detect"]}},
+            {"_source": {"@timestamp": "2026-01-01T01:00:00Z",
+                          "kibana": {"alert": {"start": "2026-01-01T01:20:00Z"}},
+                          "tags": ["NIST:Respond", "NIST:Detect"]}},
+            # negative delta (clock skew) — must not be averaged in
+            {"_source": {"@timestamp": "2026-01-01T02:30:00Z",
+                          "kibana": {"alert": {"start": "2026-01-01T02:00:00Z"}},
+                          "tags": []}},
+            # missing timestamps entirely — must not raise
+            {"_source": {"tags": ["not-nist"]}},
+        ]
+        fake_es_instance = mock.Mock()
+        fake_es_instance.search.return_value = {"hits": {"hits": hits}}
+        with mock.patch.object(wcr, "Elasticsearch", return_value=fake_es_instance):
+            metrics = wcr.fetch_and_calculate_metrics()
+
+        self.assertFalse(metrics["demo_mode"])
+        self.assertEqual(metrics["total_alerts"], 4)
+        self.assertEqual(metrics["average_mttd_minutes"], 15.0)  # avg(10, 20)
+        self.assertEqual(metrics["nist_breakdown"]["Detect"], 2)
+        self.assertEqual(metrics["nist_breakdown"]["Respond"], 1)
+        self.assertEqual(metrics["nist_breakdown"]["Protect"], 0)
+
+
+class GenerateExecutiveSummaryTests(unittest.TestCase):
+    METRICS = {"total_alerts": 10, "average_mttd_minutes": 5.0,
+               "nist_breakdown": {"Detect": 10}}
+
+    def test_hosted_llm_blocked_by_default(self):
+        with mock.patch.object(wcr, "LLM_API_URL", "https://api.openai.com/v1/chat/completions"), \
+             mock.patch.object(wcr, "LLM_ALLOW_HOSTED", False), \
+             mock.patch.object(wcr.requests, "post") as post:
+            summary = wcr.generate_executive_summary(self.METRICS)
+        post.assert_not_called()
+        self.assertIn("skipped", summary.lower())
+
+    def test_local_llm_is_never_blocked(self):
+        with mock.patch.object(wcr, "LLM_API_URL", "http://localhost:11434/v1/chat/completions"), \
+             mock.patch.object(wcr, "LLM_ALLOW_HOSTED", False), \
+             mock.patch.object(wcr.requests, "post",
+                               return_value=_FakeLLMResponse(200, {
+                                   "choices": [{"message": {"content": "  Board summary.  "}}]})):
+            summary = wcr.generate_executive_summary(self.METRICS)
+        self.assertEqual(summary, "Board summary.")
+
+    def test_hosted_llm_allowed_when_opted_in(self):
+        with mock.patch.object(wcr, "LLM_API_URL", "https://api.openai.com/v1/chat/completions"), \
+             mock.patch.object(wcr, "LLM_ALLOW_HOSTED", True), \
+             mock.patch.object(wcr.requests, "post",
+                               return_value=_FakeLLMResponse(200, {
+                                   "choices": [{"message": {"content": "Hosted summary."}}]})) as post:
+            summary = wcr.generate_executive_summary(self.METRICS)
+        post.assert_called_once()
+        self.assertEqual(summary, "Hosted summary.")
+
+    def test_llm_failure_returns_fallback_message(self):
+        with mock.patch.object(wcr, "LLM_API_URL", "http://localhost:11434/v1/chat/completions"), \
+             mock.patch.object(wcr.requests, "post", side_effect=ConnectionError("refused")):
+            summary = wcr.generate_executive_summary(self.METRICS)
+        self.assertIn("could not be generated", summary)
+
+    def test_llm_non_200_returns_fallback_message(self):
+        with mock.patch.object(wcr, "LLM_API_URL", "http://localhost:11434/v1/chat/completions"), \
+             mock.patch.object(wcr.requests, "post", return_value=_FakeLLMResponse(500)):
+            summary = wcr.generate_executive_summary(self.METRICS)
+        self.assertIn("could not be generated", summary)
+
+
+class CreatePdfReportTests(unittest.TestCase):
+    def test_renders_real_pdf_with_demo_banner_and_zero_tagged(self):
+        metrics = {"total_alerts": 0, "average_mttd_minutes": 0,
+                   "nist_breakdown": {f: 0 for f in wcr.NIST_FUNCTIONS}, "demo_mode": True}
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = os.path.join(tmp, "report.pdf")
+            with mock.patch.object(wcr, "PDF_FILENAME", out_path):
+                result = wcr.create_pdf_report(metrics, "Paragraph one.\n\nParagraph two.")
+            self.assertEqual(result, out_path)
+            self.assertTrue(os.path.isfile(out_path))
+            self.assertGreater(os.path.getsize(out_path), 0)
+            with open(out_path, "rb") as fh:
+                self.assertTrue(fh.read(5).startswith(b"%PDF-"))
+
+    def test_renders_real_pdf_with_nist_breakdown_percentages(self):
+        metrics = {"total_alerts": 100, "average_mttd_minutes": 12.3,
+                   "nist_breakdown": {"Identify": 5, "Protect": 15, "Detect": 60,
+                                      "Respond": 15, "Recover": 5}, "demo_mode": False}
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = os.path.join(tmp, "report.pdf")
+            with mock.patch.object(wcr, "PDF_FILENAME", out_path):
+                result = wcr.create_pdf_report(metrics, "Some narrative.")
+            self.assertTrue(os.path.isfile(out_path))
+            self.assertEqual(result, out_path)
+
+
+class SendToSlackTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.pdf_path = os.path.join(self._tmp.name, "report.pdf")
+        with open(self.pdf_path, "wb") as fh:
+            fh.write(b"%PDF-1.7 fake pdf content")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_no_credentials_configured_returns_false_without_calling_slack(self):
+        with mock.patch.object(wcr, "SLACK_TOKEN", ""), \
+             mock.patch.object(wcr, "SLACK_CHANNEL", ""), \
+             mock.patch.object(wcr.requests, "get") as get:
+            self.assertFalse(wcr.send_to_slack(self.pdf_path))
+        get.assert_not_called()
+
+    def test_full_three_step_upload_succeeds(self):
+        with mock.patch.object(wcr, "SLACK_TOKEN", "xoxb-test"), \
+             mock.patch.object(wcr, "SLACK_CHANNEL", "C123"), \
+             mock.patch.object(wcr.requests, "get",
+                               return_value=_FakeLLMResponse(200, {
+                                   "ok": True, "upload_url": "https://slack.example/upload",
+                                   "file_id": "F123"})), \
+             mock.patch.object(wcr.requests, "put",
+                               return_value=mock.Mock(status_code=200)), \
+             mock.patch.object(wcr.requests, "post",
+                               return_value=_FakeLLMResponse(200, {"ok": True})):
+            self.assertTrue(wcr.send_to_slack(self.pdf_path))
+
+    def test_step1_failure_returns_false(self):
+        with mock.patch.object(wcr, "SLACK_TOKEN", "xoxb-test"), \
+             mock.patch.object(wcr, "SLACK_CHANNEL", "C123"), \
+             mock.patch.object(wcr.requests, "get",
+                               return_value=_FakeLLMResponse(200, {"ok": False})):
+            self.assertFalse(wcr.send_to_slack(self.pdf_path))
+
+    def test_step2_non_2xx_returns_false(self):
+        with mock.patch.object(wcr, "SLACK_TOKEN", "xoxb-test"), \
+             mock.patch.object(wcr, "SLACK_CHANNEL", "C123"), \
+             mock.patch.object(wcr.requests, "get",
+                               return_value=_FakeLLMResponse(200, {
+                                   "ok": True, "upload_url": "https://slack.example/upload",
+                                   "file_id": "F123"})), \
+             mock.patch.object(wcr.requests, "put",
+                               return_value=mock.Mock(status_code=500)):
+            self.assertFalse(wcr.send_to_slack(self.pdf_path))
+
+    def test_step3_failure_returns_false(self):
+        with mock.patch.object(wcr, "SLACK_TOKEN", "xoxb-test"), \
+             mock.patch.object(wcr, "SLACK_CHANNEL", "C123"), \
+             mock.patch.object(wcr.requests, "get",
+                               return_value=_FakeLLMResponse(200, {
+                                   "ok": True, "upload_url": "https://slack.example/upload",
+                                   "file_id": "F123"})), \
+             mock.patch.object(wcr.requests, "put",
+                               return_value=mock.Mock(status_code=200)), \
+             mock.patch.object(wcr.requests, "post",
+                               return_value=_FakeLLMResponse(200, {"ok": False, "error": "bad"})):
+            self.assertFalse(wcr.send_to_slack(self.pdf_path))
+
+
+class SendNtfyNotificationTests(unittest.TestCase):
+    METRICS = {"total_alerts": 7, "average_mttd_minutes": 3.5}
+
+    def test_success_posts_expected_message(self):
+        with mock.patch.object(wcr, "NTFY_TOPIC", "test-topic"), \
+             mock.patch.object(wcr.requests, "post") as post:
+            wcr.send_ntfy_notification(self.METRICS, pdf_delivered=True)
+        post.assert_called_once()
+        sent = post.call_args.kwargs["data"].decode()
+        self.assertIn("Delivered to Slack", sent)
+        self.assertIn("7", sent)
+
+    def test_failure_is_swallowed_not_raised(self):
+        with mock.patch.object(wcr, "NTFY_TOPIC", "test-topic"), \
+             mock.patch.object(wcr.requests, "post", side_effect=ConnectionError("refused")):
+            wcr.send_ntfy_notification(self.METRICS, pdf_delivered=False)  # must not raise
+
+
+class RunReportingPipelineTests(unittest.TestCase):
+    def test_orchestrates_all_stages_in_order_and_returns_summary(self):
+        metrics = {"total_alerts": 5, "average_mttd_minutes": 2.0, "demo_mode": False}
+        with mock.patch.object(wcr, "fetch_and_calculate_metrics", return_value=metrics) as m_fetch, \
+             mock.patch.object(wcr, "generate_executive_summary", return_value="narrative") as m_gen, \
+             mock.patch.object(wcr, "create_pdf_report", return_value="/tmp/report.pdf") as m_pdf, \
+             mock.patch.object(wcr, "send_to_slack", return_value=True) as m_slack, \
+             mock.patch.object(wcr, "send_ntfy_notification") as m_ntfy:
+            result = wcr.run_reporting_pipeline()
+
+        m_fetch.assert_called_once()
+        m_gen.assert_called_once_with(metrics)
+        m_pdf.assert_called_once_with(metrics, "narrative")
+        m_slack.assert_called_once_with("/tmp/report.pdf")
+        m_ntfy.assert_called_once_with(metrics, True)
+        self.assertEqual(result, {
+            "status": "complete", "pdf": "/tmp/report.pdf",
+            "total_alerts": 5, "average_mttd_minutes": 2.0,
+            "slack_delivered": True, "demo_mode": False,
+        })
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/hunts/test_run_hunts.py
+++ b/tests/hunts/test_run_hunts.py
@@ -9,6 +9,7 @@ query or the final bulk index write failed — it must never silently exit 0.
 Run:  python tests/hunts/test_run_hunts.py     (or: pytest tests/hunts)
 """
 
+import json
 import os
 import sys
 import tempfile
@@ -125,6 +126,48 @@ class MainExitCodeTests(unittest.TestCase):
             ]
             code = self._run_main_capturing_exit()
         self.assertEqual(code, 3)
+
+    def test_hunt_meeting_threshold_is_a_finding(self):
+        # HUNT-TEST-A's threshold is 1; a count of 3 must register as a finding
+        # and be bulk-indexed with finding=true.
+        with mock.patch.object(run_hunts.SESSION, "post") as post:
+            post.side_effect = [
+                _FakeResponse(200, {"count": 3}),   # HUNT-TEST-A: finding
+                _FakeResponse(200, {"count": 0}),   # HUNT-TEST-B: no finding
+                _FakeResponse(200, {}),             # bulk index
+            ]
+            code = self._run_main_capturing_exit()
+        self.assertEqual(code, 0)
+        bulk_call = post.call_args_list[-1]
+        sent = bulk_call.kwargs["data"]
+        # The finding doc for HUNT-TEST-A must carry finding:true and the real count.
+        finding_line = [line for line in sent.splitlines() if "HUNT-TEST-A" in line][0]
+        doc = json.loads(finding_line)
+        self.assertTrue(doc["finding"])
+        self.assertEqual(doc["match_count"], 3)
+
+
+class MainNoHuntsAndMissingCredsTests(unittest.TestCase):
+    def test_no_hunts_found_exits_1(self):
+        with tempfile.TemporaryDirectory() as empty_dir:
+            with mock.patch.object(run_hunts, "HUNTS_DIR", Path(empty_dir)):
+                try:
+                    run_hunts.main()
+                except SystemExit as e:
+                    code = e.code
+                else:
+                    code = None
+        self.assertEqual(code, 1)
+
+    def test_missing_es_pass_exits_1(self):
+        with mock.patch.object(run_hunts, "ES_PASS", ""):
+            try:
+                run_hunts.main()
+            except SystemExit as e:
+                code = e.code
+            else:
+                code = None
+        self.assertEqual(code, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Extends `tests/ai_agent/test_slo_metrics.py` and `tests/hunts/test_run_hunts.py` (both pre-existing from #165 but wired into no CI workflow, and missing several happy-path branches), and adds a new `tests/ai_agent/test_weekly_ciso_report.py` (first direct test of that module). Combined: 82 tests, 97%+ line coverage on all three target files.
- New `.github/workflows/reporting-coverage.yml` gates pytest-cov at 70%. Kept separate from `soar-tests.yml`, which deliberately avoids the heavy WeasyPrint/elasticsearch deps by stubbing `weekly_ciso_report` — this workflow exists specifically to exercise the real module, so it installs WeasyPrint's native libs (matching the agent Dockerfile).
- Dockerfile CMD: `python agent_app.py` → `gunicorn`. Deliberately `--worker-class gthread --workers 1 --threads 4`, **not** the `-w 2` (multi-process) the issue text suggested — `agent_app.py`'s HMAC replay-nonce cache and approval-queue writer are `threading.Lock`-guarded in-process state, not cross-process-safe. Multiple worker processes would each keep an independent nonce cache, letting a replayed signature land on a worker that never saw the original.
- **Found and fixed a real concurrency regression this move exposed**: `/approve`'s read-check-execute wasn't atomic, so two genuinely concurrent requests for the same `action_id` (each validly signed — replay protection alone doesn't stop two *different* signed requests) could both pass the "still pending" check and both execute isolation, silently defeating the existing "can't approve twice" guarantee. Unreachable under the old sequential dev server; reachable under gthread's real concurrency. Fixed by claiming the id atomically under the existing `_queue_lock` before the slow isolation call.
- Healthcheck added to the `ai-agent` compose service: `GET /weekly-report/status` (an existing unauthenticated, side-effect-free route) rather than a bare TCP connect — a hung WSGI worker would still accept the TCP handshake but never respond.

## Review

- **security-auditor**: confirmed the `gthread` reasoning is correct, and caught the `/approve` TOCTOU race above (the one real finding) plus the healthcheck gap (both fixed).
- **code-reviewer**: approved; one minor fix applied (an `ExitStack`-based rewrite of the breach/NTFY test setup to avoid a latent patch-leak on `mock.patch.start()` failure).

## Test plan

- [x] `pytest tests/ai_agent/ tests/hunts/ --cov=... --cov-fail-under=70` — 82 passed, 97.36% combined coverage
- [x] `python tests/ai_agent/test_alert_auth.py` (exact `soar-tests.yml` invocation) — 26 passed, unchanged after the server swap
- [x] `ruff check .` / `mypy` (repo-wide) — clean
- [x] Live-verified: rebuilt `soc_ai_agent`, confirmed gunicorn (`gthread`, 1 worker) in `docker logs` instead of the Werkzeug dev-server banner; healthcheck reports healthy; sent a real signed `/alert` webhook end-to-end (200, action drafted); confirmed replay protection still works (200 then 401 on replay)
- [x] Live-verified the `/approve` race fix against the real running container: fired two truly concurrent signed `/approve` requests for the same drafted action — confirmed it double-dispatches *without* the fix and single-dispatches *with* it (also covered by a unit-level regression test using real threads against the Flask test client)

Closes #172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)