### PR TITLE
fix(#176): bound three unbounded-growth vectors in runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,8 @@ node_modules/
 scripts/setup/.env
 scripts/setup/certs/
 **/approval_queue.jsonl
+**/approval_queue.jsonl.lock
+**/approval_queue.archive.jsonl
 
 # Python virtual environments
 .venv/

--- a/scripts/hive-mind-broker/app.py
+++ b/scripts/hive-mind-broker/app.py
@@ -20,6 +20,7 @@ import uuid
 import os
 import re
 import threading
+import fcntl
 import logging
 import httpx
 from datetime import datetime, timezone
@@ -67,6 +68,8 @@ ES_VERIFY = ES_CA if ES_CA else True  # fail closed: never silently disable TLS 
 AUTONOMOUS_BLOCK_ENABLED = os.getenv("AUTONOMOUS_BLOCK_ENABLED", "false").lower() == "true"
 
 APPROVAL_QUEUE = os.getenv("APPROVAL_QUEUE", "approval_queue.jsonl")
+# audit #176: a stable cross-process lock path — see _append_action().
+_QUEUE_LOCK_PATH = APPROVAL_QUEUE + ".lock"
 _queue_lock = threading.Lock()
 
 # Tenant slug (WS0.3) — same grammar as agent_app/logstash/provision_tenant.sh.
@@ -111,9 +114,26 @@ async def write_denial(reason: str, request: Request, detail: str = "") -> None:
 
 
 def _append_action(action: dict) -> None:
+    """Append a resolved/drafted action to the approval queue (audit log).
+
+    audit #176: flocks _QUEUE_LOCK_PATH — a path that is never itself
+    replaced/truncated — rather than APPROVAL_QUEUE directly. A separate OS
+    process (compact_broker_approval_queue.py, run via cron) can't see
+    _queue_lock at all, so cross-process safety has to come from flock; but
+    flocking the *data* file doesn't compose safely with that script's atomic
+    replace: a fresh open(APPROVAL_QUEUE, "a") that resolves the path right
+    before a concurrent os.replace(), then blocks in flock() until after it,
+    would end up writing to the now-orphaned pre-replace inode and silently
+    lose the append. Locking a path that's never replaced avoids that.
+    """
     with _queue_lock:
-        with open(APPROVAL_QUEUE, "a", encoding="utf-8") as fh:
-            fh.write(json.dumps(action) + "\n")
+        with open(_QUEUE_LOCK_PATH, "a") as lock_fh:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+            try:
+                with open(APPROVAL_QUEUE, "a", encoding="utf-8") as fh:
+                    fh.write(json.dumps(action) + "\n")
+            finally:
+                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
 
 
 def _read_queue():

--- a/scripts/hive-mind-broker/compact_broker_approval_queue.py
+++ b/scripts/hive-mind-broker/compact_broker_approval_queue.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+compact_broker_approval_queue.py — bounds growth of approval_queue.jsonl (#176).
+
+The queue is append-only by design (audit trail — every draft/resolution is
+its own line, never edited in place). Left alone it grows forever. This
+archives entries whose id's LATEST recorded status is a terminal state
+(approved/denied/executed) and whose most recent line is older than the
+retention window; everything still pending stays in the live file untouched.
+
+Concurrency: flocks _QUEUE_LOCK_PATH, the same stable (never itself replaced)
+path app.py's _append_action() locks — so a compaction run can't race a live
+append and silently drop it. Locking the data file directly wouldn't compose
+safely with the atomic replace below (see the comment on _QUEUE_LOCK_PATH in
+app.py).
+
+Run manually or on a schedule.
+Usage: python compact_broker_approval_queue.py [--retention-days N] [--dry-run]
+"""
+import argparse
+import fcntl
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+APPROVAL_QUEUE = Path(os.environ.get("APPROVAL_QUEUE", str(HERE / "approval_queue.jsonl")))
+ARCHIVE_QUEUE = Path(os.environ.get("APPROVAL_QUEUE_ARCHIVE", str(HERE / "approval_queue.archive.jsonl")))
+_QUEUE_LOCK_PATH = Path(str(APPROVAL_QUEUE) + ".lock")
+# "executed" covers the immediate /webhook/dispatch path (no separate pending
+# draft precedes it); "approved"/"denied" cover the drafted-then-resolved path.
+TERMINAL_STATUSES = frozenset({"approved", "denied", "executed"})
+DEFAULT_RETENTION_DAYS = 30
+
+
+def compact(retention_days: int = DEFAULT_RETENTION_DAYS, dry_run: bool = False) -> int:
+    """Archive fully-resolved, aged-out entries. Returns the count of ids archived."""
+    if not APPROVAL_QUEUE.exists():
+        print(f"No queue file at {APPROVAL_QUEUE} — nothing to do.")
+        return 0
+
+    with open(_QUEUE_LOCK_PATH, "a") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            entries = []
+            for line in APPROVAL_QUEUE.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    print(f"Skipping malformed line: {line[:80]}", file=sys.stderr)
+
+            # Append-only log => the LAST entry for a given id is its current state.
+            latest = {}
+            for e in entries:
+                aid = e.get("id")
+                if aid is not None:
+                    latest[aid] = e
+
+            cutoff = time.time() - retention_days * 86400
+            archivable_ids = {
+                aid for aid, e in latest.items()
+                if e.get("status") in TERMINAL_STATUSES and e.get("ts", 0) < cutoff
+            }
+
+            if not archivable_ids:
+                print(f"Nothing to archive (retention={retention_days}d): "
+                      f"{len(latest)} distinct id(s), {len(entries)} total line(s).")
+                return 0
+
+            keep = [e for e in entries if e.get("id") not in archivable_ids]
+            archived = [e for e in entries if e.get("id") in archivable_ids]
+
+            print(f"Archiving {len(archivable_ids)} resolved id(s) "
+                  f"({len(archived)} line(s)) older than {retention_days}d; "
+                  f"{len(keep)} line(s) remain live.")
+
+            if dry_run:
+                print("Dry run — no files written.")
+                return len(archivable_ids)
+
+            # Durability order matters: append+fsync the archive copy BEFORE
+            # replacing the live file, so a crash in between leaves the
+            # archived lines duplicated in the live file (re-compactable next
+            # run) rather than lost from both.
+            with open(ARCHIVE_QUEUE, "a", encoding="utf-8") as afh:
+                for e in archived:
+                    afh.write(json.dumps(e) + "\n")
+                afh.flush()
+                os.fsync(afh.fileno())
+
+            # Atomic replace (temp file + os.replace), not truncate-in-place —
+            # a crash mid-rewrite of the live file in place would lose every
+            # kept (still-pending) line; os.replace() can only ever leave the
+            # old or the new complete content, never a partial one.
+            tmp_path = APPROVAL_QUEUE.with_suffix(APPROVAL_QUEUE.suffix + ".tmp")
+            with open(tmp_path, "w", encoding="utf-8") as tmp_fh:
+                for e in keep:
+                    tmp_fh.write(json.dumps(e) + "\n")
+                tmp_fh.flush()
+                os.fsync(tmp_fh.fileno())
+            os.replace(tmp_path, APPROVAL_QUEUE)
+            return len(archivable_ids)
+        finally:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--retention-days", type=int, default=DEFAULT_RETENTION_DAYS,
+                        help=f"Archive terminal entries older than this many days "
+                             f"(default {DEFAULT_RETENTION_DAYS})")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Report what would be archived without writing anything")
+    args = parser.parse_args()
+    compact(args.retention_days, args.dry_run)

--- a/scripts/hive-mind-broker/test_compact_broker_approval_queue.py
+++ b/scripts/hive-mind-broker/test_compact_broker_approval_queue.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+compact_broker_approval_queue.py — approval-queue compaction tests (issue #176).
+
+Mirrors tests/ai_agent/test_compact_agent_approval_queue.py for the broker's own
+queue, whose terminal-status vocabulary differs slightly (adds "executed",
+the immediate /webhook/dispatch path that never goes through "pending").
+
+Run:  pytest scripts/hive-mind-broker/test_compact_broker_approval_queue.py
+"""
+
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import compact_broker_approval_queue as caq
+
+
+def _write_queue(path, entries):
+    with open(path, "w", encoding="utf-8") as fh:
+        for e in entries:
+            fh.write(json.dumps(e) + "\n")
+
+
+def _read_lines(path):
+    if not os.path.exists(path):
+        return []
+    with open(path, "r", encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+class CompactTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.queue = os.path.join(self._tmp.name, "approval_queue.jsonl")
+        self.archive = os.path.join(self._tmp.name, "approval_queue.archive.jsonl")
+        mock.patch.object(caq, "APPROVAL_QUEUE", Path(self.queue)).start()
+        mock.patch.object(caq, "ARCHIVE_QUEUE", Path(self.archive)).start()
+        # _QUEUE_LOCK_PATH is derived from APPROVAL_QUEUE at import time, so
+        # patching APPROVAL_QUEUE alone leaves it pointing at the real default.
+        mock.patch.object(caq, "_QUEUE_LOCK_PATH", Path(self.queue + ".lock")).start()
+        self.addCleanup(mock.patch.stopall)
+
+    def test_missing_queue_file_is_a_no_op(self):
+        self.assertEqual(caq.compact(), 0)
+
+    def test_old_executed_entry_is_archived(self):
+        # /webhook/dispatch's immediate path: a single "executed" line, no
+        # preceding "pending" draft.
+        old = time.time() - 40 * 86400
+        _write_queue(self.queue, [{"id": "b1", "ts": old, "status": "executed"}])
+        archived_count = caq.compact(retention_days=30)
+        self.assertEqual(archived_count, 1)
+        self.assertEqual(_read_lines(self.queue), [])
+        self.assertEqual(len(_read_lines(self.archive)), 1)
+
+    def test_old_approved_entry_is_archived(self):
+        old = time.time() - 40 * 86400
+        _write_queue(self.queue, [
+            {"id": "b2", "ts": old, "status": "pending"},
+            {"id": "b2", "ts": old + 1, "status": "approved"},
+        ])
+        archived_count = caq.compact(retention_days=30)
+        self.assertEqual(archived_count, 1)
+        self.assertEqual(_read_lines(self.queue), [])
+
+    def test_recent_denied_entry_is_not_yet_archived(self):
+        recent = time.time() - 2 * 86400
+        _write_queue(self.queue, [
+            {"id": "b3", "ts": recent, "status": "pending"},
+            {"id": "b3", "ts": recent + 1, "status": "denied"},
+        ])
+        archived_count = caq.compact(retention_days=30)
+        self.assertEqual(archived_count, 0)
+        self.assertEqual(len(_read_lines(self.queue)), 2)
+
+    def test_still_pending_entry_is_never_archived_regardless_of_age(self):
+        old = time.time() - 400 * 86400
+        _write_queue(self.queue, [{"id": "b4", "ts": old, "status": "pending"}])
+        archived_count = caq.compact(retention_days=30)
+        self.assertEqual(archived_count, 0)
+        self.assertEqual(len(_read_lines(self.queue)), 1)
+
+    def test_dry_run_reports_but_writes_nothing(self):
+        old = time.time() - 40 * 86400
+        _write_queue(self.queue, [{"id": "b5", "ts": old, "status": "executed"}])
+        archived_count = caq.compact(retention_days=30, dry_run=True)
+        self.assertEqual(archived_count, 1)
+        self.assertEqual(len(_read_lines(self.queue)), 1)
+        self.assertFalse(os.path.exists(self.archive))
+
+    def test_mixed_ids_only_archives_the_eligible_ones(self):
+        old = time.time() - 40 * 86400
+        recent = time.time() - 2 * 86400
+        _write_queue(self.queue, [
+            {"id": "old-executed", "ts": old, "status": "executed"},
+            {"id": "recent-denied", "ts": recent, "status": "denied"},
+            {"id": "still-pending", "ts": old, "status": "pending"},
+        ])
+        archived_count = caq.compact(retention_days=30)
+        self.assertEqual(archived_count, 1)
+        remaining_ids = {e["id"] for e in _read_lines(self.queue)}
+        self.assertEqual(remaining_ids, {"recent-denied", "still-pending"})
+        archived_ids = {e["id"] for e in _read_lines(self.archive)}
+        self.assertEqual(archived_ids, {"old-executed"})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/setup/ai_agent/agent_app.py
+++ b/scripts/setup/ai_agent/agent_app.py
@@ -20,6 +20,7 @@ import hmac
 import hashlib
 import ipaddress
 import threading
+import fcntl
 import requests
 import logging
 from datetime import datetime, timezone
@@ -105,6 +106,8 @@ APPROVAL_QUEUE = os.environ.get(
     "APPROVAL_QUEUE",
     str((Path(__file__).resolve().parent / "approval_queue.jsonl")),
 )
+# audit #176: a stable cross-process lock path — see _append_pending_action_locked().
+_QUEUE_LOCK_PATH = APPROVAL_QUEUE + ".lock"
 _queue_lock = threading.Lock()
 # audit #172: any status other than "pending" means the action is no longer
 # awaiting approval — "claimed" marks one mid-execution (see approve_action).
@@ -518,8 +521,31 @@ def send_discord_alert(device_ip: str, device_mac: str, ai_summary: str, tenant:
 def _append_pending_action(action: dict) -> None:
     """Append a drafted action to the approval queue (append-only audit log)."""
     with _queue_lock:
-        with open(APPROVAL_QUEUE, "a", encoding="utf-8") as fh:
-            fh.write(json.dumps(action) + "\n")
+        _append_pending_action_locked(action)
+
+
+def _append_pending_action_locked(action: dict) -> None:
+    """Same as _append_pending_action(), for a caller that already holds
+    _queue_lock as part of a larger atomic read-check-append section (e.g.
+    approve_action()'s TOCTOU fix — see #172).
+
+    audit #176: flocks _QUEUE_LOCK_PATH — a path that is never itself
+    replaced/truncated — rather than APPROVAL_QUEUE directly. A separate OS
+    process (compact_agent_approval_queue.py, run via cron) can't see
+    _queue_lock at all, so cross-process safety has to come from flock; but
+    flocking the *data* file doesn't compose safely with that script's atomic
+    replace: a fresh open(APPROVAL_QUEUE, "a") that resolves the path right
+    before a concurrent os.replace(), then blocks in flock() until after it,
+    would end up writing to the now-orphaned pre-replace inode and silently
+    lose the append. Locking a path that's never replaced avoids that.
+    """
+    with open(_QUEUE_LOCK_PATH, "a") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            with open(APPROVAL_QUEUE, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(action) + "\n")
+        finally:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
 
 
 def _read_queue():
@@ -912,9 +938,12 @@ def approve_action():
         action = pending.get(action_id)
         if not action:
             return jsonify({"error": f"no pending action {action_id}"}), 404
-        with open(APPROVAL_QUEUE, "a", encoding="utf-8") as fh:
-            fh.write(json.dumps({"id": action_id, "ts": time.time(),
-                                  "status": "claimed", "approver": approver}) + "\n")
+        # audit #176: was a raw open().write() here — bypassed the flock in
+        # _append_pending_action() entirely (advisory locks aren't enforced
+        # against writers that never take them), so a concurrent compaction
+        # run could silently drop this claim marker.
+        _append_pending_action_locked({"id": action_id, "ts": time.time(),
+                                        "status": "claimed", "approver": approver})
 
     _t0 = time.time()
     action_tenant = safe_tenant(action.get("tenant"))

--- a/scripts/setup/ai_agent/compact_agent_approval_queue.py
+++ b/scripts/setup/ai_agent/compact_agent_approval_queue.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+compact_agent_approval_queue.py — bounds growth of approval_queue.jsonl (#176).
+
+The queue is append-only by design (audit trail — every draft/claim/resolution
+is its own line, never edited in place). Left alone it grows forever. This
+archives entries whose id's LATEST recorded status is a true terminal state
+(approved/denied) and whose most recent line is older than the retention
+window; everything else (pending, claimed-but-not-yet-resolved, or resolved
+but still within the window) stays in the live file untouched.
+
+Concurrency: flocks _QUEUE_LOCK_PATH, the same stable (never itself replaced)
+path agent_app.py's _append_pending_action()/_append_pending_action_locked()
+lock — so a compaction run can't race a live append and silently drop it.
+Locking the data file directly wouldn't compose safely with the atomic
+replace below (see the comment on _QUEUE_LOCK_PATH in agent_app.py).
+
+Run manually or on a schedule (e.g. weekly, alongside refresh_intel.sh).
+Usage: python compact_agent_approval_queue.py [--retention-days N] [--dry-run]
+"""
+import argparse
+import fcntl
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+APPROVAL_QUEUE = Path(os.environ.get("APPROVAL_QUEUE", str(HERE / "approval_queue.jsonl")))
+ARCHIVE_QUEUE = Path(os.environ.get("APPROVAL_QUEUE_ARCHIVE", str(HERE / "approval_queue.archive.jsonl")))
+_QUEUE_LOCK_PATH = Path(str(APPROVAL_QUEUE) + ".lock")
+# "claimed" (audit #172) is deliberately excluded — it marks a resolution
+# in progress; if it's still the latest status, the request never finished
+# and the entry needs a human look, not silent archiving.
+TERMINAL_STATUSES = frozenset({"approved", "denied"})
+DEFAULT_RETENTION_DAYS = 30
+
+
+def compact(retention_days: int = DEFAULT_RETENTION_DAYS, dry_run: bool = False) -> int:
+    """Archive fully-resolved, aged-out entries. Returns the count of ids archived."""
+    if not APPROVAL_QUEUE.exists():
+        print(f"No queue file at {APPROVAL_QUEUE} — nothing to do.")
+        return 0
+
+    with open(_QUEUE_LOCK_PATH, "a") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            entries = []
+            for line in APPROVAL_QUEUE.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    print(f"Skipping malformed line: {line[:80]}", file=sys.stderr)
+
+            # Append-only log => the LAST entry for a given id is its current state.
+            latest = {}
+            for e in entries:
+                aid = e.get("id")
+                if aid is not None:
+                    latest[aid] = e
+
+            cutoff = time.time() - retention_days * 86400
+            archivable_ids = {
+                aid for aid, e in latest.items()
+                if e.get("status") in TERMINAL_STATUSES and e.get("ts", 0) < cutoff
+            }
+
+            if not archivable_ids:
+                print(f"Nothing to archive (retention={retention_days}d): "
+                      f"{len(latest)} distinct id(s), {len(entries)} total line(s).")
+                return 0
+
+            keep = [e for e in entries if e.get("id") not in archivable_ids]
+            archived = [e for e in entries if e.get("id") in archivable_ids]
+
+            print(f"Archiving {len(archivable_ids)} resolved id(s) "
+                  f"({len(archived)} line(s)) older than {retention_days}d; "
+                  f"{len(keep)} line(s) remain live.")
+
+            if dry_run:
+                print("Dry run — no files written.")
+                return len(archivable_ids)
+
+            # Durability order matters: append+fsync the archive copy BEFORE
+            # replacing the live file, so a crash in between leaves the
+            # archived lines duplicated in the live file (re-compactable next
+            # run) rather than lost from both.
+            with open(ARCHIVE_QUEUE, "a", encoding="utf-8") as afh:
+                for e in archived:
+                    afh.write(json.dumps(e) + "\n")
+                afh.flush()
+                os.fsync(afh.fileno())
+
+            # Atomic replace (temp file + os.replace), not truncate-in-place —
+            # a crash mid-rewrite of the live file in place would lose every
+            # kept (still-pending) line; os.replace() can only ever leave the
+            # old or the new complete content, never a partial one.
+            tmp_path = APPROVAL_QUEUE.with_suffix(APPROVAL_QUEUE.suffix + ".tmp")
+            with open(tmp_path, "w", encoding="utf-8") as tmp_fh:
+                for e in keep:
+                    tmp_fh.write(json.dumps(e) + "\n")
+                tmp_fh.flush()
+                os.fsync(tmp_fh.fileno())
+            os.replace(tmp_path, APPROVAL_QUEUE)
+            return len(archivable_ids)
+        finally:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--retention-days", type=int, default=DEFAULT_RETENTION_DAYS,
+                        help=f"Archive terminal entries older than this many days "
+                             f"(default {DEFAULT_RETENTION_DAYS})")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Report what would be archived without writing anything")
+    args = parser.parse_args()
+    compact(args.retention_days, args.dry_run)

--- a/scripts/setup/ai_agent/weekly_ciso_report.py
+++ b/scripts/setup/ai_agent/weekly_ciso_report.py
@@ -18,6 +18,7 @@ import os
 import json
 import logging
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import requests
 from jinja2 import Template
@@ -42,8 +43,17 @@ LLM_MODEL       = os.getenv("LLM_MODEL",         "gpt-4")
 NTFY_TOPIC      = os.getenv("NTFY_TOPIC",        "")  # shared with agent_app; set in .env (audit P2-6)
 SLACK_TOKEN     = os.getenv("SLACK_BOT_TOKEN",   "")
 SLACK_CHANNEL   = os.getenv("SLACK_CHANNEL_ID",  "")
-PDF_OUTPUT_DIR  = os.getenv("PDF_OUTPUT_DIR",    "/tmp")
-PDF_FILENAME    = os.path.join(PDF_OUTPUT_DIR, "Weekly_NIST_Security_Report.pdf")
+# audit #176 (SC-28): was a fixed /tmp path — predictable, shared, world-readable
+# when run standalone on a host (not just inside the agent's own container).
+# Defaults to a dedicated subdirectory next to this script instead: inside the
+# container that's /app/reports (owned solely by the non-root appuser per the
+# Dockerfile's `chown -R appuser:appuser /app`); run standalone it's a
+# repo-local dir, never a shared system temp directory either way.
+PDF_OUTPUT_DIR  = os.getenv("PDF_OUTPUT_DIR", str(Path(__file__).resolve().parent / "reports"))
+# How many past reports to keep on disk before pruning the oldest — otherwise
+# moving off a fixed, overwritten filename just trades one unbounded-growth
+# problem (#176) for another.
+PDF_RETENTION_COUNT = int(os.getenv("PDF_RETENTION_COUNT", "12"))
 
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 log = logging.getLogger(__name__)
@@ -300,21 +310,47 @@ _HTML_TEMPLATE = """
 """
 
 
+_REPORT_FILENAME_PREFIX = "Weekly_NIST_Security_Report"
+
+
+def _prune_old_reports(directory: Path, keep: int) -> None:
+    """Delete all but the `keep` most-recently-modified reports (audit #176) —
+    otherwise per-run filenames just trade one unbounded-growth problem for
+    another."""
+    reports = sorted(directory.glob(f"{_REPORT_FILENAME_PREFIX}_*.pdf"),
+                      key=lambda p: p.stat().st_mtime, reverse=True)
+    for stale in reports[keep:]:
+        try:
+            stale.unlink()
+        except OSError as exc:
+            log.warning("Failed to prune old report %s: %s", stale, exc)
+
+
 def create_pdf_report(metrics: dict, narrative: str) -> str:
     """
     Renders the Jinja2 HTML template and converts to PDF via WeasyPrint.
     Returns the absolute path to the saved PDF.
     """
-    log.info("Compiling PDF report -> %s", PDF_FILENAME)
+    out_dir = Path(PDF_OUTPUT_DIR)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(out_dir, 0o700)  # audit #176 (SC-28): owner-only, defense in depth
+
+    # audit #176: per-run filename, not a fixed one — a fixed name is a
+    # predictable "latest report" path even after moving off shared /tmp.
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    pdf_path = str(out_dir / f"{_REPORT_FILENAME_PREFIX}_{stamp}.pdf")
+
+    log.info("Compiling PDF report -> %s", pdf_path)
     rendered = Template(_HTML_TEMPLATE).render(
         date=datetime.now().strftime("%B %d, %Y"),
         year=datetime.now().year,
         metrics=metrics,
         narrative=narrative,
     )
-    HTML(string=rendered).write_pdf(PDF_FILENAME)
-    log.info("PDF saved: %s", PDF_FILENAME)
-    return PDF_FILENAME
+    HTML(string=rendered).write_pdf(pdf_path)
+    log.info("PDF saved: %s", pdf_path)
+    _prune_old_reports(out_dir, PDF_RETENTION_COUNT)
+    return pdf_path
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/setup/run_hunts.py
+++ b/scripts/setup/run_hunts.py
@@ -79,7 +79,15 @@ def main():
     if not hunts:
         print("No hunts found in hunts/", file=sys.stderr)
         sys.exit(1)
-    now = datetime.now(timezone.utc).isoformat()
+    now_dt = datetime.now(timezone.utc)
+    now = now_dt.isoformat()
+    # audit #176: cron runs this hourly (configs/hunts/hunts.cron), and every
+    # run re-evaluates the full rolling HUNT_WINDOW — without a stable _id,
+    # each run appends a fresh doc per hunt, so soc-hunts grows unbounded
+    # (hunts x 24/day forever). A deterministic per-day _id makes the bulk
+    # "index" op an upsert: same hunt, same day -> the latest run's result
+    # overwrites the prior one, bounding growth to hunts x days.
+    day_bucket = now_dt.strftime("%Y-%m-%d")
     bulk, findings, hunt_errors = [], 0, 0
     print(f"Threat hunts @ {now}  (window {WINDOW})")
     print(f"  {'hunt'.ljust(10)} {'attack'.ljust(12)} {'count':>7}  finding")
@@ -103,7 +111,12 @@ def main():
                "status": h.get("status", "active")}, "attack": h.get("attack", []),
                "data_source": h.get("data_source"), "match_count": count,
                "threshold": threshold, "finding": finding}
-        bulk.append('{"index":{"_index":"soc-hunts"}}')
+        # Fall back to the filename stem if a hunt has no id — otherwise every
+        # id-less hunt would share the literal string "None" and collide onto
+        # the same per-day doc as each other.
+        hunt_key = h.get("id") or path.stem
+        doc_id = f"{hunt_key}:{day_bucket}"
+        bulk.append(json.dumps({"index": {"_index": "soc-hunts", "_id": doc_id}}))
         bulk.append(json.dumps(doc))
     index_failed = False
     if bulk:

--- a/tests/ai_agent/test_compact_agent_approval_queue.py
+++ b/tests/ai_agent/test_compact_agent_approval_queue.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+compact_agent_approval_queue.py — approval-queue compaction tests (issue #176).
+
+Guards the core safety property: an id's FULL history is archived only when
+its latest recorded status is a true terminal state (approved/denied) AND
+that status is older than the retention window. Pending or claimed-but-not-
+resolved ids, and recently-resolved ids, must never be silently dropped.
+
+Run:  pytest tests/ai_agent/test_compact_agent_approval_queue.py
+"""
+
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import compact_agent_approval_queue as caq
+
+
+def _write_queue(path, entries):
+    with open(path, "w", encoding="utf-8") as fh:
+        for e in entries:
+            fh.write(json.dumps(e) + "\n")
+
+
+def _read_lines(path):
+    if not os.path.exists(path):
+        return []
+    with open(path, "r", encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+class CompactTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.queue = os.path.join(self._tmp.name, "approval_queue.jsonl")
+        self.archive = os.path.join(self._tmp.name, "approval_queue.archive.jsonl")
+        mock.patch.object(caq, "APPROVAL_QUEUE", Path(self.queue)).start()
+        mock.patch.object(caq, "ARCHIVE_QUEUE", Path(self.archive)).start()
+        # _QUEUE_LOCK_PATH is derived from APPROVAL_QUEUE at import time, so
+        # patching APPROVAL_QUEUE alone leaves it pointing at the real default.
+        mock.patch.object(caq, "_QUEUE_LOCK_PATH", Path(self.queue + ".lock")).start()
+        self.addCleanup(mock.patch.stopall)
+
+    def test_missing_queue_file_is_a_no_op(self):
+        self.assertEqual(caq.compact(), 0)
+
+    def test_old_resolved_entry_is_archived(self):
+        old = time.time() - 40 * 86400
+        _write_queue(self.queue, [
+            {"id": "a1", "ts": old, "status": "pending"},
+            {"id": "a1", "ts": old + 1, "status": "approved"},
+        ])
+        archived_count = caq.compact(retention_days=30)
+        self.assertEqual(archived_count, 1)
+        self.assertEqual(_read_lines(self.queue), [])
+        archived = _read_lines(self.archive)
+        self.assertEqual(len(archived), 2)
+        self.assertEqual({e["status"] for e in archived}, {"pending", "approved"})
+
+    def test_recent_resolved_entry_is_not_yet_archived(self):
+        recent = time.time() - 2 * 86400
+        _write_queue(self.queue, [
+            {"id": "a2", "ts": recent, "status": "pending"},
+            {"id": "a2", "ts": recent + 1, "status": "denied"},
+        ])
+        archived_count = caq.compact(retention_days=30)
+        self.assertEqual(archived_count, 0)
+        self.assertEqual(len(_read_lines(self.queue)), 2)
+        self.assertEqual(_read_lines(self.archive), [])
+
+    def test_still_pending_entry_is_never_archived_regardless_of_age(self):
+        old = time.time() - 400 * 86400
+        _write_queue(self.queue, [{"id": "a3", "ts": old, "status": "pending"}])
+        archived_count = caq.compact(retention_days=30)
+        self.assertEqual(archived_count, 0)
+        self.assertEqual(len(_read_lines(self.queue)), 1)
+
+    def test_claimed_but_never_resolved_is_never_archived(self):
+        # A "claimed" latest status means the request started resolving but the
+        # process crashed before writing approved/denied — must stay visible
+        # for a human to investigate, not be silently swept into the archive.
+        old = time.time() - 400 * 86400
+        _write_queue(self.queue, [
+            {"id": "a4", "ts": old, "status": "pending"},
+            {"id": "a4", "ts": old + 1, "status": "claimed"},
+        ])
+        archived_count = caq.compact(retention_days=30)
+        self.assertEqual(archived_count, 0)
+        self.assertEqual(len(_read_lines(self.queue)), 2)
+
+    def test_dry_run_reports_but_writes_nothing(self):
+        old = time.time() - 40 * 86400
+        _write_queue(self.queue, [
+            {"id": "a5", "ts": old, "status": "pending"},
+            {"id": "a5", "ts": old + 1, "status": "approved"},
+        ])
+        archived_count = caq.compact(retention_days=30, dry_run=True)
+        self.assertEqual(archived_count, 1)
+        self.assertEqual(len(_read_lines(self.queue)), 2)   # untouched
+        self.assertFalse(os.path.exists(self.archive))       # never created
+
+    def test_malformed_line_is_skipped_not_fatal(self):
+        old = time.time() - 40 * 86400
+        with open(self.queue, "w", encoding="utf-8") as fh:
+            fh.write("not valid json\n")
+            fh.write(json.dumps({"id": "a6", "ts": old, "status": "approved"}) + "\n")
+        archived_count = caq.compact(retention_days=30)
+        self.assertEqual(archived_count, 1)
+
+    def test_mixed_ids_only_archives_the_eligible_ones(self):
+        old = time.time() - 40 * 86400
+        recent = time.time() - 2 * 86400
+        _write_queue(self.queue, [
+            {"id": "old-resolved", "ts": old, "status": "approved"},
+            {"id": "recent-resolved", "ts": recent, "status": "denied"},
+            {"id": "still-pending", "ts": old, "status": "pending"},
+        ])
+        archived_count = caq.compact(retention_days=30)
+        self.assertEqual(archived_count, 1)
+        remaining_ids = {e["id"] for e in _read_lines(self.queue)}
+        self.assertEqual(remaining_ids, {"recent-resolved", "still-pending"})
+        archived_ids = {e["id"] for e in _read_lines(self.archive)}
+        self.assertEqual(archived_ids, {"old-resolved"})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/ai_agent/test_weekly_ciso_report.py
+++ b/tests/ai_agent/test_weekly_ciso_report.py
@@ -12,6 +12,7 @@ Run:  pytest tests/ai_agent/test_weekly_ciso_report.py
 import os
 import sys
 import tempfile
+import time
 import unittest
 from unittest import mock
 
@@ -143,13 +144,13 @@ class CreatePdfReportTests(unittest.TestCase):
         metrics = {"total_alerts": 0, "average_mttd_minutes": 0,
                    "nist_breakdown": {f: 0 for f in wcr.NIST_FUNCTIONS}, "demo_mode": True}
         with tempfile.TemporaryDirectory() as tmp:
-            out_path = os.path.join(tmp, "report.pdf")
-            with mock.patch.object(wcr, "PDF_FILENAME", out_path):
+            out_dir = os.path.join(tmp, "reports")
+            with mock.patch.object(wcr, "PDF_OUTPUT_DIR", out_dir):
                 result = wcr.create_pdf_report(metrics, "Paragraph one.\n\nParagraph two.")
-            self.assertEqual(result, out_path)
-            self.assertTrue(os.path.isfile(out_path))
-            self.assertGreater(os.path.getsize(out_path), 0)
-            with open(out_path, "rb") as fh:
+            self.assertTrue(result.startswith(out_dir))
+            self.assertTrue(os.path.isfile(result))
+            self.assertGreater(os.path.getsize(result), 0)
+            with open(result, "rb") as fh:
                 self.assertTrue(fh.read(5).startswith(b"%PDF-"))
 
     def test_renders_real_pdf_with_nist_breakdown_percentages(self):
@@ -157,11 +158,59 @@ class CreatePdfReportTests(unittest.TestCase):
                    "nist_breakdown": {"Identify": 5, "Protect": 15, "Detect": 60,
                                       "Respond": 15, "Recover": 5}, "demo_mode": False}
         with tempfile.TemporaryDirectory() as tmp:
-            out_path = os.path.join(tmp, "report.pdf")
-            with mock.patch.object(wcr, "PDF_FILENAME", out_path):
+            out_dir = os.path.join(tmp, "reports")
+            with mock.patch.object(wcr, "PDF_OUTPUT_DIR", out_dir):
                 result = wcr.create_pdf_report(metrics, "Some narrative.")
-            self.assertTrue(os.path.isfile(out_path))
-            self.assertEqual(result, out_path)
+            self.assertTrue(os.path.isfile(result))
+            self.assertTrue(result.startswith(out_dir))
+
+    def test_output_dir_created_owner_only(self):
+        metrics = {"total_alerts": 0, "average_mttd_minutes": 0,
+                   "nist_breakdown": {}, "demo_mode": False}
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = os.path.join(tmp, "reports")
+            with mock.patch.object(wcr, "PDF_OUTPUT_DIR", out_dir):
+                wcr.create_pdf_report(metrics, "Narrative.")
+            # audit #176 (SC-28): not world-readable — owner-only.
+            self.assertEqual(os.stat(out_dir).st_mode & 0o777, 0o700)
+
+    def test_each_run_gets_a_distinct_filename(self):
+        metrics = {"total_alerts": 0, "average_mttd_minutes": 0,
+                   "nist_breakdown": {}, "demo_mode": False}
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = os.path.join(tmp, "reports")
+            with mock.patch.object(wcr, "PDF_OUTPUT_DIR", out_dir):
+                first = wcr.create_pdf_report(metrics, "Narrative one.")
+                time.sleep(1.1)  # filenames are second-precision timestamps
+                second = wcr.create_pdf_report(metrics, "Narrative two.")
+            self.assertNotEqual(first, second)
+            self.assertTrue(os.path.isfile(first))
+            self.assertTrue(os.path.isfile(second))
+
+    def test_prunes_old_reports_beyond_retention_count(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = os.path.join(tmp, "reports")
+            os.makedirs(out_dir)
+            # Pre-seed more report files than the retention count, with distinct
+            # mtimes so "oldest" is unambiguous.
+            paths = []
+            for i in range(5):
+                p = os.path.join(out_dir, f"Weekly_NIST_Security_Report_fake-{i}.pdf")
+                with open(p, "wb") as fh:
+                    fh.write(b"%PDF-1.7 fake")
+                os.utime(p, (1000 + i, 1000 + i))
+                paths.append(p)
+            with mock.patch.object(wcr, "PDF_OUTPUT_DIR", out_dir), \
+                 mock.patch.object(wcr, "PDF_RETENTION_COUNT", 3):
+                metrics = {"total_alerts": 0, "average_mttd_minutes": 0,
+                           "nist_breakdown": {}, "demo_mode": False}
+                wcr.create_pdf_report(metrics, "Narrative.")
+            remaining = sorted(os.listdir(out_dir))
+            # 5 pre-seeded + 1 new = 6 candidates; retention=3 must prune to 3.
+            self.assertEqual(len(remaining), 3)
+            # The 2 oldest pre-seeded files must be the ones pruned.
+            self.assertNotIn(os.path.basename(paths[0]), remaining)
+            self.assertNotIn(os.path.basename(paths[1]), remaining)
 
 
 class SendToSlackTests(unittest.TestCase):

--- a/tests/hunts/test_run_hunts.py
+++ b/tests/hunts/test_run_hunts.py
@@ -137,10 +137,34 @@ class MainExitCodeTests(unittest.TestCase):
         bulk_call = post.call_args_list[-1]
         sent = bulk_call.kwargs["data"]
         # The finding doc for HUNT-TEST-A must carry finding:true and the real count.
-        finding_line = [line for line in sent.splitlines() if "HUNT-TEST-A" in line][0]
-        doc = json.loads(finding_line)
+        # (Not the preceding bulk action line — audit #176's deterministic _id
+        # embeds the hunt id there too, so a bare substring match would grab
+        # either line.)
+        parsed = [json.loads(line) for line in sent.splitlines() if line.strip()]
+        doc = next(d for d in parsed if d.get("hunt", {}).get("id") == "HUNT-TEST-A")
         self.assertTrue(doc["finding"])
         self.assertEqual(doc["match_count"], 3)
+
+    def test_bulk_action_uses_deterministic_per_day_id(self):
+        # audit #176: same hunt, same day -> same _id, so a re-run overwrites
+        # (upserts) the prior doc via ES's index op instead of accumulating a
+        # new one every hourly cron tick.
+        import datetime as _dt
+        today = _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%d")
+        with mock.patch.object(run_hunts.SESSION, "post") as post:
+            post.side_effect = [
+                _FakeResponse(200, {"count": 0}),
+                _FakeResponse(200, {"count": 0}),
+                _FakeResponse(200, {}),
+            ]
+            self._run_main_capturing_exit()
+        sent = post.call_args_list[-1].kwargs["data"]
+        parsed = [json.loads(line) for line in sent.splitlines() if line.strip()]
+        actions = [p for p in parsed if "index" in p]
+        ids = {a["index"]["_id"] for a in actions}
+        self.assertEqual(ids, {f"HUNT-TEST-A:{today}", f"HUNT-TEST-B:{today}"})
+        for a in actions:
+            self.assertEqual(a["index"]["_index"], "soc-hunts")
 
 
 class MainNoHuntsAndMissingCredsTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- **`run_hunts.py`**: hourly cron re-runs every hunt over a rolling window with no dedup, so `soc-hunts` grows unbounded. Each bulk doc now carries a deterministic `_id` (`hunt_id:day_bucket`), so ES's `index` op upserts — same hunt, same day, overwrites instead of appending. Falls back to the hunt file's stem when a hunt has no `id`. Live-verified the upsert mechanic directly against the running ES cluster.
- **Approval-queue compaction**: new `compact_agent_approval_queue.py` / `compact_broker_approval_queue.py` archive an id's full line history once its latest status is terminal and older than a retention window (default 30d); anything still pending is never auto-archived. Since these run as a separate cron process, added a **stable lock-file path** (never itself replaced) that both the live services and the compaction scripts flock — locking the mutable data file directly doesn't compose safely with atomic replace (a fresh append that resolves the path just before a concurrent `os.replace()` would write to an orphaned inode and silently lose the write).
- **`weekly_ciso_report.py`**: PDF output moved off shared `/tmp` (fixed, world-readable, overwritten-every-run filename — SC-28) to a `reports/` dir next to the script, created `0700`, per-run timestamped filenames, plus retention pruning (keep last 12) so this doesn't just trade one unbounded-growth vector for another.

## Review

Two real findings from **security-auditor** + **code-reviewer** (run in parallel), both fixed:
1. The agent's `"claimed"` marker write in `/approve` bypassed the flock entirely (a raw `open().write()`, not routed through the flocked helper) — now goes through a shared `_append_pending_action_locked()`.
2. The original truncate-in-place rewrite had a crash-durability window (a `kill -9` mid-rewrite loses every kept line) — replaced with archive-then-fsync followed by a temp-file + `os.replace()` atomic swap.

Also renamed both compaction scripts (and their tests) after discovering CI's `git ls-files '*.py' | xargs mypy` invocation errors on "duplicate module" when two tracked files share a basename with no `__init__.py` packaging.

## Test plan

- [x] 160 tests across agent/broker/hunts/detections/setup all passing
- [x] `ruff`/`mypy` clean repo-wide (including the renamed files checked together, matching CI's exact invocation)
- [x] Exact `reporting-coverage.yml` CI gate locally (96.98%)
- [x] Live-verified against the running stack: full pending→claimed→resolution sequence still correct after the lock refactor; both compaction scripts dry-run cleanly against the real live queues; PDF path/permissions/per-run filename confirmed via a real triggered report; ES upsert mechanic confirmed directly (two bulk ops, same `_id` → "created" then "updated", one document)

Closes #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)