### PR TITLE
feat(#184): dashboard-visible metric for SOC agent audit-write failures

### DIFF
--- a/configs/elasticsearch/roles/logstash_writer.json
+++ b/configs/elasticsearch/roles/logstash_writer.json
@@ -1,7 +1,7 @@
 {
   "cluster": ["monitor","manage_index_templates","manage_ilm"],
   "indices": [
-    {"names": ["logstash-*","soar-actions-*","asset-inventory-*"],
+    {"names": ["logstash-*","soar-actions-*","asset-inventory-*","soc-agent-health-*"],
      "privileges": ["create_index","create","write","manage"]}
   ]
 }

--- a/configs/elasticsearch/roles/logstash_writer.json
+++ b/configs/elasticsearch/roles/logstash_writer.json
@@ -2,6 +2,6 @@
   "cluster": ["monitor","manage_index_templates","manage_ilm"],
   "indices": [
     {"names": ["logstash-*","soar-actions-*","asset-inventory-*","soc-agent-health-*"],
-     "privileges": ["create_index","create","write","manage"]}
+     "privileges": ["create_index","create","write","manage","auto_configure"]}
   ]
 }

--- a/docs/superpowers/plans/2026-07-12-audit-write-failure-visibility.md
+++ b/docs/superpowers/plans/2026-07-12-audit-write-failure-visibility.md
@@ -1,0 +1,510 @@
+# Audit-Write Failure Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a *sustained* run of SOC-agent audit-write failures visible on the SLO dashboard without changing `write_audit()`'s "never raise" contract.
+
+**Architecture:** `write_audit()`'s existing `except` block gains a call to a new helper that best-effort-writes a failure-marker doc to a new per-tenant ES index (`soc-agent-health-<tenant>`). `slo_metrics.py` gains a new metric that counts those docs over its existing rolling window and plugs into its existing generic breach/alert/dashboard-index machinery — no new endpoint, no new dashboard code.
+
+**Tech Stack:** Python 3.12 (Flask agent), Elasticsearch 9.3.2, pytest/unittest, Docker Compose.
+
+## Global Constraints
+
+- `write_audit()`'s "never raise" contract must hold under **any** combination of failures (spec, Goals section).
+- The new index write reuses the agent's existing `logstash_internal` ES credential — no new user/role/password (spec, Design §2 + user's explicit choice during brainstorming).
+- Breach threshold defaults to `3` failures in the rolling window, overridable via `SLO_AUDIT_WRITE_FAIL_MAX` (spec, Design §3 + user's explicit choice during brainstorming).
+- No new dashboard panel, endpoint, or ILM policy — out of scope (spec, Non-goals).
+- Reference spec: `docs/superpowers/specs/2026-07-12-audit-write-failure-visibility-design.md`.
+
+---
+
+### Task 1: Audit-write failure marker in `agent_app.py`
+
+**Files:**
+- Modify: `scripts/setup/ai_agent/agent_app.py:784-808` (`write_audit`)
+- Create: `tests/ai_agent/test_audit_write_health.py`
+
+**Interfaces:**
+- Consumes: existing module globals `ES_HOST`, `ES_USER`, `ES_PASS`, `ES_VERIFY` (all defined at `agent_app.py:75-85`); existing `app.logger`; existing `requests`, `json`, `datetime`/`timezone` imports.
+- Produces: new function `_write_audit_health_marker(action: str, tenant: str, error: Exception) -> None` — no return value, never raises. Later tasks do not depend on this (it's only called internally by `write_audit`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/ai_agent/test_audit_write_health.py`:
+
+```python
+#!/usr/bin/env python3
+"""
+Audit-write failure visibility tests (issue #184).
+
+write_audit()'s ES write failures must never propagate (auditing must not break
+alert handling) — but a failure now also writes a best-effort marker doc to
+soc-agent-health-<tenant> so a SUSTAINED run of failures is dashboard-visible
+(via slo_metrics.py's metric_audit_write_failures()), not just a log line.
+
+Run:  pytest tests/ai_agent/test_audit_write_health.py
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+os.environ["SOC_AGENT_HMAC_SECRET"] = "unit_test_secret"
+
+_stub = types.ModuleType("weekly_ciso_report")
+_stub.run_reporting_pipeline = lambda *a, **k: {"status": "stub"}  # type: ignore[attr-defined]
+sys.modules["weekly_ciso_report"] = _stub
+
+import agent_app  # noqa: E402
+
+
+class WriteAuditHealthMarkerTests(unittest.TestCase):
+    def test_health_marker_written_on_audit_write_failure(self):
+        with mock.patch.object(agent_app.requests, "post",
+                               side_effect=ConnectionError("refused")) as m:
+            agent_app.write_audit("quarantine_mac", "system", "acme-corp",
+                                   outcome="success", target="AA:BB:CC:DD:EE:FF")
+        # Two POST attempts: the original audit write, then the health marker.
+        self.assertEqual(m.call_count, 2)
+        marker_args, marker_kwargs = m.call_args_list[1]
+        self.assertEqual(marker_args[0],
+                         f"{agent_app.ES_HOST}/soc-agent-health-acme-corp/_bulk")
+        self.assertIn('"event.action": "audit_write_failed"', marker_kwargs["data"])
+        self.assertIn('"target_action": "quarantine_mac"', marker_kwargs["data"])
+        self.assertIn('"tenant.id": "acme-corp"', marker_kwargs["data"])
+
+    def test_write_audit_never_raises_even_if_health_marker_also_fails(self):
+        # Core acceptance criterion: BOTH writes failing must not raise.
+        with mock.patch.object(agent_app.requests, "post",
+                               side_effect=ConnectionError("refused")):
+            try:
+                agent_app.write_audit("quarantine_mac", "system", "acme-corp")
+            except Exception as e:
+                self.fail(f"write_audit() raised unexpectedly: {e}")
+
+    def test_health_marker_not_written_on_audit_write_success(self):
+        with mock.patch.object(agent_app.requests, "post") as m:
+            agent_app.write_audit("quarantine_mac", "system", "acme-corp")
+        # Only the original audit write — no marker needed when it succeeds.
+        self.assertEqual(m.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/tjlam/projects/Suburban-SOC && .venv/bin/python3 -m pytest tests/ai_agent/test_audit_write_health.py -v`
+Expected: FAIL — `test_health_marker_written_on_audit_write_failure` and `test_health_marker_not_written_on_audit_write_success` fail on `self.assertEqual(m.call_count, 2)` / `1` (currently always 1, no marker logic exists yet). `test_write_audit_never_raises_even_if_health_marker_also_fails` passes already (existing code already doesn't raise) — that's fine, it's a regression guard for the change about to be made.
+
+- [ ] **Step 3: Implement the marker-write helper and wire it into `write_audit()`**
+
+Replace `scripts/setup/ai_agent/agent_app.py:784-808` (the current `write_audit` function) with:
+
+```python
+def write_audit(action, actor, tenant, outcome="", target="", detail=""):
+    """Append a tamper-evident audit record (who/what/when/tenant) to soc-audit-<tenant>.
+
+    The agent's ES account holds the append-only `soc_audit_appender` role (create
+    privilege only — no update/delete), so it can ADD audit records but never modify
+    or remove them. Every quarantine/response decision is recorded. Failures are
+    logged, never raised — auditing must not break alert handling.
+    """
+    doc = {
+        "@timestamp":    datetime.now(timezone.utc).isoformat(),
+        "event.action":  action,
+        "actor":         actor,
+        "tenant.id":     tenant,
+        "event.outcome": outcome,
+        "target":        target,
+        "detail":        detail,
+    }
+    # op_type=create (append-only) via the bulk create form.
+    ndjson = '{"create":{}}\n' + json.dumps(doc) + "\n"
+    try:
+        requests.post(f"{ES_HOST}/soc-audit-{tenant}/_bulk", data=ndjson,
+                      headers={"Content-Type": "application/x-ndjson"},
+                      auth=(ES_USER, ES_PASS), verify=ES_VERIFY, timeout=5)
+    except Exception as e:  # noqa: BLE001
+        app.logger.error("Failed to write audit record: %s", e)
+        _write_audit_health_marker(action, tenant, e)
+
+
+def _write_audit_health_marker(action, tenant, error):
+    """Best-effort dashboard-visible signal for a failed audit write (#184).
+
+    A single failure doc in soc-agent-health-<tenant>; slo_metrics.py counts these
+    over its rolling window so a SUSTAINED run of failures breaches an SLO (and
+    alerts), while a one-off transient blip does not. Must never raise itself — if
+    this ALSO fails (e.g. total ES outage), that's already caught by
+    stack_health.sh / the ingest-lag SLO, not this function's job to escalate further.
+    """
+    doc = {
+        "@timestamp":    datetime.now(timezone.utc).isoformat(),
+        "tenant.id":     tenant,
+        "event.action":  "audit_write_failed",
+        "target_action": action,
+        "error":         str(error),
+    }
+    ndjson = '{"create":{}}\n' + json.dumps(doc) + "\n"
+    try:
+        requests.post(f"{ES_HOST}/soc-agent-health-{tenant}/_bulk", data=ndjson,
+                      headers={"Content-Type": "application/x-ndjson"},
+                      auth=(ES_USER, ES_PASS), verify=ES_VERIFY, timeout=5)
+    except Exception as e:  # noqa: BLE001
+        app.logger.warning("Failed to write audit-write-failure health marker: %s", e)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/tjlam/projects/Suburban-SOC && .venv/bin/python3 -m pytest tests/ai_agent/test_audit_write_health.py -v`
+Expected: PASS (3/3)
+
+- [ ] **Step 5: Run the full suite to check for regressions**
+
+Run: `cd /home/tjlam/projects/Suburban-SOC && .venv/bin/python3 -m pytest tests/ -q`
+Expected: all tests pass (145 existing + 3 new = 148). `test_alert_auth.py`/`test_notify_masking.py` mock `write_audit` entirely, so they're unaffected by this change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/tjlam/projects/Suburban-SOC
+git add scripts/setup/ai_agent/agent_app.py tests/ai_agent/test_audit_write_health.py
+git commit -m "feat(#184): write a health-marker doc when write_audit() fails
+
+write_audit()'s 'never raise' contract is unchanged — the new marker write
+is itself wrapped in its own try/except. Lays the groundwork for a
+dashboard-visible SLO metric (next commit) rather than a log-grep-only signal."
+```
+
+---
+
+### Task 2: Grant the agent's ES role write access to the new index
+
+**Files:**
+- Modify: `configs/elasticsearch/roles/logstash_writer.json`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: ES role grant that Task 4's live verification and Task 3's metric queries both depend on being applied to the running stack.
+
+- [ ] **Step 1: Edit the role definition**
+
+Current content of `configs/elasticsearch/roles/logstash_writer.json`:
+
+```json
+{
+  "cluster": ["monitor","manage_index_templates","manage_ilm"],
+  "indices": [
+    {"names": ["logstash-*","soar-actions-*","asset-inventory-*"],
+     "privileges": ["create_index","create","write","manage"]}
+  ]
+}
+```
+
+Replace with:
+
+```json
+{
+  "cluster": ["monitor","manage_index_templates","manage_ilm"],
+  "indices": [
+    {"names": ["logstash-*","soar-actions-*","asset-inventory-*","soc-agent-health-*"],
+     "privileges": ["create_index","create","write","manage"]}
+  ]
+}
+```
+
+Note: this file — not the inline bootstrap JSON in `docker-compose.yml`'s `provision` service (line 171) — is the actual source of truth. The `roles` service (`docker-compose.yml`, applies `configs/elasticsearch/roles/*.json` after `provision` runs) overwrites whatever the inline bootstrap created; the two are documented as already having drifted (`docker-compose.yml:356-361`), and this project's convention is to only maintain the `roles/*.json` files going forward, not re-sync the inline bootstrap. Do not edit `docker-compose.yml:171`.
+
+- [ ] **Step 2: Verify the JSON is valid**
+
+Run: `cd /home/tjlam/projects/Suburban-SOC && python3 -c "import json; json.load(open('configs/elasticsearch/roles/logstash_writer.json'))" && echo OK`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/tjlam/projects/Suburban-SOC
+git add configs/elasticsearch/roles/logstash_writer.json
+git commit -m "feat(#184): grant logstash_writer role write access to soc-agent-health-*
+
+Reuses the agent's existing logstash_internal credential rather than a new
+dedicated user — this data isn't sensitive/tamper-critical like the audit
+trail itself. Applied to the running stack in the live-verification task."
+```
+
+---
+
+### Task 3: `metric_audit_write_failures()` in `slo_metrics.py`
+
+**Files:**
+- Modify: `scripts/setup/ai_agent/slo_metrics.py:50-68` (`TARGETS`/`LOWER_BETTER`/`BREACH_IF_NA`), and after `metric_parse_error_pct` (~line 199), and `main()`'s `metric_fns` dict (~line 207)
+- Modify: `tests/ai_agent/test_slo_metrics.py`
+
+**Interfaces:**
+- Consumes: existing `_count(index, query)` helper (`slo_metrics.py:104-112`), existing `WINDOW` global (`slo_metrics.py:48`).
+- Produces: `metric_audit_write_failures() -> float` — raises `MetricUnavailable` on a real query failure (same contract as every other `metric_*` function); not consumed by any later task in this plan.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/ai_agent/test_slo_metrics.py`, add to `MetricFunctionTests` as the last three methods in the class — after `test_parse_error_pct_propagates_count_failure` (the class's last existing method, ending at line 149) and before the blank line/`class EsKbWrapperTests` boundary at line 152:
+
+```python
+    def test_audit_write_failures_raises_on_es_failure(self):
+        with mock.patch.object(slo_metrics, "es", side_effect=ConnectionError("refused")):
+            with self.assertRaises(slo_metrics.MetricUnavailable):
+                slo_metrics.metric_audit_write_failures()
+
+    def test_audit_write_failures_returns_count_on_success(self):
+        with mock.patch.object(slo_metrics, "es",
+                               return_value=_FakeResponse(200, {"count": 5})):
+            self.assertEqual(slo_metrics.metric_audit_write_failures(), 5)
+
+    def test_audit_write_failures_returns_zero_when_healthy(self):
+        with mock.patch.object(slo_metrics, "es",
+                               return_value=_FakeResponse(200, {"count": 0})):
+            self.assertEqual(slo_metrics.metric_audit_write_failures(), 0)
+```
+
+Then update `MainExitCodeTests._mock_all_metrics` to accept and mock the new metric (existing default of `0.0` preserves every current caller's behavior unchanged):
+
+```python
+    def _mock_all_metrics(self, mttd=0.0, mttr=0.0, coverage=12.0, fp_pct=0.0,
+                           ingest_lag=10.0, parse_err=0.0, audit_write_failures=0.0):
+        return [
+            mock.patch.object(slo_metrics, "metric_mttd", return_value=mttd),
+            mock.patch.object(slo_metrics, "metric_mttr", return_value=mttr),
+            mock.patch.object(slo_metrics, "metric_coverage", return_value=coverage),
+            mock.patch.object(slo_metrics, "metric_false_positive_pct", return_value=fp_pct),
+            mock.patch.object(slo_metrics, "metric_ingest_lag_seconds", return_value=ingest_lag),
+            mock.patch.object(slo_metrics, "metric_parse_error_pct", return_value=parse_err),
+            mock.patch.object(slo_metrics, "metric_audit_write_failures",
+                               return_value=audit_write_failures),
+            mock.patch.object(slo_metrics, "es", return_value=_FakeResponse(200, {})),
+        ]
+```
+
+Add a new test to `MainExitCodeTests` (after `test_breach_detected_exits_2_and_sends_ntfy`) for the breach threshold itself:
+
+```python
+    def test_audit_write_failures_below_threshold_does_not_breach(self):
+        with contextlib.ExitStack() as stack, \
+             mock.patch.object(slo_metrics, "NTFY_TOPIC", ""):
+            for p in self._mock_all_metrics(audit_write_failures=2.0):
+                stack.enter_context(p)
+            code = self._run_main_capturing_exit()
+        self.assertEqual(code, 0)
+
+    def test_audit_write_failures_at_threshold_breaches(self):
+        with contextlib.ExitStack() as stack, \
+             mock.patch.object(slo_metrics, "NTFY_TOPIC", "test-topic"), \
+             mock.patch.object(slo_metrics.requests, "post") as ntfy_post:
+            for p in self._mock_all_metrics(audit_write_failures=3.0):
+                stack.enter_context(p)
+            code = self._run_main_capturing_exit()
+        self.assertEqual(code, 2)
+        self.assertIn("audit_write_failures", ntfy_post.call_args.kwargs["data"].decode())
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/tjlam/projects/Suburban-SOC && .venv/bin/python3 -m pytest tests/ai_agent/test_slo_metrics.py -v`
+Expected: FAIL — `metric_audit_write_failures` doesn't exist yet (`AttributeError`), so every new test fails, and `_mock_all_metrics`'s new `mock.patch.object(slo_metrics, "metric_audit_write_failures", ...)` also fails to resolve the attribute.
+
+- [ ] **Step 3: Implement the metric and wire it in**
+
+In `scripts/setup/ai_agent/slo_metrics.py`, change `TARGETS` (currently lines 50-57) to add one line:
+
+```python
+TARGETS = {
+    "mttd_minutes":        float(os.environ.get("SLO_MTTD_MAX_MIN", "30")),
+    "mttr_minutes":        float(os.environ.get("SLO_MTTR_MAX_MIN", "5")),
+    "coverage_techniques": float(os.environ.get("SLO_COVERAGE_MIN", "10")),
+    "false_positive_pct":  float(os.environ.get("SLO_FP_MAX_PCT", "10")),
+    "ingest_lag_seconds":  float(os.environ.get("SLO_INGEST_LAG_MAX_S", "300")),
+    "parse_error_pct":     float(os.environ.get("SLO_PARSE_ERR_MAX_PCT", "1")),
+    "audit_write_failures": float(os.environ.get("SLO_AUDIT_WRITE_FAIL_MAX", "3")),
+}
+```
+
+Change `LOWER_BETTER` (currently lines 59-62) to add one entry:
+
+```python
+LOWER_BETTER = {
+    "mttd_minutes": True, "mttr_minutes": True, "coverage_techniques": False,
+    "false_positive_pct": True, "ingest_lag_seconds": True, "parse_error_pct": True,
+    "audit_write_failures": True,
+}
+```
+
+Leave `BREACH_IF_NA` (line 68) unchanged — `audit_write_failures` is never unmeasurable-as-None; `_count()` either returns a real number or raises `MetricUnavailable` (handled generically by `main()` already), matching the spec's explicit decision not to add it there.
+
+Add the new function directly after `metric_parse_error_pct` (currently ending around line 199):
+
+```python
+def metric_audit_write_failures():
+    """Count of write_audit() failures in the window (#184).
+
+    Every doc in soc-agent-health-* IS a failure marker — nothing else writes
+    there — so a plain count over the window is the metric, no extra filter.
+    """
+    return _count("soc-agent-health-*", {"match_all": {}})
+```
+
+In `main()`, add one line to the `metric_fns` dict (currently lines 207-213):
+
+```python
+    metric_fns = {
+        "mttd_minutes": metric_mttd,
+        "mttr_minutes": metric_mttr,
+        "coverage_techniques": metric_coverage,
+        "false_positive_pct": metric_false_positive_pct,
+        "ingest_lag_seconds": metric_ingest_lag_seconds,
+        "parse_error_pct": metric_parse_error_pct,
+        "audit_write_failures": metric_audit_write_failures,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/tjlam/projects/Suburban-SOC && .venv/bin/python3 -m pytest tests/ai_agent/test_slo_metrics.py -v`
+Expected: PASS (all tests, including the 5 new ones)
+
+- [ ] **Step 5: Run the full suite to check for regressions**
+
+Run: `cd /home/tjlam/projects/Suburban-SOC && .venv/bin/python3 -m pytest tests/ -q`
+Expected: all tests pass (148 from Task 1 + 5 new = 153)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/tjlam/projects/Suburban-SOC
+git add scripts/setup/ai_agent/slo_metrics.py tests/ai_agent/test_slo_metrics.py
+git commit -m "feat(#184): add audit_write_failures SLO metric
+
+Wired into the existing generic breach/alert/soc-slo-metrics-index machinery
+in main() — no new dashboard code needed. Default threshold 3 (override via
+SLO_AUDIT_WRITE_FAIL_MAX) distinguishes a transient blip from a sustained
+failure run, per the issue's own framing of the problem."
+```
+
+---
+
+### Task 4: Live verification and PR
+
+**Files:** none (verification only)
+
+**Interfaces:**
+- Consumes: Task 1's `_write_audit_health_marker`, Task 2's role grant, Task 3's `metric_audit_write_failures`.
+- Produces: merged/PR'd feature, nothing further consumes this.
+
+- [ ] **Step 1: Apply the updated role to the running stack**
+
+The `roles` one-shot service already re-applies every file in `configs/elasticsearch/roles/` on `docker compose up`. Re-run it directly rather than restarting the whole stack:
+
+Run: `cd /home/tjlam/projects/Suburban-SOC/scripts/setup && docker compose up roles 2>&1 | tail -10`
+Expected: a line like `role logstash_writer -> HTTP 200`
+
+- [ ] **Step 2: Confirm the role grant took effect**
+
+Run:
+```bash
+cd /home/tjlam/projects/Suburban-SOC/scripts/setup
+set -a; source .env; set +a
+curl -s --cacert /certs/ca/ca.crt -u "elastic:${ELASTIC_PASSWORD}" \
+  https://localhost:9200/_security/role/logstash_writer | python3 -m json.tool
+```
+Expected: the `indices[0].names` array includes `"soc-agent-health-*"`.
+
+(If `/certs/ca/ca.crt` isn't readable from the host in this environment, run the same `curl` inside the `elasticsearch` container instead: `docker exec elasticsearch curl -s --cacert config/certs/ca/ca.crt -u "elastic:${ELASTIC_PASSWORD}" https://localhost:9200/_security/role/logstash_writer`.)
+
+- [ ] **Step 3: Rebuild and redeploy the agent with the new code**
+
+Run:
+```bash
+cd /home/tjlam/projects/Suburban-SOC/scripts/setup
+docker compose build ai-agent
+docker compose up -d ai-agent
+```
+Expected: `Container soc_ai_agent` reaches `healthy` within ~30s (poll `docker inspect --format='{{.State.Health.Status}}' soc_ai_agent` if needed).
+
+- [ ] **Step 4: Trigger a real audit-write failure and confirm the marker doc lands**
+
+Exec into the already-running agent container and call `write_audit()` directly, monkey-patching `ES_HOST` in-process to an unreachable address so the write genuinely fails (no need to touch the container's real environment or the live ES service):
+
+```bash
+cd /home/tjlam/projects/Suburban-SOC/scripts/setup
+docker compose exec -T ai-agent python3 -c "
+import agent_app
+agent_app.ES_HOST = 'https://elasticsearch:9999'  # force a connection failure
+agent_app.write_audit('quarantine_mac', 'system', 'unassigned', outcome='success', target='AA:BB:CC:DD:EE:FF')
+print('write_audit() returned without raising')
+"
+```
+Expected: prints `write_audit() returned without raising` (confirms the never-raise contract live, not just in mocked tests).
+
+Then confirm the marker doc actually landed in ES (using the real, correct `ES_HOST` this time):
+```bash
+set -a; source .env; set +a
+curl -s --cacert /certs/ca/ca.crt -u "elastic:${ELASTIC_PASSWORD}" \
+  "https://localhost:9200/soc-agent-health-unassigned/_search?pretty" \
+  -H 'Content-Type: application/json' -d '{"sort":[{"@timestamp":"desc"}],"size":1}'
+```
+Expected: one hit with `"event.action": "audit_write_failed"` and `"target_action": "quarantine_mac"`.
+
+- [ ] **Step 5: Confirm slo_metrics.py picks up the new metric**
+
+```bash
+cd /home/tjlam/projects/Suburban-SOC
+set -a; source scripts/setup/.env; set +a
+.venv/bin/python3 scripts/setup/ai_agent/slo_metrics.py 2>&1 | tail -12
+```
+
+Expected: the printed metrics table includes an `audit_write_failures` row with a value of at least `1` (from Step 4) against a target of `<=3.0`, status `ok` (below threshold from a single test doc).
+
+- [ ] **Step 6: Run the full test suite one more time**
+
+Run: `cd /home/tjlam/projects/Suburban-SOC && .venv/bin/python3 -m pytest tests/ -q`
+Expected: all 153 tests pass.
+
+- [ ] **Step 7: Push and open the PR**
+
+```bash
+cd /home/tjlam/projects/Suburban-SOC
+git push -u origin remediation/p3-issue-184-audit-write-visibility
+gh pr create --title "feat(#184): dashboard-visible metric for SOC agent audit-write failures" --body "$(cat <<'EOF'
+## Summary
+Closes #184 — a sustained run of write_audit() failures (the tamper-evident
+audit trail write) is now visible on the SLO dashboard, not just a log line.
+
+- write_audit()'s existing except block now also best-effort-writes a failure
+  marker to a new soc-agent-health-<tenant> index (its own nested try/except —
+  the "never raise" contract is unchanged and covered by a dedicated test).
+- logstash_writer's ES role grant extended to that new index pattern — reuses
+  the agent's existing credential, no new user/password.
+- New metric_audit_write_failures() in slo_metrics.py, wired into the existing
+  generic breach/alert/soc-slo-metrics machinery. Default breach threshold is
+  3 failures in the rolling window (SLO_AUDIT_WRITE_FAIL_MAX) — tolerates a
+  one-off transient blip, alerts on a sustained pattern, per the issue's own
+  framing of the problem.
+
+Design spec: docs/superpowers/specs/2026-07-12-audit-write-failure-visibility-design.md
+
+## Test plan
+- [x] New tests/ai_agent/test_audit_write_health.py — never-raise contract
+      verified under single AND double write failure
+- [x] New tests in tests/ai_agent/test_slo_metrics.py — metric function +
+      breach-threshold behavior (2 does not breach, 3 does)
+- [x] Full suite passing
+- [x] Live-verified against the running stack: role grant applied and
+      confirmed, a real write_audit() failure produced a real marker doc in
+      ES, slo_metrics.py's own output shows the new metric row
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+EOF is here; PR body needs no further edits.

--- a/docs/superpowers/plans/2026-07-12-audit-write-failure-visibility.md
+++ b/docs/superpowers/plans/2026-07-12-audit-write-failure-visibility.md
@@ -12,7 +12,7 @@
 
 - `write_audit()`'s "never raise" contract must hold under **any** combination of failures (spec, Goals section).
 - The new index write reuses the agent's existing `logstash_internal` ES credential — no new user/role/password (spec, Design §2 + user's explicit choice during brainstorming).
-- Breach threshold defaults to `3` failures in the rolling window, overridable via `SLO_AUDIT_WRITE_FAIL_MAX` (spec, Design §3 + user's explicit choice during brainstorming).
+- Breach threshold: 1-2 failures in the rolling window tolerated, 3+ breaches, overridable via `SLO_AUDIT_WRITE_FAIL_MAX` (spec, Design §3 + user's explicit choice during brainstorming). **Note:** Task 3 below originally specified a target default of `"3"`, which — combined with `main()`'s existing strict `val > target` comparator — would actually have meant "breach only above 3" (4+), not "3+". This was caught during implementation (see Task 3's fix-round commits) and corrected to a target default of `"2"`, which combined with the same comparator correctly means "3+ breaches." The shipped code uses `"2"`; treat the `"3"` appearing in Task 3's original step-by-step text below as superseded.
 - No new dashboard panel, endpoint, or ILM policy — out of scope (spec, Non-goals).
 - Reference spec: `docs/superpowers/specs/2026-07-12-audit-write-failure-visibility-design.md`.
 

--- a/docs/superpowers/specs/2026-07-12-audit-write-failure-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-12-audit-write-failure-visibility-design.md
@@ -1,0 +1,125 @@
+# Audit-Write Failure Visibility — Design Spec
+
+**Issue:** [#184](https://github.com/voltron-1/Suburban_SOC/issues/184) (follow-up to #165)
+**Date:** 2026-07-12
+**Status:** Approved, ready for implementation plan
+
+## Problem
+
+`write_audit()` in `scripts/setup/ai_agent/agent_app.py` appends a tamper-evident record to
+`soc-audit-<tenant>` for every privileged decision the SOC agent makes. It has a correct,
+intentional "never raise" contract — auditing must not break alert handling — so ES write
+failures are caught and logged, never propagated. But today that's *all* that happens: a log
+line at `ERROR` level, with no counter, metric, or dashboard signal. Nothing distinguishes "one
+audit write failed transiently" from "the compliance audit trail has been silently blank for six
+hours." An operator would only discover a sustained failure by grepping raw logs.
+
+## Goals
+
+- Make a *sustained* run of audit-write failures visible outside raw logs (dashboard/alert), without
+  paging on a single transient blip.
+- Preserve `write_audit()`'s "never raise" contract exactly as-is.
+- Reuse existing architecture and conventions rather than introducing a new subsystem.
+
+## Non-goals
+
+- Solving total-ES-outage visibility — already covered by `stack_health.sh`'s ES healthcheck and
+  `slo_metrics.py`'s `ingest_lag_seconds` (`BREACH_IF_NA`).
+- A new authenticated/unauthenticated HTTP endpoint on the agent. Considered and rejected — see
+  Alternatives.
+- Retention/ILM policy for the new index. Expected volume is low (failures should be rare); revisit
+  only if that assumption breaks.
+
+## Design
+
+### 1. Failure-marker write in `write_audit()`
+
+`write_audit()`'s existing `except` block gains one addition: a best-effort write of a minimal
+marker doc to a new per-tenant index, `soc-agent-health-<tenant>`, mirroring `soc-audit-<tenant>`'s
+own naming and `_bulk`-with-`create`-op shape (same tenant scoping the function already has).
+
+Doc shape:
+
+```json
+{
+  "@timestamp": "<now, UTC ISO8601>",
+  "tenant.id": "<tenant>",
+  "event.action": "audit_write_failed",
+  "target_action": "<the action write_audit was originally called for>",
+  "error": "<str(exception)>"
+}
+```
+
+This write is wrapped in its **own** nested `try/except`. If it also fails (e.g. total ES outage),
+log at `WARNING` (the primary failure is already logged at `ERROR`; this is a secondary, expected-
+possible event) and return — no retry chain, no further fallback.
+
+### 2. ES role change
+
+The agent authenticates as `logstash_internal` (role `logstash_writer`) for all its ES writes,
+including the existing `soar-actions-<tenant>` stream. `logstash_writer`'s `indices` grant in
+`docker-compose.yml`'s `provision` service gets `"soc-agent-health-*"` added alongside the existing
+`"logstash-*"`/`"soar-actions-*"` patterns. No new user, role, or password — this data isn't
+sensitive/tamper-critical the way the audit trail itself is (that's exactly why it's fine to share
+the less-restrictive `create+write` role rather than get its own `soc_audit_appender`-style
+create-only role).
+
+### 3. New SLO metric
+
+`slo_metrics.py` gains `metric_audit_write_failures()`, using the existing `_count()` helper against
+`soc-agent-health-*` with a `match_all` query over the existing `WINDOW` (`now-7d` default) — nothing
+else ever writes to that index, so every doc in it *is* a failure, no extra filter needed. A
+wildcard `_count` against zero matching indices (the common case — no failures ever) returns `0`
+successfully; it does not error the way an exact non-existent index name would.
+
+Wired in exactly like the other five metrics:
+
+- `TARGETS["audit_write_failures"] = float(os.environ.get("SLO_AUDIT_WRITE_FAIL_MAX", "3"))`
+- `LOWER_BETTER["audit_write_failures"] = True`
+- **Not** added to `BREACH_IF_NA` — an unmeasurable *query failure* still raises `MetricUnavailable`
+  via `_count()`'s existing exception handling (same as every other metric), but a genuine zero-count
+  result is a legitimate "good" value, not an unmeasurable one.
+- Added to the `metric_fns` dict in `main()`.
+
+That's the entire dashboard/alerting integration: `main()` already handles breach evaluation,
+indexing to `soc-slo-metrics`, and the ntfy alert generically for anything in `metric_fns`. Target
+of `3` means a single transient failure doesn't breach; three or more within the rolling window
+does — resolves the "transient vs. sustained" distinction from the issue directly.
+
+## Testing
+
+New file `tests/ai_agent/test_audit_write_health.py` (no existing file tests `write_audit()`'s own
+behavior — it's only ever mocked away as a no-op dependency in other tests):
+
+- Simulate an ES write failure (mock `requests.post` to raise) and assert the health-marker write
+  is attempted with the expected shape.
+- Simulate **both** writes failing and assert the function still returns normally (doesn't raise) —
+  the core acceptance criterion.
+- `metric_audit_write_failures()`: mirrors the existing `MetricFunctionTests` pattern in
+  `test_slo_metrics.py` — raises `MetricUnavailable` on a query failure, returns the correct count
+  on success.
+- A breach-threshold test: 2 failures in the window does not breach; 3 does (matches
+  `SLO_AUDIT_WRITE_FAIL_MAX` default).
+
+## Alternatives considered
+
+**In-process counter + new `/health` endpoint polled by `slo_metrics.py`.** Simpler code-wise (no
+new ES role/index), and the issue's own suggested remediation. Rejected as the primary approach:
+the counter resets to zero on every container restart/redeploy — for a compliance-audit-trail
+visibility feature, a redeploy silently masking a sustained failure run is a worse failure mode than
+the one being fixed. Also introduces a new inter-service HTTP dependency (`slo_metrics.py` → agent
+`:5000`) that doesn't exist today, whereas every existing SLO metric already queries ES directly.
+
+**Dedicated least-privilege ES user/role** (mirroring `hive_mind_broker`/`slo_metrics` in #167/#171).
+More consistent with this project's least-privilege philosophy in the abstract, but adds a new
+password env var and provisioning block for a low-sensitivity liveness signal. Rejected in favor of
+extending the existing `logstash_writer` grant — the agent already holds broader write access than
+this new index needs, so a new role buys no real isolation here.
+
+## Files touched (expected)
+
+- `scripts/setup/ai_agent/agent_app.py` — `write_audit()` addition
+- `scripts/setup/ai_agent/slo_metrics.py` — new metric function + wiring
+- `scripts/setup/docker-compose.yml` — `logstash_writer` role index grant
+- `tests/ai_agent/test_slo_metrics.py` — new metric tests
+- `tests/ai_agent/test_audit_write_health.py` (new) — `write_audit()` dual-failure behavior

--- a/docs/superpowers/specs/2026-07-12-audit-write-failure-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-12-audit-write-failure-visibility-design.md
@@ -54,27 +54,43 @@ This write is wrapped in its **own** nested `try/except`. If it also fails (e.g.
 log at `WARNING` (the primary failure is already logged at `ERROR`; this is a secondary, expected-
 possible event) and return — no retry chain, no further fallback.
 
+**Addendum (found during live verification, not in the original design):** `requests.post` does not
+raise on HTTP 4xx/5xx, and Elasticsearch's `_bulk` endpoint can return HTTP 200 with an embedded
+per-item error (e.g. a permissions or mapping rejection) — a "successful" response that isn't
+actually a successful write. Both the primary audit write and the health-marker write now check
+the response status code and the bulk response's `errors` field, raising inside the same `try` so
+detection is unified with the existing connection-level exception handling (no duplicated logging/
+marker-write logic). This was not a hypothetical: an ES role missing the `auto_configure`
+privilege caused exactly this failure mode during this feature's own rollout, silently, until
+traced by hand — see the `configs/elasticsearch/roles/logstash_writer.json` privilege list above.
+
 ### 2. ES role change
 
 The agent authenticates as `logstash_internal` (role `logstash_writer`) for all its ES writes,
 including the existing `soar-actions-<tenant>` stream. `logstash_writer`'s `indices` grant in
-`docker-compose.yml`'s `provision` service gets `"soc-agent-health-*"` added alongside the existing
-`"logstash-*"`/`"soar-actions-*"` patterns. No new user, role, or password — this data isn't
-sensitive/tamper-critical the way the audit trail itself is (that's exactly why it's fine to share
-the less-restrictive `create+write` role rather than get its own `soc_audit_appender`-style
-create-only role).
+`configs/elasticsearch/roles/logstash_writer.json` — the actual applied source of truth, via a
+separate `roles` one-shot service that overwrites `docker-compose.yml`'s inline bootstrap JSON
+after `provision` runs — gets `"soc-agent-health-*"` added alongside the existing
+`"logstash-*"`/`"soar-actions-*"`/`"asset-inventory-*"` patterns. No new user, role, or password —
+this data isn't sensitive/tamper-critical the way the audit trail itself is (that's exactly why
+it's fine to share the less-restrictive `create+write` role rather than get its own
+`soc_audit_appender`-style create-only role). Live verification also surfaced that ES's implicit
+index auto-creation via a `_bulk` "create" op requires the `auto_configure` privilege specifically
+— `create_index`/`manage` alone aren't sufficient — so that privilege was added too.
 
 ### 3. New SLO metric
 
 `slo_metrics.py` gains `metric_audit_write_failures()`, using the existing `_count()` helper against
-`soc-agent-health-*` with a `match_all` query over the existing `WINDOW` (`now-7d` default) — nothing
-else ever writes to that index, so every doc in it *is* a failure, no extra filter needed. A
-wildcard `_count` against zero matching indices (the common case — no failures ever) returns `0`
-successfully; it does not error the way an exact non-existent index name would.
+`soc-agent-health-*` with a `{"range": {"@timestamp": {"gte": WINDOW}}}` filter — matching
+`metric_parse_error_pct()`'s exact windowing pattern — over the existing `WINDOW` (`now-7d`
+default). Nothing else ever writes to that index, so every doc in it *is* a failure, no extra
+filter beyond the time range needed. A wildcard `_count` against zero matching indices (the common
+case — no failures ever) returns `0` successfully; it does not error the way an exact non-existent
+index name would.
 
 Wired in exactly like the other five metrics:
 
-- `TARGETS["audit_write_failures"] = float(os.environ.get("SLO_AUDIT_WRITE_FAIL_MAX", "3"))`
+- `TARGETS["audit_write_failures"] = float(os.environ.get("SLO_AUDIT_WRITE_FAIL_MAX", "2"))`
 - `LOWER_BETTER["audit_write_failures"] = True`
 - **Not** added to `BREACH_IF_NA` — an unmeasurable *query failure* still raises `MetricUnavailable`
   via `_count()`'s existing exception handling (same as every other metric), but a genuine zero-count
@@ -82,9 +98,11 @@ Wired in exactly like the other five metrics:
 - Added to the `metric_fns` dict in `main()`.
 
 That's the entire dashboard/alerting integration: `main()` already handles breach evaluation,
-indexing to `soc-slo-metrics`, and the ntfy alert generically for anything in `metric_fns`. Target
-of `3` means a single transient failure doesn't breach; three or more within the rolling window
-does — resolves the "transient vs. sustained" distinction from the issue directly.
+indexing to `soc-slo-metrics`, and the ntfy alert generically for anything in `metric_fns`. `main()`'s
+existing breach comparator is strict (`val > target`), so a target of `2` means 1-2 failures in the
+window don't breach; 3 or more does — resolves the "transient vs. sustained" distinction from the
+issue directly. (A target of `3` here, matching the "3" in the issue's own framing verbatim, would
+actually have meant "breach only above 3" i.e. 4+ — caught during implementation and corrected.)
 
 ## Testing
 

--- a/scripts/setup/ai_agent/agent_app.py
+++ b/scripts/setup/ai_agent/agent_app.py
@@ -801,9 +801,17 @@ def write_audit(action, actor, tenant, outcome="", target="", detail=""):
     # op_type=create (append-only) via the bulk create form.
     ndjson = '{"create":{}}\n' + json.dumps(doc) + "\n"
     try:
-        requests.post(f"{ES_HOST}/soc-audit-{tenant}/_bulk", data=ndjson,
+        r = requests.post(f"{ES_HOST}/soc-audit-{tenant}/_bulk", data=ndjson,
                       headers={"Content-Type": "application/x-ndjson"},
                       auth=(ES_USER, ES_PASS), verify=ES_VERIFY, timeout=5)
+        # ES's _bulk endpoint can return HTTP 200 with an embedded per-item error
+        # (e.g. a 403 from a missing role privilege, a mapping conflict, or an
+        # ILM write-block) — requests.post never raises for that, so an
+        # unchecked response silently "succeeds" while the audit record is
+        # actually dropped. Escalate both that case and a non-200 into the same
+        # except-driven health-marker path below (#184).
+        if r.status_code != 200 or r.json().get("errors"):
+            raise RuntimeError(f"audit bulk write rejected: HTTP {r.status_code}: {r.text[:500]}")
     except Exception as e:  # noqa: BLE001
         app.logger.error("Failed to write audit record: %s", e)
         _write_audit_health_marker(action, tenant, e)
@@ -818,18 +826,22 @@ def _write_audit_health_marker(action, tenant, error):
     this ALSO fails (e.g. total ES outage), that's already caught by
     stack_health.sh / the ingest-lag SLO, not this function's job to escalate further.
     """
-    doc = {
-        "@timestamp":    datetime.now(timezone.utc).isoformat(),
-        "tenant.id":     tenant,
-        "event.action":  "audit_write_failed",
-        "target_action": action,
-        "error":         str(error),
-    }
-    ndjson = '{"create":{}}\n' + json.dumps(doc) + "\n"
     try:
-        requests.post(f"{ES_HOST}/soc-agent-health-{tenant}/_bulk", data=ndjson,
+        doc = {
+            "@timestamp":    datetime.now(timezone.utc).isoformat(),
+            "tenant.id":     tenant,
+            "event.action":  "audit_write_failed",
+            "target_action": action,
+            "error":         str(error),
+        }
+        ndjson = '{"create":{}}\n' + json.dumps(doc) + "\n"
+        r = requests.post(f"{ES_HOST}/soc-agent-health-{tenant}/_bulk", data=ndjson,
                       headers={"Content-Type": "application/x-ndjson"},
                       auth=(ES_USER, ES_PASS), verify=ES_VERIFY, timeout=5)
+        # Same embedded-error case as write_audit() above: a 200 with
+        # "errors": true means the marker itself was silently dropped.
+        if r.status_code != 200 or r.json().get("errors"):
+            raise RuntimeError(f"health-marker bulk write rejected: HTTP {r.status_code}: {r.text[:500]}")
     except Exception as e:  # noqa: BLE001
         app.logger.warning("Failed to write audit-write-failure health marker: %s", e)
 

--- a/scripts/setup/ai_agent/agent_app.py
+++ b/scripts/setup/ai_agent/agent_app.py
@@ -806,6 +806,32 @@ def write_audit(action, actor, tenant, outcome="", target="", detail=""):
                       auth=(ES_USER, ES_PASS), verify=ES_VERIFY, timeout=5)
     except Exception as e:  # noqa: BLE001
         app.logger.error("Failed to write audit record: %s", e)
+        _write_audit_health_marker(action, tenant, e)
+
+
+def _write_audit_health_marker(action, tenant, error):
+    """Best-effort dashboard-visible signal for a failed audit write (#184).
+
+    A single failure doc in soc-agent-health-<tenant>; slo_metrics.py counts these
+    over its rolling window so a SUSTAINED run of failures breaches an SLO (and
+    alerts), while a one-off transient blip does not. Must never raise itself — if
+    this ALSO fails (e.g. total ES outage), that's already caught by
+    stack_health.sh / the ingest-lag SLO, not this function's job to escalate further.
+    """
+    doc = {
+        "@timestamp":    datetime.now(timezone.utc).isoformat(),
+        "tenant.id":     tenant,
+        "event.action":  "audit_write_failed",
+        "target_action": action,
+        "error":         str(error),
+    }
+    ndjson = '{"create":{}}\n' + json.dumps(doc) + "\n"
+    try:
+        requests.post(f"{ES_HOST}/soc-agent-health-{tenant}/_bulk", data=ndjson,
+                      headers={"Content-Type": "application/x-ndjson"},
+                      auth=(ES_USER, ES_PASS), verify=ES_VERIFY, timeout=5)
+    except Exception as e:  # noqa: BLE001
+        app.logger.warning("Failed to write audit-write-failure health marker: %s", e)
 
 
 # =============================================================================

--- a/scripts/setup/ai_agent/slo_metrics.py
+++ b/scripts/setup/ai_agent/slo_metrics.py
@@ -54,11 +54,13 @@ TARGETS = {
     "false_positive_pct":  float(os.environ.get("SLO_FP_MAX_PCT", "10")),
     "ingest_lag_seconds":  float(os.environ.get("SLO_INGEST_LAG_MAX_S", "300")),
     "parse_error_pct":     float(os.environ.get("SLO_PARSE_ERR_MAX_PCT", "1")),
+    "audit_write_failures": float(os.environ.get("SLO_AUDIT_WRITE_FAIL_MAX", "3")),
 }
 # Comparator per metric: True = lower is better (value <= target).
 LOWER_BETTER = {
     "mttd_minutes": True, "mttr_minutes": True, "coverage_techniques": False,
     "false_positive_pct": True, "ingest_lag_seconds": True, "parse_error_pct": True,
+    "audit_write_failures": True,
 }
 # Fail closed: for these metrics an unmeasurable value (None) is itself a breach,
 # not a benign "n/a". A dead/unreachable pipeline produces no fresh docs, so
@@ -199,6 +201,15 @@ def metric_parse_error_pct():
     return round(100.0 * errs / total, 3) if total else 0.0
 
 
+def metric_audit_write_failures():
+    """Count of write_audit() failures in the window (#184).
+
+    Every doc in soc-agent-health-* IS a failure marker — nothing else writes
+    there — so a plain count over the window is the metric, no extra filter.
+    """
+    return _count("soc-agent-health-*", {"match_all": {}})
+
+
 def main():
     if not ES_PASS:
         print("ERROR: ES_PASS / ELASTIC_PASSWORD required", file=sys.stderr)
@@ -211,6 +222,7 @@ def main():
         "false_positive_pct": metric_false_positive_pct,
         "ingest_lag_seconds": metric_ingest_lag_seconds,
         "parse_error_pct": metric_parse_error_pct,
+        "audit_write_failures": metric_audit_write_failures,
     }
     values, errors = {}, {}
     for name, fn in metric_fns.items():

--- a/scripts/setup/ai_agent/slo_metrics.py
+++ b/scripts/setup/ai_agent/slo_metrics.py
@@ -205,9 +205,11 @@ def metric_audit_write_failures():
     """Count of write_audit() failures in the window (#184).
 
     Every doc in soc-agent-health-* IS a failure marker — nothing else writes
-    there — so a plain count over the window is the metric, no extra filter.
+    there — so a windowed count is the metric, no extra filter beyond the
+    time range.
     """
-    return _count("soc-agent-health-*", {"match_all": {}})
+    win = {"range": {"@timestamp": {"gte": WINDOW}}}
+    return _count("soc-agent-health-*", win)
 
 
 def main():

--- a/scripts/setup/ai_agent/slo_metrics.py
+++ b/scripts/setup/ai_agent/slo_metrics.py
@@ -54,7 +54,7 @@ TARGETS = {
     "false_positive_pct":  float(os.environ.get("SLO_FP_MAX_PCT", "10")),
     "ingest_lag_seconds":  float(os.environ.get("SLO_INGEST_LAG_MAX_S", "300")),
     "parse_error_pct":     float(os.environ.get("SLO_PARSE_ERR_MAX_PCT", "1")),
-    "audit_write_failures": float(os.environ.get("SLO_AUDIT_WRITE_FAIL_MAX", "3")),
+    "audit_write_failures": float(os.environ.get("SLO_AUDIT_WRITE_FAIL_MAX", "2")),
 }
 # Comparator per metric: True = lower is better (value <= target).
 LOWER_BETTER = {

--- a/tests/ai_agent/test_audit_write_health.py
+++ b/tests/ai_agent/test_audit_write_health.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Audit-write failure visibility tests (issue #184).
+
+write_audit()'s ES write failures must never propagate (auditing must not break
+alert handling) — but a failure now also writes a best-effort marker doc to
+soc-agent-health-<tenant> so a SUSTAINED run of failures is dashboard-visible
+(via slo_metrics.py's metric_audit_write_failures()), not just a log line.
+
+Run:  pytest tests/ai_agent/test_audit_write_health.py
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+os.environ["SOC_AGENT_HMAC_SECRET"] = "unit_test_secret"
+
+_stub = types.ModuleType("weekly_ciso_report")
+_stub.run_reporting_pipeline = lambda *a, **k: {"status": "stub"}  # type: ignore[attr-defined]
+sys.modules["weekly_ciso_report"] = _stub
+
+import agent_app  # noqa: E402
+
+
+class WriteAuditHealthMarkerTests(unittest.TestCase):
+    def test_health_marker_written_on_audit_write_failure(self):
+        with mock.patch.object(agent_app.requests, "post",
+                               side_effect=ConnectionError("refused")) as m:
+            agent_app.write_audit("quarantine_mac", "system", "acme-corp",
+                                   outcome="success", target="AA:BB:CC:DD:EE:FF")
+        # Two POST attempts: the original audit write, then the health marker.
+        self.assertEqual(m.call_count, 2)
+        marker_args, marker_kwargs = m.call_args_list[1]
+        self.assertEqual(marker_args[0],
+                         f"{agent_app.ES_HOST}/soc-agent-health-acme-corp/_bulk")
+        self.assertIn('"event.action": "audit_write_failed"', marker_kwargs["data"])
+        self.assertIn('"target_action": "quarantine_mac"', marker_kwargs["data"])
+        self.assertIn('"tenant.id": "acme-corp"', marker_kwargs["data"])
+
+    def test_write_audit_never_raises_even_if_health_marker_also_fails(self):
+        # Core acceptance criterion: BOTH writes failing must not raise.
+        with mock.patch.object(agent_app.requests, "post",
+                               side_effect=ConnectionError("refused")):
+            try:
+                agent_app.write_audit("quarantine_mac", "system", "acme-corp")
+            except Exception as e:
+                self.fail(f"write_audit() raised unexpectedly: {e}")
+
+    def test_health_marker_not_written_on_audit_write_success(self):
+        with mock.patch.object(agent_app.requests, "post") as m:
+            agent_app.write_audit("quarantine_mac", "system", "acme-corp")
+        # Only the original audit write — no marker needed when it succeeds.
+        self.assertEqual(m.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/ai_agent/test_audit_write_health.py
+++ b/tests/ai_agent/test_audit_write_health.py
@@ -10,6 +10,7 @@ soc-agent-health-<tenant> so a SUSTAINED run of failures is dashboard-visible
 Run:  pytest tests/ai_agent/test_audit_write_health.py
 """
 
+import json
 import os
 import sys
 import types
@@ -50,10 +51,48 @@ class WriteAuditHealthMarkerTests(unittest.TestCase):
                 self.fail(f"write_audit() raised unexpectedly: {e}")
 
     def test_health_marker_not_written_on_audit_write_success(self):
-        with mock.patch.object(agent_app.requests, "post") as m:
+        success = mock.Mock(status_code=200)
+        success.json.return_value = {"errors": False, "items": [{"create": {"status": 201}}]}
+        with mock.patch.object(agent_app.requests, "post", return_value=success) as m:
             agent_app.write_audit("quarantine_mac", "system", "acme-corp")
         # Only the original audit write — no marker needed when it succeeds.
         self.assertEqual(m.call_count, 1)
+
+    def test_health_marker_written_on_embedded_bulk_rejection(self):
+        # ES's _bulk endpoint can return HTTP 200 with an embedded per-item
+        # error (e.g. a 403 from a missing role privilege) — requests.post
+        # never raises for that. write_audit() must still detect it and fall
+        # into the same health-marker path as a connection-level failure.
+        rejected = mock.Mock(status_code=200)
+        rejected.json.return_value = {
+            "errors": True,
+            "items": [{"create": {"status": 403, "error": {
+                "type": "security_exception", "reason": "action denied"}}}],
+        }
+        rejected.text = json.dumps(rejected.json.return_value)
+
+        accepted = mock.Mock(status_code=200)
+        accepted.json.return_value = {"errors": False, "items": [{"create": {"status": 201}}]}
+        accepted.text = json.dumps(accepted.json.return_value)
+
+        with mock.patch.object(agent_app.requests, "post",
+                               side_effect=[rejected, accepted]) as m:
+            try:
+                agent_app.write_audit("quarantine_mac", "system", "acme-corp",
+                                       outcome="success", target="AA:BB:CC:DD:EE:FF")
+            except Exception as e:
+                self.fail(f"write_audit() raised unexpectedly: {e}")
+
+        # Two POST attempts: the (rejected) original audit write, then the
+        # health marker — proving the embedded-error case is detected, not
+        # just connection-level exceptions.
+        self.assertEqual(m.call_count, 2)
+        marker_args, marker_kwargs = m.call_args_list[1]
+        self.assertEqual(marker_args[0],
+                         f"{agent_app.ES_HOST}/soc-agent-health-acme-corp/_bulk")
+        self.assertIn('"event.action": "audit_write_failed"', marker_kwargs["data"])
+        self.assertIn('"target_action": "quarantine_mac"', marker_kwargs["data"])
+        self.assertIn('"tenant.id": "acme-corp"', marker_kwargs["data"])
 
 
 if __name__ == "__main__":

--- a/tests/ai_agent/test_slo_metrics.py
+++ b/tests/ai_agent/test_slo_metrics.py
@@ -263,16 +263,10 @@ class MainExitCodeTests(unittest.TestCase):
         self.assertEqual(code, 0)
 
     def test_audit_write_failures_at_threshold_breaches(self):
-        # NOTE: default target is 3 and breach is strictly-greater (val > target,
-        # same convention as every other lower-is-better metric in this file, e.g.
-        # mttd_minutes/mttr_minutes/ingest_lag_seconds/parse_error_pct) — hitting
-        # the target exactly is "ok", not a breach. 4.0 is the first value that
-        # actually breaches; see task-3-report.md for why this differs from the
-        # task brief's literal 3.0.
         with contextlib.ExitStack() as stack, \
              mock.patch.object(slo_metrics, "NTFY_TOPIC", "test-topic"), \
              mock.patch.object(slo_metrics.requests, "post") as ntfy_post:
-            for p in self._mock_all_metrics(audit_write_failures=4.0):
+            for p in self._mock_all_metrics(audit_write_failures=3.0):
                 stack.enter_context(p)
             code = self._run_main_capturing_exit()
         self.assertEqual(code, 2)

--- a/tests/ai_agent/test_slo_metrics.py
+++ b/tests/ai_agent/test_slo_metrics.py
@@ -148,6 +148,21 @@ class MetricFunctionTests(unittest.TestCase):
             with self.assertRaises(slo_metrics.MetricUnavailable):
                 slo_metrics.metric_parse_error_pct()
 
+    def test_audit_write_failures_raises_on_es_failure(self):
+        with mock.patch.object(slo_metrics, "es", side_effect=ConnectionError("refused")):
+            with self.assertRaises(slo_metrics.MetricUnavailable):
+                slo_metrics.metric_audit_write_failures()
+
+    def test_audit_write_failures_returns_count_on_success(self):
+        with mock.patch.object(slo_metrics, "es",
+                               return_value=_FakeResponse(200, {"count": 5})):
+            self.assertEqual(slo_metrics.metric_audit_write_failures(), 5)
+
+    def test_audit_write_failures_returns_zero_when_healthy(self):
+        with mock.patch.object(slo_metrics, "es",
+                               return_value=_FakeResponse(200, {"count": 0})):
+            self.assertEqual(slo_metrics.metric_audit_write_failures(), 0)
+
 
 class EsKbWrapperTests(unittest.TestCase):
     """Cover the real es()/kb() request wrappers — every test above mocks them
@@ -213,7 +228,7 @@ class MainExitCodeTests(unittest.TestCase):
         self.assertEqual(code, 0)
 
     def _mock_all_metrics(self, mttd=0.0, mttr=0.0, coverage=12.0, fp_pct=0.0,
-                           ingest_lag=10.0, parse_err=0.0):
+                           ingest_lag=10.0, parse_err=0.0, audit_write_failures=0.0):
         return [
             mock.patch.object(slo_metrics, "metric_mttd", return_value=mttd),
             mock.patch.object(slo_metrics, "metric_mttr", return_value=mttr),
@@ -221,6 +236,8 @@ class MainExitCodeTests(unittest.TestCase):
             mock.patch.object(slo_metrics, "metric_false_positive_pct", return_value=fp_pct),
             mock.patch.object(slo_metrics, "metric_ingest_lag_seconds", return_value=ingest_lag),
             mock.patch.object(slo_metrics, "metric_parse_error_pct", return_value=parse_err),
+            mock.patch.object(slo_metrics, "metric_audit_write_failures",
+                               return_value=audit_write_failures),
             mock.patch.object(slo_metrics, "es", return_value=_FakeResponse(200, {})),
         ]
 
@@ -236,6 +253,30 @@ class MainExitCodeTests(unittest.TestCase):
         self.assertEqual(code, 2)
         ntfy_post.assert_called_once()
         self.assertIn("mttd_minutes", ntfy_post.call_args.kwargs["data"].decode())
+
+    def test_audit_write_failures_below_threshold_does_not_breach(self):
+        with contextlib.ExitStack() as stack, \
+             mock.patch.object(slo_metrics, "NTFY_TOPIC", ""):
+            for p in self._mock_all_metrics(audit_write_failures=2.0):
+                stack.enter_context(p)
+            code = self._run_main_capturing_exit()
+        self.assertEqual(code, 0)
+
+    def test_audit_write_failures_at_threshold_breaches(self):
+        # NOTE: default target is 3 and breach is strictly-greater (val > target,
+        # same convention as every other lower-is-better metric in this file, e.g.
+        # mttd_minutes/mttr_minutes/ingest_lag_seconds/parse_error_pct) — hitting
+        # the target exactly is "ok", not a breach. 4.0 is the first value that
+        # actually breaches; see task-3-report.md for why this differs from the
+        # task brief's literal 3.0.
+        with contextlib.ExitStack() as stack, \
+             mock.patch.object(slo_metrics, "NTFY_TOPIC", "test-topic"), \
+             mock.patch.object(slo_metrics.requests, "post") as ntfy_post:
+            for p in self._mock_all_metrics(audit_write_failures=4.0):
+                stack.enter_context(p)
+            code = self._run_main_capturing_exit()
+        self.assertEqual(code, 2)
+        self.assertIn("audit_write_failures", ntfy_post.call_args.kwargs["data"].decode())
 
     def test_ntfy_failure_is_swallowed_not_fatal(self):
         # A downed ntfy.sh must not crash main() or change the breach exit code.


### PR DESCRIPTION
## Summary
Closes #184 — a sustained run of write_audit() failures (the tamper-evident
audit trail write) is now visible on the SLO dashboard, not just a log line.

- write_audit()'s existing except block now also best-effort-writes a failure
  marker to a new soc-agent-health-<tenant> index (its own nested try/except —
  the "never raise" contract is unchanged and covered by a dedicated test).
- logstash_writer's ES role grant extended to that new index pattern — reuses
  the agent's existing credential, no new user/password.
- New metric_audit_write_failures() in slo_metrics.py, wired into the existing
  generic breach/alert/soc-slo-metrics machinery. Breach threshold: 1-2
  failures in the rolling window tolerated, 3+ breaches (SLO_AUDIT_WRITE_FAIL_MAX,
  default 2 — combined with the existing strict `>` comparator that gives "3+").
- Both write_audit() and the health-marker write now check the ES bulk
  response body (not just connection-level exceptions) — requests.post
  doesn't raise on HTTP 4xx/5xx, and ES's _bulk API can return HTTP 200 with
  an embedded per-item rejection. Found live: an ES role missing the
  `auto_configure` privilege caused exactly this failure mode, silently,
  during this feature's own rollout.

Design spec: docs/superpowers/specs/2026-07-12-audit-write-failure-visibility-design.md
Implementation plan: docs/superpowers/plans/2026-07-12-audit-write-failure-visibility.md

Built via subagent-driven development: implementer + task-reviewer per task,
plus a final whole-branch review (opus) that caught the bulk-response gap
above. Two real bugs were found and fixed beyond the original plan: a
breach-threshold semantics bug (target=3 with the existing strict `>`
comparator actually meant "breach at 4+", not "3+" as intended — corrected
to target=2), and the bulk-response-checking gap.

## Test plan
- [x] New tests/ai_agent/test_audit_write_health.py — never-raise contract
      verified under connection failure, bulk-rejection failure, and both
      failing simultaneously
- [x] New tests in tests/ai_agent/test_slo_metrics.py — metric function +
      breach-threshold behavior (2 does not breach, 3 does)
- [x] Full suite passing (154/154)
- [x] Live-verified against the running stack across two real bugs found
      this way (ES auto_configure privilege gap, bulk-response blind spot) —
      neither was caught by mocked unit tests alone. A real write_audit()
      failure now produces a real, queryable marker doc, and slo_metrics.py's
      own output confirms the metric counts it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)